### PR TITLE
Sorting link references

### DIFF
--- a/packages/foam-vscode/src/extension.ts
+++ b/packages/foam-vscode/src/extension.ts
@@ -154,6 +154,8 @@ async function generateReferenceList(doc: TextDocument): Promise<string[]> {
     }
   }
 
+  references.sort()
+
   // for (const backlink of note.backlinks) {
   //   references.push(
   //     `[backlink:${backlink.id}]: ${backlink.filename} "${backlink.title}"`


### PR DESCRIPTION
I noticed [here](https://github.com/foambubble/foam/pull/69/files#diff-f2d1eb072b7cb530c555baf35e664b9c) that links are not generated consistently and that causes messy diffs.

This change sorts the links alphabetically to avoid messy git diffs on the generated markdown part of the files