### PR TITLE
Improve wikilink detection

### DIFF
--- a/docs/_layouts/foam.html
+++ b/docs/_layouts/foam.html
@@ -19,10 +19,20 @@ window.addEventListener('DOMContentLoaded', (event) => {
   document
     .querySelectorAll(".markdown-body a[title]:not([href^=http])")
     .forEach((a) => {
-      // Hack: Replace page-link with "Page Title"...
-      a.innerText = a.title;
-      // ...and normalize the links to allow html pages navigation
-      a.href = normalizeMdLink(a.href);
+      // filter to only wiki-links
+      var prev = a.previousSibling;
+      var next = a.nextSibling;
+      if (
+        prev instanceof Text && prev.textContent.endsWith('[') && 
+        next instanceof Text && next.textContent.startsWith(']')
+      ) {
+
+        // replace page-link with "Page Title"...
+        a.innerText = a.title;
+
+        // ...and normalize the links to allow html pages navigation
+        a.href = normalizeMdLink(a.href);
+      }
     });
 
   document.querySelectorAll(".github-only").forEach((el) => {


### PR DESCRIPTION
On the published Foam site, the bit of JavaScript that replaces `[page-slug]` with `[Page Title]` was overly eager, causing some non-wikilinks content be replaced by their title elements.

Before:
https://foambubble.github.io/foam/#thanks-and-attribution
![image](https://user-images.githubusercontent.com/1203949/89948380-edccb680-dc1d-11ea-8db6-b45de79b8423.png)

After:
https://jevakallio.github.io/foam/#thanks-and-attribution
![image](https://user-images.githubusercontent.com/1203949/89948463-15bc1a00-dc1e-11ea-80d7-ad803d4d0b1c.png)

