### PR TITLE
Fix keyboard shortcuts for Command Palette on Mac

### DIFF
--- a/backlinking.md
+++ b/backlinking.md
@@ -2,7 +2,7 @@
 
 When using [[wiki-links]], you can find all notes that link to a specific note in the [VS Code Markdown Notes](https://marketplace.visualstudio.com/items?itemName=kortina.vscode-markdown-notes) **Backlinks Explorer**
 
-- Run `Cmd` + `P` (`Ctrl` + `Shift` + `P` for Windows), type "backlinks" and run the **Explorer: Focus on Backlinks** view.
+- Run `Shift` + `Cmd` + `P` (`Ctrl` + `Shift` + `P` for Windows), type "backlinks" and run the **Explorer: Focus on Backlinks** view.
 - Keep this pane always visible to discover relationships between your thoughts
 - You can drag the backlinks pane to a different section in VS Code if you prefer.
 - Finding backlinks in published Foam workspaces via [[materialized-backlinks]] is on the [[roadmap]] but not yet implemented.

--- a/creating-new-notes.md
+++ b/creating-new-notes.md
@@ -1,7 +1,7 @@
 # Creating New Notes
 
 - Write out a new `[[wiki-link]]` and `Cmd` + `Click` to create a new file.
-- `Cmd` + `P` (`Ctrl` + `Shift` + `P` for Windows), execute `New Note` from [VS Code Markdown Notes](<(https://marketplace.visualstudio.com/items?itemName=kortina.vscode-markdown-notes)>) and enter a **Title Case Name** to create `title-case-name.md`
+- `Shift` + `Cmd` + `P` (`Ctrl` + `Shift` + `P` for Windows), execute `New Note` from [VS Code Markdown Notes](<(https://marketplace.visualstudio.com/items?itemName=kortina.vscode-markdown-notes)>) and enter a **Title Case Name** to create `title-case-name.md`
   - Add a keyboard binding to make creating new notes easier.
 - You shouldn't worry too much about categorising your notes. You can always [[search-for-notes]], and explore them using the [[graph-visualisation]].
 

--- a/git-integration.md
+++ b/git-integration.md
@@ -8,7 +8,7 @@ There are (too) many ways to commit your changes to source control:
 
 The quick and easy way is to use the Git: Commit All command after editing files. The default Foam workspace settings will stage & sync all of your changes to the remote:
 
-- `Cmd` + `P` (`Ctrl` + `Shift` + `P` for Windows), execute `Git: Commit All`
+- `Shift` + `Cmd` + `P` (`Ctrl` + `Shift` + `P` for Windows), execute `Git: Commit All`
 
 This could be improved. [[todo]] [[good-first-task]]
 

--- a/graph-visualisation.md
+++ b/graph-visualisation.md
@@ -1,6 +1,6 @@
 # Graph visualisation
 
-`Cmd` + `P` (`Ctrl` + `Shift` + `P` for Windows), type `Show graph`.
+`Shift` + `Cmd` + `P` (`Ctrl` + `Shift` + `P` for Windows), type `Show graph`.
 
 (Depends on [Markdown Links](https://marketplace.visualstudio.com/items?itemName=tchayen.markdown-links).)
 


### PR DESCRIPTION
Change documentation, to use ⇧⌘P as keyboard shortcut for 'Command Palette'  (also known as Show All Commands).

(Not ⌘P, that's a typo, it's the shortcut for 'Go to File..., Quick Open'.)

Reference: https://code.visualstudio.com/docs/getstarted/keybindings