### PR TITLE
fixed issue with opening daily note on windows

### DIFF
--- a/packages/foam-vscode/src/features/open-daily-note.ts
+++ b/packages/foam-vscode/src/features/open-daily-note.ts
@@ -86,7 +86,7 @@ async function createDailyNoteDirectoryIfNotExists(dailyNotePath: string) {
 }
 
 async function focusDailyNote(dailyNotePath: string, isNewNote: boolean) {
-  const document = await workspace.openTextDocument(Uri.parse(dailyNotePath));
+  const document = await workspace.openTextDocument(Uri.file(dailyNotePath));
   const editor = await window.showTextDocument(document);
 
   // Move the cursor to end of the file

--- a/yarn.lock
+++ b/yarn.lock
@@ -5188,6 +5188,22 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
+foam-core@0.3.0-alpha.0:
+  version "0.3.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/foam-core/-/foam-core-0.3.0-alpha.0.tgz#792ef6b344854f6e34af954cbbce0a39c1657712"
+  integrity sha512-HNCjlb8LtWePry/llLQRm5L8pJGredD6bj3WrILivIwIvYiXhhNzuIdFZkkUQKLcxQawKGBs9SkIapYrAk0rFw==
+  dependencies:
+    detect-newline "^3.1.0"
+    github-slugger "^1.3.0"
+    glob "^7.1.6"
+    graphlib "^2.1.8"
+    lodash "^4.17.19"
+    remark-parse "^8.0.2"
+    remark-wiki-link "^0.0.4"
+    title-case "^3.0.2"
+    unified "^9.0.0"
+    unist-util-visit "^2.0.2"
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5188,22 +5188,6 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-foam-core@0.3.0-alpha.0:
-  version "0.3.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/foam-core/-/foam-core-0.3.0-alpha.0.tgz#792ef6b344854f6e34af954cbbce0a39c1657712"
-  integrity sha512-HNCjlb8LtWePry/llLQRm5L8pJGredD6bj3WrILivIwIvYiXhhNzuIdFZkkUQKLcxQawKGBs9SkIapYrAk0rFw==
-  dependencies:
-    detect-newline "^3.1.0"
-    github-slugger "^1.3.0"
-    glob "^7.1.6"
-    graphlib "^2.1.8"
-    lodash "^4.17.19"
-    remark-parse "^8.0.2"
-    remark-wiki-link "^0.0.4"
-    title-case "^3.0.2"
-    unified "^9.0.0"
-    unist-util-visit "^2.0.2"
-
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"


### PR DESCRIPTION
Fixed issue with opening daily note on windows ( #160 )

Seems like `uri.parse` screws up file paths on windows. `uri.file` fixes this issue.