### PR TITLE
Fix issue with janitor crashing when file is only frontmatter

### DIFF
--- a/packages/foam-core/src/janitor/index.ts
+++ b/packages/foam-core/src/janitor/index.ts
@@ -61,7 +61,6 @@ export const generateLinkReferences = (
   } else {
     const first = note.definitions[0];
     const last = note.definitions[note.definitions.length - 1];
-
     const oldReferences = note.definitions
       .map(stringifyMarkdownLinkReferenceDefinition)
       .join(note.source.eol);
@@ -92,10 +91,13 @@ export const generateHeading = (note: Note): TextEdit | null => {
 
   const frontmatterExists = note.source.contentStart.line !== 1;
 
-  const newLineExistsAfterFrontmatter =
-    frontmatterExists &&
-    note.source.text.split(note.source.eol)[note.source.contentStart.line - 1]
-      .length === 0;
+  let newLineExistsAfterFrontmatter = false;
+  if (frontmatterExists) {
+    const lines = note.source.text.split(note.source.eol);
+    const index = note.source.contentStart.line - 1;
+    const line = lines[index];
+    newLineExistsAfterFrontmatter = line === '';
+  }
 
   const paddingStart = frontmatterExists ? note.source.eol : '';
   const paddingEnd = newLineExistsAfterFrontmatter

--- a/packages/foam-core/test/__scaffold__/file-with-only-frontmatter.md
+++ b/packages/foam-core/test/__scaffold__/file-with-only-frontmatter.md
@@ -1,0 +1,3 @@
+---
+noTitle: This frontmatter doesn't contain any title
+---

--- a/packages/foam-core/test/janitor/generateHeadings.test.ts
+++ b/packages/foam-core/test/janitor/generateHeadings.test.ts
@@ -41,4 +41,22 @@ describe('generateHeadings', () => {
     const note = _graph.getNotes({ slug: 'index' })[0];
     expect(generateHeading(note)).toBeNull();
   });
+
+  it('should generate heading when the file only contains frontmatter', () => {
+    const note = _graph.getNotes({ slug: 'file-with-only-frontmatter' })[0];
+
+    const expected = {
+      newText: '\n# File with only Frontmatter\n\n',
+      range: {
+        start: { line: 4, column: 1, offset: 60 },
+        end: { line: 4, column: 1, offset: 60 },
+      },
+    };
+
+    const actual = generateHeading(note);
+
+    expect(actual!.range.start).toEqual(expected.range.start);
+    expect(actual!.range.end).toEqual(expected.range.end);
+    expect(actual!.newText).toEqual(expected.newText);
+  });
 });

--- a/packages/foam-core/test/janitor/generateLinkReferences.test.ts
+++ b/packages/foam-core/test/janitor/generateLinkReferences.test.ts
@@ -11,7 +11,7 @@ describe('generateLinkReferences', () => {
   });
 
   it('initialised test graph correctly', () => {
-    expect(_graph.getNotes().length).toEqual(5);
+    expect(_graph.getNotes().length).toEqual(6);
   });
 
   it('should add link references to a file that does not have them', () => {

--- a/packages/foam-vscode/src/features/janitor.ts
+++ b/packages/foam-vscode/src/features/janitor.ts
@@ -58,7 +58,7 @@ async function janitor(foam: Foam) {
   } catch (e) {
     window.showErrorMessage(`Foam Janitor attempted to clean your workspace but ran into an error. Please check that we didn't break anything before committing any changes to version control, and pass the following error message to the Foam team on GitHub issues:
     ${e.message}
-    ${e.stackTrace}`);
+    ${e.stack}`);
   }
 }
 


### PR DESCRIPTION
In cases where a file contained frontmatter but no actual text, janitor would crash due to the contentStart line index being beyond the file's line count.

The main fix is to check whether line is whitespace by `===` comparison rather than `.length` check, but the diff is slightly larger due to readability improvements.