### PR TITLE
Add NoteLink.position to keep track of link ranges

### DIFF
--- a/packages/foam-core/src/markdown-provider.ts
+++ b/packages/foam-core/src/markdown-provider.ts
@@ -4,7 +4,7 @@ import wikiLinkPlugin from 'remark-wiki-link';
 import visit, { CONTINUE, EXIT } from 'unist-util-visit';
 import { Node, Parent } from 'unist';
 import * as path from 'path';
-import { Link, Note, NoteGraph } from './note-graph';
+import { Note, NoteLink, NoteGraph } from './note-graph';
 import { dropExtension } from './utils';
 
 let processor: unified.Processor | null = null;
@@ -29,13 +29,13 @@ export function createNoteFromMarkdown(uri: string, markdown: string): Note {
     }
     return title === id ? CONTINUE : EXIT;
   });
-  const links: Link[] = [];
+  const links: NoteLink[] = [];
   visit(tree, node => {
     if (node.type === 'wikiLink') {
       links.push({
-        from: id,
         to: node.value as string,
         text: node.value as string,
+        position: node.position!
       });
     }
   });

--- a/packages/foam-core/src/note-graph.ts
+++ b/packages/foam-core/src/note-graph.ts
@@ -1,4 +1,5 @@
 import { Graph, Edge } from 'graphlib';
+import { Position } from 'unist';
 
 type ID = string;
 
@@ -11,6 +12,7 @@ export interface Link {
 export interface NoteLink {
   to: ID;
   text: string;
+  position: Position;
 }
 
 export class Note {

--- a/packages/foam-core/test/core.test.ts
+++ b/packages/foam-core/test/core.test.ts
@@ -1,5 +1,10 @@
 import { NoteGraph, Note } from '../src/note-graph';
 
+const position = {
+  start: { line: 0, column: 0},
+  end: { line: 0, column: 0}
+};
+
 describe('Note graph', () => {
   it('Adds notes to graph', () => {
     const graph = new NoteGraph();
@@ -22,7 +27,7 @@ describe('Note graph', () => {
       new Note(
         'page-b',
         'page-b',
-        [{ to: 'page-a', text: 'go' }],
+        [{ to: 'page-a', text: 'go', position }],
         '/page-b.md',
         ''
       )
@@ -44,7 +49,7 @@ describe('Note graph', () => {
       new Note(
         'page-b',
         'page-b',
-        [{ to: 'page-a', text: 'go' }],
+        [{ to: 'page-a', text: 'go', position }],
         '/page-b.md',
         ''
       )
@@ -73,7 +78,7 @@ describe('Note graph', () => {
       new Note(
         'page-a',
         'page-a',
-        [{ to: 'non-existing', text: 'does not exist' }],
+        [{ to: 'non-existing', text: 'does not exist', position }],
         '/path-b.md',
         ''
       )
@@ -88,7 +93,7 @@ describe('Note graph', () => {
       new Note(
         'page-b',
         'page-b',
-        [{ to: 'page-a', text: 'go' }],
+        [{ to: 'page-a', text: 'go', position }],
         '/page-b.md',
         ''
       )
@@ -118,7 +123,7 @@ describe('Note graph', () => {
       new Note(
         'page-b',
         'page-b',
-        [{ to: 'page-c', text: 'go' }],
+        [{ to: 'page-c', text: 'go', position }],
         '/path-2b.md',
         ''
       )


### PR DESCRIPTION
Cherry-picked this off from #107, as it's likely we'll need this for other core/janitor features before the spike can land.

- Adds `NoteLink.position` field to attach Markdown AST positional information to links, to be used by VS Code providers. 
- Uses the unist types directly as they are just plain interfaces.