### PR TITLE
Make wikilinks more flexible

### DIFF
--- a/packages/foam-vscode/src/extension.ts
+++ b/packages/foam-vscode/src/extension.ts
@@ -149,7 +149,7 @@ async function generateReferenceList(doc: TextDocument): Promise<string[]> {
 
       // [wiki-link-text]: wiki-link "Page title"
       references.push(
-        `[${link.id}]: ${relativePathWithoutExtension} "${link.title}"`
+        `[${link.original}]: ${relativePathWithoutExtension} "${link.title}"`
       );
     }
   }
@@ -158,7 +158,7 @@ async function generateReferenceList(doc: TextDocument): Promise<string[]> {
 
   // for (const backlink of note.backlinks) {
   //   references.push(
-  //     `[backlink:${backlink.id}]: ${backlink.filename} "${backlink.title}"`
+  //     `[backlink:${backlink.original}]: ${backlink.filename} "${backlink.title}"`
   //   );
   // }
 

--- a/packages/foam-workspace-manager/src/WorkspaceManager.ts
+++ b/packages/foam-workspace-manager/src/WorkspaceManager.ts
@@ -169,30 +169,13 @@ export class WorkspaceManager {
     }
   }
 
-  /*
-  // Clearly I'm too tired to do this right now
-  public removeNote(a: ID): Note | null {
-    let note = this.notes.get(a);
+  
+  public removeNote(note: ID) {
     if (!note) {
       return null;
     }
-
-    // find references from this note to others
-    let linksFromNote = getOrInitializeIndexForId(this.linksFromNoteById, a);
-
-    // remove the index
-    this.linksFromNoteById.delete(a);
-
-    // find all notes that reference the note we are deleting
-    for (const b in linksFromNote) {
-      const backlinks = getOrInitializeIndexForId(this.linksBackToNoteById, b);
-      if (backlinks.has(a)) {
-        // @todo, trigger event?
-        backlinks.delete(a);
-      }
-    }
-
-    return note;
+    this.notes = this.notes.filter(v => v.original !== note);
+    return true;
   }
   
 
@@ -200,5 +183,4 @@ export class WorkspaceManager {
   public renameNote(note: Note, newFilename: string) {
     throw new Error('Not implemented');
   }
-  */
 }

--- a/packages/foam-workspace-manager/src/WorkspaceManager.ts
+++ b/packages/foam-workspace-manager/src/WorkspaceManager.ts
@@ -52,18 +52,6 @@ export class LooseFilename implements ILooseFilename {
       .replace(/[-_－＿ ]*$/g, ''); // removing trailing slug chars
   }
 }
-/*
-function getOrInitializeIndexForId(index: Index, id: ID): Set<ID> {
-  let links: Set<ID>;
-  if (index.has(id)) {
-    links = index.get(id)!;
-  } else {
-    index.set(id, (links = new Set<ID>()));
-  }
-
-  return links;
-}
-*/
 
 export class WorkspaceManager {
   /**
@@ -136,12 +124,7 @@ export class WorkspaceManager {
     // extract linksTo
     return note;
   }
-  public reparseBacklinks(file: LooseFilename) {
-    this.notes = this.notes.map(note => {
-      note.backlinks = this.getBacklinksToThisFile(file)
-      return note;
-    })
-  }
+
   public associateAllForwardLinks() {
     this.notes = this.notes.map(note => {
       note.linkedNotes = this.associateForwardlinks(note)
@@ -185,7 +168,7 @@ export class WorkspaceManager {
       this.notes.push(note);
     }
   }
-  
+
   /*
   // Clearly I'm too tired to do this right now
   public removeNote(a: ID): Note | null {

--- a/packages/foam-workspace-manager/test/WorkspaceManager.test.ts
+++ b/packages/foam-workspace-manager/test/WorkspaceManager.test.ts
@@ -45,7 +45,7 @@ describe('WorkspaceManager', () => {
     expect(note!.backlinks.map(n => n.clean)).toEqual(['page-b']);
   });
 
-  it('links things correctly when the original file has different capitalization', () => {
+  it('links things correctly when the original file has different capitalisation', () => {
     const ws = new WorkspaceManager('dir/');
 
     const original = `Link to [[new-file]]`;
@@ -75,7 +75,7 @@ describe('WorkspaceManager', () => {
     expect(note!.linkedNotes.map(n => n.clean)).toEqual(['new-file']);
   });
 
-  it('Links with a lose accent match', () => {
+  it('links with a loose accent match', () => {
     const ws = new WorkspaceManager('dir/');
 
     ws.addNoteFromMarkdown('original.md', `Link to [[Zoë]]`);
@@ -87,7 +87,7 @@ describe('WorkspaceManager', () => {
     expect(note!.linkedNotes.map(n => n.clean)).toEqual(['zoe']);
   });
 
-  it('Links to the most specific match', () => {
+  it('links to the most specific match', () => {
     const ws = new WorkspaceManager('dir/');
 
     ws.addNoteFromMarkdown('original.md', `Link to [[Zoë]]`);
@@ -100,7 +100,24 @@ describe('WorkspaceManager', () => {
     expect(note!.linkedNotes.map(n => n.original)).toEqual(['Zoë']);
   });
 
-  it('Backlinks with a lose accent match', () => {
+  it('backlinks with a specific accent match', () => {
+    const ws = new WorkspaceManager('dir/');
+
+    ws.addNoteFromMarkdown('original.md', `Link to [[Zoë]]`);
+    ws.addNoteFromMarkdown('zoe.md', `# LooseZoe`);
+    ws.addNoteFromMarkdown('Zoë.md', `# SpecificZoë`);
+    
+    const loose = ws.getNoteWithLinks('zoe');
+    const specific = ws.getNoteWithLinks('Zoë');
+
+    expect(specific!.title).toEqual('SpecificZoë');
+    expect(loose!.title).toEqual('LooseZoe');
+    expect(specific!.backlinks.map(n => n.clean)).toEqual(['original']);
+    expect(loose!.backlinks.map(n => n.clean)).toEqual([]);
+
+  });
+
+  it('backlinks with a loose accent match', () => {
     const ws = new WorkspaceManager('dir/');
 
     ws.addNoteFromMarkdown('original.md', `Link to [[Zoë]]`);
@@ -163,7 +180,7 @@ describe('WorkspaceManager', () => {
     expect(before).not.toEqual(after);
     expect(after).toEqual(['has-link', 'add-link']);
   });
-  /*
+  
   it('updates links correctly when page is removed', () => {
     const ws = new WorkspaceManager('dir/');
 
@@ -176,10 +193,9 @@ describe('WorkspaceManager', () => {
 
     const note = ws.getNoteWithLinks('page-a');
 
-    console.log(note);
     expect(note).not.toBeNull();
-    expect(note!.linkedNotes.map(n => n.id)).toEqual(['page-b']);
-    expect(note!.backlinks.map(n => n.id)).toEqual(['page-b']);
+    expect(note!.linkedNotes.map(n => n.clean)).toEqual(['page-b']);
+    expect(note!.backlinks.map(n => n.clean)).toEqual(['page-b']);
   });
-  */
+  
 });

--- a/packages/foam-workspace-manager/test/WorkspaceManager.test.ts
+++ b/packages/foam-workspace-manager/test/WorkspaceManager.test.ts
@@ -33,8 +33,8 @@ describe('WorkspaceManager', () => {
 
     const note = ws.getNoteWithLinks('page-a');
     expect(note).not.toBeNull();
-    expect(note!.linkedNotes.map(n => n.id)).toEqual(['page-b', 'page-c']);
-    expect(note!.backlinks.map(n => n.id)).toEqual(['page-b']);
+    expect(note!.linkedNotes.map(n => n.clean)).toEqual(['page-b', 'page-c']);
+    expect(note!.backlinks.map(n => n.clean)).toEqual(['page-b']);
   });
 
   it('links things correctly when added out of order', () => {
@@ -47,8 +47,40 @@ describe('WorkspaceManager', () => {
     const note = ws.getNoteWithLinks('page-a');
 
     expect(note).not.toBeNull();
-    expect(note!.linkedNotes.map(n => n.id)).toEqual(['page-b', 'page-c']);
-    expect(note!.backlinks.map(n => n.id)).toEqual(['page-b']);
+    expect(note!.linkedNotes.map(n => n.clean)).toEqual(['page-b', 'page-c']);
+    expect(note!.backlinks.map(n => n.clean)).toEqual(['page-b']);
+  });
+
+  it('links things correctly when the original file has different capitalization', () => {
+    const ws = new WorkspaceManager('dir/');
+
+    const original = `# Original
+[[new-file]]`;
+    const newFile = `# New File`;
+
+    ws.addNoteFromMarkdown('original.md', original);
+    ws.addNoteFromMarkdown('New-File.md', newFile);
+    
+    const note = ws.getNoteWithLinks('original');
+
+    expect(note).not.toBeNull();
+    expect(note!.linkedNotes.map(n => n.clean)).toEqual(['new-file']);
+  });
+
+  it('links things correctly when the link has different capitalization', () => {
+    const ws = new WorkspaceManager('dir/');
+
+    const original = `# Original
+[[New-File]]`;
+    const newFile = `# New File`;
+
+    ws.addNoteFromMarkdown('original.md', original);
+    ws.addNoteFromMarkdown('new-file.md', newFile);
+    
+    const note = ws.getNoteWithLinks('original');
+
+    expect(note).not.toBeNull();
+    expect(note!.linkedNotes.map(n => n.clean)).toEqual(['new-file']);
   });
 
   it('updates links when adding a changed document', () => {
@@ -66,11 +98,11 @@ describe('WorkspaceManager', () => {
     const after = ws.getNoteWithLinks('page-a');
 
     expect(before).not.toEqual(after);
-    expect(before!.linkedNotes.map(n => n.id)).toEqual(['page-b', 'page-c']);
-    expect(before!.backlinks.map(n => n.id)).toEqual(['page-b']);
+    expect(before!.linkedNotes.map(n => n.clean)).toEqual(['page-b', 'page-c']);
+    expect(before!.backlinks.map(n => n.clean)).toEqual(['page-b']);
 
-    expect(after!.linkedNotes.map(n => n.id)).toEqual(['page-b', 'page-c']);
-    expect(after!.backlinks.map(n => n.id)).toEqual(['page-b', 'page-c']);
+    expect(after!.linkedNotes.map(n => n.clean)).toEqual(['page-b', 'page-c']);
+    expect(after!.backlinks.map(n => n.clean)).toEqual(['page-b', 'page-c']);
   });
 
   /*

--- a/packages/foam-workspace-manager/test/WorkspaceManager.test.ts
+++ b/packages/foam-workspace-manager/test/WorkspaceManager.test.ts
@@ -17,12 +17,6 @@ const pageC = `
 # Page C
 `;
 
-const updatedPageC = `
-# Page C
-[[page-a]]
-[[page-b]]
-`;
-
 describe('WorkspaceManager', () => {
   it('links things correctly when added in order', () => {
     const ws = new WorkspaceManager('dir/');
@@ -54,8 +48,7 @@ describe('WorkspaceManager', () => {
   it('links things correctly when the original file has different capitalization', () => {
     const ws = new WorkspaceManager('dir/');
 
-    const original = `# Original
-[[new-file]]`;
+    const original = `Link to [[new-file]]`;
     const newFile = `# New File`;
 
     ws.addNoteFromMarkdown('original.md', original);
@@ -70,8 +63,7 @@ describe('WorkspaceManager', () => {
   it('links things correctly when the link has different capitalization', () => {
     const ws = new WorkspaceManager('dir/');
 
-    const original = `# Original
-[[New-File]]`;
+    const original = `Link to [[New-File]]`;
     const newFile = `# New File`;
 
     ws.addNoteFromMarkdown('original.md', original);
@@ -83,28 +75,94 @@ describe('WorkspaceManager', () => {
     expect(note!.linkedNotes.map(n => n.clean)).toEqual(['new-file']);
   });
 
-  it('updates links when adding a changed document', () => {
+  it('Links with a lose accent match', () => {
     const ws = new WorkspaceManager('dir/');
 
-    ws.addNoteFromMarkdown('page-b.md', pageB);
-    ws.addNoteFromMarkdown('page-a.md', pageA);
-    ws.addNoteFromMarkdown('page-c.md', pageC);
+    ws.addNoteFromMarkdown('original.md', `Link to [[Zoë]]`);
+    ws.addNoteFromMarkdown('zoe.md', `# Zoë`);
+    
+    const note = ws.getNoteWithLinks('original');
 
-    const before = ws.getNoteWithLinks('page-a');
-
-    // change document
-    ws.addNoteFromMarkdown('page-c.md', updatedPageC);
-
-    const after = ws.getNoteWithLinks('page-a');
-
-    expect(before).not.toEqual(after);
-    expect(before!.linkedNotes.map(n => n.clean)).toEqual(['page-b', 'page-c']);
-    expect(before!.backlinks.map(n => n.clean)).toEqual(['page-b']);
-
-    expect(after!.linkedNotes.map(n => n.clean)).toEqual(['page-b', 'page-c']);
-    expect(after!.backlinks.map(n => n.clean)).toEqual(['page-b', 'page-c']);
+    expect(note).not.toBeNull();
+    expect(note!.linkedNotes.map(n => n.clean)).toEqual(['zoe']);
   });
 
+  it('Links to the most specific match', () => {
+    const ws = new WorkspaceManager('dir/');
+
+    ws.addNoteFromMarkdown('original.md', `Link to [[Zoë]]`);
+    ws.addNoteFromMarkdown('zoe.md', `# Zoe`);
+    ws.addNoteFromMarkdown('Zoë.md', `# Zoë`);
+    
+    const note = ws.getNoteWithLinks('original');
+
+    expect(note).not.toBeNull();
+    expect(note!.linkedNotes.map(n => n.original)).toEqual(['Zoë']);
+  });
+
+  it('Backlinks with a lose accent match', () => {
+    const ws = new WorkspaceManager('dir/');
+
+    ws.addNoteFromMarkdown('original.md', `Link to [[Zoë]]`);
+    ws.addNoteFromMarkdown('zoe.md', `# Zoë`);
+    
+    const note = ws.getNoteWithLinks('zoe');
+
+    expect(note).not.toBeNull();
+    expect(note!.backlinks.map(n => n.clean)).toEqual(['original']);
+  });
+
+  it('updates document content', () => {
+
+    const ws = new WorkspaceManager('dir/');
+
+    ws.addNoteFromMarkdown('simple.md', `This content will be updated`);
+    const before = ws.getNoteWithLinks('simple')!.markdown;
+    
+    ws.addNoteFromMarkdown('simple.md', `This content has been updated`);
+    const after = ws.getNoteWithLinks('simple')!.markdown;
+
+    expect(before).not.toEqual(after);
+  });
+  it('Updates can update forward links', () => {
+    const ws = new WorkspaceManager('dir/');
+    
+    ws.addNoteFromMarkdown('changeme.md', `I have an [[old]] link`);
+    ws.addNoteFromMarkdown('old.md', `#Old`);
+    ws.addNoteFromMarkdown('new.md', `#New`);
+
+    const before = ws.getNoteWithLinks('changeme')!
+                     .linkedNotes.map(n => n.clean);
+    
+    // change document
+    ws.addNoteFromMarkdown('changeme.md', `I have a [[new]] link`)
+
+    const after = ws.getNoteWithLinks('changeme')!
+                    .linkedNotes.map(n => n.clean);
+    
+    expect(before).not.toEqual(after);
+    expect(after).toEqual(['new']);
+  });
+
+  it('Updates can update back links', () => {
+    const ws = new WorkspaceManager('dir/');
+
+    ws.addNoteFromMarkdown('has-link.md', `Link to [[referenced]] file`);
+    ws.addNoteFromMarkdown('referenced.md', `#Referenced`);
+    ws.addNoteFromMarkdown('add-link.md', `Will add a link to the referenced file`);
+
+    const before = ws.getNoteWithLinks('referenced')!
+                     .backlinks.map(n => n.clean);
+    
+    // change document
+    ws.addNoteFromMarkdown('add-link.md', `Now also links to the [[referenced]] file`)
+
+    const after = ws.getNoteWithLinks('referenced')!
+                    .backlinks.map(n => n.clean);
+    
+    expect(before).not.toEqual(after);
+    expect(after).toEqual(['has-link', 'add-link']);
+  });
   /*
   it('updates links correctly when page is removed', () => {
     const ws = new WorkspaceManager('dir/');


### PR DESCRIPTION
Just playing with an idea to make WikiLinks more flexible to allow alternative slug characters, capitalisation and accents yet it still generate a link to the original document.