### PR TITLE
Remove brackets in creating-new-notes.md

### DIFF
--- a/docs/creating-new-notes.md
+++ b/docs/creating-new-notes.md
@@ -2,7 +2,7 @@
 
 - Write out a new `[[wiki-link]]` and `Cmd` + `Click` to create a new file and enter it.
   - For keyboard navigation, use the 'Follow Definition' key `F12` (or [remap key binding](https://code.visualstudio.com/docs/getstarted/keybindings) to something more ergonomic)
-- `Cmd` + `Shift` + `P` (`Ctrl` + `Shift` + `P` for Windows), execute `New Note` from [VS Code Markdown Notes](<(https://marketplace.visualstudio.com/items?itemName=kortina.vscode-markdown-notes)>) and enter a **Title Case Name** to create `title-case-name.md`
+- `Cmd` + `Shift` + `P` (`Ctrl` + `Shift` + `P` for Windows), execute `New Note` from [VS Code Markdown Notes](https://marketplace.visualstudio.com/items?itemName=kortina.vscode-markdown-notes) and enter a **Title Case Name** to create `title-case-name.md`
   - Add a keyboard binding to make creating new notes easier.
 - You shouldn't worry too much about categorising your notes. You can always [[search-for-notes]], and explore them using the [[graph-visualisation]].
 


### PR DESCRIPTION
When using command Markdown Links: Show Graph for the entire docs folder, there was this issue of 
`Command 'Markdown Links: Show Graph' resulted in an error ([UriError]: Scheme contains illegal characters.)`

Problem lies with how markdown links parses tokens. This PR removes unused tokens for show graph command to work again