### PR TITLE
Add open daily note base feature

### DIFF
--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -37,6 +37,7 @@
     "publish-extension": "npx vsce publish && yarn npm-cleanup"
   },
   "devDependencies": {
+    "@types/dateformat": "^3.0.1",
     "@types/glob": "^7.1.1",
     "@types/node": "^13.11.0",
     "@types/vscode": "^1.45.1",
@@ -49,6 +50,7 @@
     "vscode-test": "^1.3.0"
   },
   "dependencies": {
+    "dateformat": "^3.0.3",    
     "foam-core": "^0.2.0"
   }
 }

--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -15,7 +15,8 @@
   ],
   "activationEvents": [
     "workspaceContains:.vscode/foam.json",
-    "onCommand:foam-vscode.update-wikilinks"
+    "onCommand:foam-vscode.update-wikilinks",
+    "onCommand:foam-vscode.open-daily-note"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -23,6 +24,49 @@
       {
         "command": "foam-vscode.update-wikilinks",
         "title": "Foam: Update Markdown Reference List"
+      },
+      {
+        "command": "foam-vscode.open-daily-note",
+        "title": "Foam: Open Daily Note"
+      }
+    ],
+    "configuration": {
+      "title": "Foam",
+      "properties": {
+        "foam.openDailyNote.fileExtension": {
+          "type": "string",
+          "scope": "resource",
+          "default": "md"
+        },
+        "foam.openDailyNote.filenameFormat": {
+          "type": "string",
+          "default": "isoDate",
+          "markdownDescription": "Specifies how the daily note filename is formatted. See the [dateformat docs](https://www.npmjs.com/package/dateformat) for valid formats",
+          "scope": "resource"
+        },
+        "foam.openDailyNote.titleFormat": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "markdownDescription": "Specifies how the daily note title is formatted. Will default to the filename format if set to null. See the [dateformat docs](https://www.npmjs.com/package/dateformat) for valid formats",
+          "scope": "resource"
+        },
+        "foam.openDailyNote.directory": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "description": "The directory into which daily notes should be created. Defaults to the workspace root."
+        }
+      }
+    },
+    "keybindings": [
+      {
+        "command": "foam-vscode.open-daily-note",
+        "key": "alt+d"
       }
     ]
   },
@@ -50,7 +94,7 @@
     "vscode-test": "^1.3.0"
   },
   "dependencies": {
-    "dateformat": "^3.0.3",    
+    "dateformat": "^3.0.3",
     "foam-core": "^0.2.0"
   }
 }

--- a/packages/foam-vscode/src/features/index.ts
+++ b/packages/foam-vscode/src/features/index.ts
@@ -1,7 +1,5 @@
+import createReferences from "./wikilink-reference-generation";
+import openDailyNote from "./open-daily-note";
+import { FoamFeature } from "../types";
 
-import createReferences from './wikilink-reference-generation'
-import { FoamFeature } from '../types'
-
-export const features: FoamFeature[] = [
-  createReferences
-]
+export const features: FoamFeature[] = [createReferences, openDailyNote];

--- a/packages/foam-vscode/src/features/open-daily-note.ts
+++ b/packages/foam-vscode/src/features/open-daily-note.ts
@@ -1,0 +1,96 @@
+import {
+  window,
+  workspace,
+  Uri,
+  WorkspaceConfiguration,
+  ExtensionContext,
+  commands,
+} from "vscode";
+import { dirname, join } from "path";
+import dateFormat = require("dateformat");
+import fs = require("fs");
+import { FoamFeature } from "../types";
+
+const feature: FoamFeature = {
+  activate: async (context: ExtensionContext) => {
+    context.subscriptions.push(
+      commands.registerCommand("foam-vscode.open-daily-note", openDailyNote)
+    );
+  },
+};
+
+async function openDailyNote() {
+  const foamConfiguration = workspace.getConfiguration("foam");
+  const currentDate = new Date();
+
+  const dailyNotePath = getDailyNotePath(foamConfiguration, currentDate);
+
+  createDailyNoteIfNotExists(foamConfiguration, dailyNotePath, currentDate);
+  await focusDailyNote(dailyNotePath);
+}
+
+function getDailyNotePath(configuration: WorkspaceConfiguration, date: Date) {
+  const rootDirectory = workspace.workspaceFolders[0].uri.fsPath;
+  const dailyNoteDirectory: string =
+    configuration.get("openDailyNote.directory") ?? ".";
+  const dailyNoteFilename = getDailyNoteFileName(configuration, date);
+
+  return join(rootDirectory, dailyNoteDirectory, dailyNoteFilename);
+}
+
+function getDailyNoteFileName(
+  configuration: WorkspaceConfiguration,
+  date: Date
+): string {
+  const filenameFormat: string = configuration.get(
+    "openDailyNote.filenameFormat"
+  );
+  const fileExtension: string = configuration.get(
+    "openDailyNote.fileExtension"
+  );
+
+  return `${dateFormat(date, filenameFormat, false)}.${fileExtension}`;
+}
+
+async function createDailyNoteIfNotExists(
+  configuration: WorkspaceConfiguration,
+  dailyNotePath: string,
+  currentDate: Date
+) {
+  if (await pathExists(dailyNotePath)) {
+    return;
+  }
+
+  createDailyNoteDirectoryIfNotExists(dailyNotePath);
+
+  const titleFormat: string =
+    configuration.get("openDailyNote.titleFormat") ??
+    configuration.get("openDailyNote.filenameFormat");
+
+  await fs.promises.writeFile(
+    dailyNotePath,
+    `# ${dateFormat(currentDate, titleFormat, false)}\r\n`
+  );
+}
+
+async function createDailyNoteDirectoryIfNotExists(dailyNotePath: string) {
+  const dailyNoteDirectory = dirname(dailyNotePath);
+
+  if (!(await pathExists(dailyNoteDirectory))) {
+    await fs.promises.mkdir(dailyNoteDirectory, { recursive: true });
+  }
+}
+
+async function focusDailyNote(dailyNotePath: string) {
+  const document = await workspace.openTextDocument(Uri.parse(dailyNotePath));
+  window.showTextDocument(document);
+}
+
+async function pathExists(path: string) {
+  return fs.promises
+    .access(path, fs.constants.F_OK)
+    .then(() => true)
+    .catch(() => false);
+}
+
+export default feature;


### PR DESCRIPTION
Open Daily Note is a core feature of roam. That's why this feature is considered as a core feature in foam's roadmap. This feature is quite simple. With the `Foam: Open Daily Note` command, vscode will create today's note (`yyyy-mm-dd.md`) if it's not already created and focus the editor on today's note. It is also possible to trigger the command via the `Alt+d` keyboard shortcut.

Some things related to the daily note are configurable:

- Filename format
- File extension
- Title format of the daily note
- Daily notes directory

This PR implements the [Must Have](https://foambubble.github.io/foam/daily-notes#must-have) and the [Should Have](https://foambubble.github.io/foam/daily-notes#should-have).

Related issue: https://github.com/foambubble/foam/issues/54