### PR TITLE
revise vscode task- and launch-configs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,10 +6,9 @@
 	"version": "0.2.0",
 	"configurations": [
 		{
-             // This task is also defined in packages/foam-vscode/.vscode/launch.json
-             // for when running separately outside of the monorepo environment
-			"name": "Run Extension",
-            "type": "extensionHost",
+			// NOTE: Remember to synchronize this with the "No Build"-variant!
+			"name": "Run VSCode Extension",
+			"type": "extensionHost",
 			"request": "launch",
 			"runtimeExecutable": "${execPath}",
 			"args": [
@@ -18,12 +17,11 @@
 			"outFiles": [
 				"${workspaceFolder}/packages/foam-vscode/out/**/*.js"
 			],
-			"preLaunchTask": "Build foam-vscode"
+			"preLaunchTask": "${defaultBuildTask}"
 		},
 		{
-            // This task is also defined in packages/foam-vscode/.vscode/launch.json
-            // for when running separately outside of the monorepo environment
-			"name": "Extension Tests",
+			// NOTE: Remember to synchronize this with the "No Build"-variant!
+			"name": "Test VSCode Extension",
 			"type": "extensionHost",
 			"request": "launch",
 			"runtimeExecutable": "${execPath}",
@@ -34,12 +32,51 @@
 			"outFiles": [
 				"${workspaceFolder}/packages/foam-vscode/out/test/**/*.js"
 			],
-			"preLaunchTask": "Build foam-vscode"
+			"preLaunchTask": "${defaultBuildTask}"
 		},
 		{
+			// NOTE: Remember to synchronize this with the "No Build"-variant!
+			"name": "Test Core",
 			"type": "node",
 			"request": "launch",
-			"name": "Workspace Manager tests",
+			"program": "${workspaceFolder}/node_modules/tsdx/dist/index.js",
+			"args": ["test"],
+			"cwd": "${workspaceFolder}/packages/foam-core",
+			"internalConsoleOptions": "openOnSessionStart",
+			"preLaunchTask": "${defaultBuildTask}"
+		},
+		{
+			// NOTE: Remember to synchronize this with the default-variant!
+			"name": "Run VSCode Extension (No Build)",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}/packages/foam-vscode"
+			],
+			"outFiles": [
+				"${workspaceFolder}/packages/foam-vscode/out/**/*.js"
+			]
+		},
+		{
+			// NOTE: Remember to synchronize this with the default-variant!
+			"name": "Test VSCode Extension (No Build)",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}/packages/foam-vscode",
+				"--extensionTestsPath=${workspaceFolder}/packages/foam-vscode/out/test/suite/index"
+			],
+			"outFiles": [
+				"${workspaceFolder}/packages/foam-vscode/out/test/**/*.js"
+			]
+		},
+		{
+			// NOTE: Remember to synchronize this with the default-variant!
+			"name": "Test Core (No Build)",
+			"type": "node",
+			"request": "launch",
 			"program": "${workspaceFolder}/node_modules/tsdx/dist/index.js",
 			"args": ["test"],
 			"cwd": "${workspaceFolder}/packages/foam-core",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,18 +4,17 @@
 	"version": "2.0.0",
 	"tasks": [
 		{
-            // This task is also defined in packages/foam-vscode/.vscode/tasks.json
-            // for when running separately outside of the monorepo environment
-            "type": "npm",
-            "script": "watch",
-            "label": "Build foam-vscode",
-            "path": "packages/foam-vscode",
-            "problemMatcher": "$tsc-watch",
-			"isBackground": true,
+			"label": "Build foam",
+			"type": "npm",
+			"script": "build",
+			"problemMatcher": "$tsc",
+			"isBackground": false,
 			"presentation": {
-				"reveal": "silent",
-				"revealProblems": "onProblem",
-				"focus": true
+				"reveal": "always"
+			},
+			"group": {
+				"kind": "build",
+				"isDefault": true
 			}
 		}
 	]


### PR DESCRIPTION
- Removed commands from sub-package:
  same can be achieved from the root
- Added build and no-build variants.
  In case separate watcher is already running,
  no need to build.
- Changed watch to build (no hot-reload in vscode by default)
- Show the build in console

Didn't update yarn.lock, seems to want to add
foam-core@0.3.0-alpha.0, but not really
related to this change

Note: the extension tests are failing due to
`Cannot find module '...foam-vscode/out/test/suite/index'`.
However that shouldn't be related to this change either.