### PR TITLE
Use built-in git instead of Git Automator extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -11,10 +11,6 @@
     // GitLens for seeing version history inline
     "eamodio.gitlens",
 
-    // Git Automator for quick commit and push
-    // (Could be improved)
-    "ivangabriele.vscode-git-add-and-commit",
-
     // Tons of markdown goodies (lists, tables of content, so much more)
     "yzhang.markdown-all-in-one",
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,7 @@
   "[markdown]": {
     "editor.quickSuggestions": true
   },
-  "cSpell.language": "en-GB"
+  "cSpell.language": "en-GB",
+  "git.enableSmartCommit": true,
+  "git.postCommitCommand": "sync"
 }

--- a/git-integration.md
+++ b/git-integration.md
@@ -6,11 +6,9 @@ There are (too) many ways to commit your changes to source control:
 - Using GitLens (included in Foam for inline blame)
 - Whatever way you like to do it (CLI?)
 
-The quick and easy way is to use [Git Automator](https://marketplace.visualstudio.com/items?itemName=ivangabriele.vscode-git-add-and-commit):
+The quick and easy way is to use the Git: Commit All command after editing files. The default Foam workspace settings will stage & sync all of your changes to the remote:
 
-- `Cmd` + `Shift` + `A` to stage and commit all files
-- `Cmd` + `Shift` + `Z` to commit current file
-- `Cmd` + `Shift` + `X` to push all changes to remote repository
+- `Cmd` + `P` (`Ctrl` + `Shift` + `P` for Windows), execute `Git: Commit All`
 
 This could be improved. [[todo]] [[good-first-task]]
 

--- a/recommended-extensions.md
+++ b/recommended-extensions.md
@@ -9,4 +9,4 @@ This list is subject to change. Especially the Git ones.
 - [Markdown Links](https://marketplace.visualstudio.com/items?itemName=tchayen.markdown-links)
 - [Markdown All In One](https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one)
 - [Git Lens](https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens)
-- [Git Automator](https://marketplace.visualstudio.com/items?itemName=ivangabriele.vscode-git-add-and-commit)
+


### PR DESCRIPTION
This commit updates the git instructions
To use the built-in VS Code git integration instead of Git Automator.

- Automatically stage all changes
  "git.enableSmartCommit": true,

- Automatically push & pull changes to the remote after committing
  "git.postCommitCommand": "sync"

Updates the settings in this project to dogfood the new defaults.

This feature could be improved further
By setting a default key-binding to Git: Commit All,
And/or by automatically committing on save or focus change
For the most SaaS-like experience.

Part of issue #30 along with a PR to foambubble/foam-template.