### PR TITLE
test: use npx

### DIFF
--- a/packages/foam-core/package.json
+++ b/packages/foam-core/package.json
@@ -9,11 +9,11 @@
   ],
   "scripts": {
     "clean": "rimraf dist",
-    "build": "tsdx build",
-    "test": "tsdx test",
-    "lint": "tsdx lint",
-    "watch": "tsdx watch",
-    "prepare": "tsdx build"
+    "build": "npx tsdx build",
+    "test": "npx tsdx test",
+    "lint": "npx tsdx lint",
+    "watch": "npx tsdx watch",
+    "prepare": "npx tsdx build"
   },
   "devDependencies": {
     "@types/github-slugger": "^1.3.0",


### PR DESCRIPTION
Running `npm run test` or `lerna exec npm run test` from a fresh clone fails because the foam-core package.json assumes a global install of `tsdx`:

```
yarn run v1.22.4
$ tsdx test
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

lerna ERR! yarn run test stderr:
/bin/sh: tsdx: command not found
error Command failed with exit code 127.

lerna ERR! yarn run test exited 127 in 'foam-core'
```

Using `npx` obviates the issue.