### PR TITLE
Improve wikilink styling

### DIFF
--- a/docs/_layouts/foam.html
+++ b/docs/_layouts/foam.html
@@ -19,10 +19,20 @@ window.addEventListener('DOMContentLoaded', (event) => {
   document
     .querySelectorAll(".markdown-body a[title]:not([href^=http])")
     .forEach((a) => {
-      // Hack: Replace page-link with "Page Title"...
-      a.innerText = a.title;
-      // ...and normalize the links to allow html pages navigation
-      a.href = normalizeMdLink(a.href);
+      // filter to only wiki-links
+      var prev = a.previousSibling;
+      var next = a.nextSibling;
+      if (
+        prev instanceof Text && prev.textContent.endsWith('[') && 
+        next instanceof Text && next.textContent.startsWith(']')
+      ) {
+
+        // replace page-link with "Page Title"...
+        a.innerText = a.title;
+
+        // ...and normalize the links to allow html pages navigation
+        a.href = normalizeMdLink(a.href);
+      }
     });
 
   document.querySelectorAll(".github-only").forEach((el) => {

--- a/docs/_layouts/foam.html
+++ b/docs/_layouts/foam.html
@@ -27,6 +27,10 @@ window.addEventListener('DOMContentLoaded', (event) => {
         next instanceof Text && next.textContent.startsWith(']')
       ) {
 
+        // remove surrounding brackets
+        prev.textContent = prev.textContent.slice(0, -1);
+        next.textContent = next.textContent.slice(1);
+        
         // replace page-link with "Page Title"...
         a.innerText = a.title;
 

--- a/docs/_layouts/foam.html
+++ b/docs/_layouts/foam.html
@@ -30,7 +30,10 @@ window.addEventListener('DOMContentLoaded', (event) => {
         // remove surrounding brackets
         prev.textContent = prev.textContent.slice(0, -1);
         next.textContent = next.textContent.slice(1);
-        
+
+        // add CSS list for styling
+        a.classList.add('wikilink');
+
         // replace page-link with "Page Title"...
         a.innerText = a.title;
 

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -52,6 +52,16 @@ blockquote {
     "DejaVu Serif", "Bitstream Vera Serif", "Liberation Serif", Georgia, serif;
 }
 
+.wikilink:before {
+  content: "[[";
+  opacity: 0.5;
+}
+
+.wikilink:after {
+  content: "]]";
+  opacity: 0.5;
+}
+
 .github-only {
   display: none;
 }


### PR DESCRIPTION
Builds on #220 (Improve Wikilink detection)

Now that we have the power to detect wiki links more accurately, we can also improve their styling. We could remove the brackets altogether, but I believe it's useful to differentiate between in-brain wikilinks and external links.

This PR:
- Removes the surrounding brackets around wikilinks https://github.com/foambubble/foam/commit/97644056782502c9e8dc6cabb7dff0d5462b2b06
- Adds them back as styleable CSS pseudoelements https://github.com/foambubble/foam/commit/d68a751e2069b86d1cf0aacdb60c15e5bcbea315

Before:
https://foambubble.github.io/foam/#call-to-adventure
![image](https://user-images.githubusercontent.com/1203949/89948822-b0b4f400-dc1e-11ea-92a3-86269b66ea98.png)

After:
https://jevakallio.github.io/foam/#call-to-adventure
![image](https://user-images.githubusercontent.com/1203949/89948777-98dd7000-dc1e-11ea-8003-a687bc9f98f8.png)

The styling could be improved, if anyone has ideas. We can style the elements with background color, font weight, other pseudo-elements etc -- anything CSS can do.

Once this lands on Foam website, we can also apply these changes to the Foam template so other new projects can inherit them.
