### PR TITLE
DX: repo-wide build tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,12 @@
     "watch:vscode": "yarn workspace foam-vscode watch",
     "build:core": "yarn workspace foam-core build",
     "watch:core": "yarn workspace foam-core start",
-    "test:core": "yarn workspace foam-core test"
+    "test:core": "yarn workspace foam-core test",
+    "clean": "lerna run clean",
+    "build": "lerna run build",
+    "test": "lerna run test",
+    "lint": "lerna run lint",
+    "watch": "lerna run watch --concurrency 20 --stream"
   },
   "devDependencies": {
     "all-contributors-cli": "^6.16.1",

--- a/packages/foam-cli/package.json
+++ b/packages/foam-cli/package.json
@@ -60,10 +60,13 @@
   },
   "repository": "foambubble/foam",
   "scripts": {
+    "clean": "rimraf tmp",
+    "build": "tsc -b",
+    "test": "jest",
+    "lint": "echo Missing lint task in CLI package",
     "cli": "./bin/run",
     "postpack": "rm -f oclif.manifest.json",
     "prepack": "rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme",
-    "test": "jest",
     "version": "oclif-dev readme && git add README.md"
   },
   "types": "lib/index.d.ts"

--- a/packages/foam-cli/src/commands/migrate.ts
+++ b/packages/foam-cli/src/commands/migrate.ts
@@ -51,9 +51,11 @@ Successfully generated link references and heading!
 
       // Kebab case file names
       const fileRename = notes.map(note => {
-        const kebabCasedFileName = getKebabCaseFileName(note.title);
-        if (kebabCasedFileName) {
-          return renameFile(note.path, kebabCasedFileName);
+        if (note.title != null) {
+          const kebabCasedFileName = getKebabCaseFileName(note.title);
+          if (kebabCasedFileName) {
+            return renameFile(note.path, kebabCasedFileName);
+          }
         }
         return Promise.resolve(null);
       });

--- a/packages/foam-core/package.json
+++ b/packages/foam-core/package.json
@@ -8,10 +8,11 @@
     "dist"
   ],
   "scripts": {
-    "start": "tsdx watch",
+    "clean": "rimraf dist",
     "build": "tsdx build",
     "test": "tsdx test",
     "lint": "tsdx lint",
+    "watch": "tsdx watch",
     "prepare": "tsdx build"
   },
   "devDependencies": {

--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -80,10 +80,12 @@
     ]
   },
   "scripts": {
-    "vscode:prepublish": "yarn npm-install && yarn run compile",
-    "compile": "tsc -p ./",
+    "clean": "rimraf out",
+    "build": "tsc -p ./",
+    "test": "echo No tests in VSCode extensions yet",
     "lint": "eslint src --ext ts",
     "watch": "tsc -watch -p ./",
+    "vscode:prepublish": "yarn npm-install && yarn run compile",
     "npm-install": "rimraf node_modules && npm i",
     "npm-cleanup": "rimraf package-lock.json node_modules && yarn",
     "package-extension": "npx vsce package && yarn npm-cleanup",


### PR DESCRIPTION
Adding a few build tasks across packages and standardizing on naming.
```
clean: remove output from build process
build: build the package
watch: build and watch for changes
test: run tests
lint: run lint
```

That means we can run any of those tasks from the root and have them executed everywhere. (I found it especially useful with `watch` to monitor both changes in `foam-core` and `foam-vscode`).

Note:
- `watch` is not defined in `foam-cli` as I don't think it's needed there
- `lint` has a placeholder in `foam-cli` because it's not there yet, but probably should
- `test` has a placeholder in `foam-vscode` because it's not there yet, but probably should

p.s. while testing the setup it found a small compilation error, so I fixed that too
