### PR TITLE
adding recipe for migrating from Onenote

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -71,7 +71,7 @@ If a roadmap item is a stub, **consider** opening a [GitHub issue](https://githu
 - [[migrating-from-obsidian]]
   - Discussion: [foam#46](https://github.com/foambubble/foam/issues/46)
 - [[Migrating from OneNote (stub)]]
-  Discussion: [foam#151](https://github.com/foambubble/foam/issues/151)
+  - Discussion: [foam#151](https://github.com/foambubble/foam/issues/151)
 - _Migration from other tools..._
 ### integration
 - _Integrations to third party tools_...

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -70,8 +70,9 @@ If a roadmap item is a stub, **consider** opening a [GitHub issue](https://githu
   - Discussion: [foam#55](https://github.com/foambubble/foam/issues/55)
 - [[migrating-from-obsidian]]
   - Discussion: [foam#46](https://github.com/foambubble/foam/issues/46)
+- [[Migrating from OneNote (stub)]]
+  Discussion: [foam#151](https://github.com/foambubble/foam/issues/151)
 - _Migration from other tools..._
-
 ### integration
 - _Integrations to third party tools_...
   


### PR DESCRIPTION
I have made a script for exporting from Onenote to markdown [here](https://github.com/nixsee/ConvertOneNote2MarkDown)

I'm happy to help integrate it into your recipes for others to use