### PR TITLE
Add support for basic link aliases

### DIFF
--- a/packages/foam-core/src/markdown-provider.ts
+++ b/packages/foam-core/src/markdown-provider.ts
@@ -12,13 +12,15 @@ import { ID } from './types';
 
 let processor: unified.Processor | null = null;
 
+const ALIAS_DIVIDER_CHAR = '|';
+
 function parse(markdown: string): Node {
   processor =
     processor ||
     unified()
       .use(markdownParse, { gfm: true })
       .use(frontmatterPlugin, ['yaml'])
-      .use(wikiLinkPlugin);
+      .use(wikiLinkPlugin, { aliasDivider: ALIAS_DIVIDER_CHAR });
   return processor.parse(markdown);
 }
 
@@ -53,9 +55,20 @@ export function createNoteFromMarkdown(
     }
 
     if (node.type === 'wikiLink') {
+      // links can be either in format [[text]] or [[text|alias]].
+      const text = node.value as string;
+      const alias = node.data?.alias as string;
+      const literalContent = markdown.substring(
+        node.position!.start.offset! + 2,
+        node.position!.end.offset! - 2
+      );
+      const hasAlias =
+        literalContent !== text && literalContent.includes(ALIAS_DIVIDER_CHAR);
       links.push({
         type: 'wikilink',
-        slug: node.value as string,
+        slug: text.trim(),
+        alias: hasAlias ? alias.trim() : null,
+        literalContent,
         position: node.position!,
       });
     }
@@ -127,6 +140,7 @@ export function stringifyMarkdownLinkReferenceDefinition(
 
   return text;
 }
+
 export function createMarkdownReferences(
   graph: NoteGraph,
   noteId: ID,
@@ -143,45 +157,79 @@ export function createMarkdownReferences(
     return [];
   }
 
-  return graph
-    .getForwardLinks(noteId)
-    .map(link => {
-      let target = graph.getNote(link.to);
-      // if we don't find the target by ID we search the graph by slug
-      if (!target) {
-        const candidates = graph.getNotes({ slug: link.link.slug });
-        if (candidates.length > 1) {
-          console.log(
-            `Warning: Slug ${link.link.slug} matches ${candidates.length} documents. Picking one.`
-          );
-        }
-        target = candidates.length > 0 ? candidates[0] : null;
-      }
-      // We are dropping links to non-existent notes here,
-      // but int the future we may want to surface these too
-      if (!target) {
-        console.log(
-          `Warning: Link '${link.to}' in '${noteId}' points to a non-existing note.`
+  // if note doesn't exist, we can't find its links
+  const note = graph.getNote(noteId);
+  if (!note) {
+    return [];
+  }
+
+  const forwardLinks = graph.getForwardLinks(noteId);
+
+  // Try to generate a definition for each [[link]] in the note. 
+  //
+  // A note may have multiple [[link]] expressions to the same target
+  // note with different aliases.s
+  //
+  // - note.links contains all the [[link]] expressions
+  // - forwardLinks contains all the edges (links) between documents
+  return (
+    note.links
+      .map(linkExpression => {
+
+        // find the link between this and other document
+        const link = forwardLinks.find(
+          note => note.link.slug === linkExpression.slug
         );
-        return null;
-      }
 
-      const relativePath = path.relative(
-        path.dirname(source.source.uri),
-        target.source.uri
-      );
+        // if other document is not found, bail
+        if (!link) {
+          return null;
+        }
 
-      const pathToNote = includeExtension
-        ? relativePath
-        : dropExtension(relativePath);
+        // find the target document
+        let target = graph.getNote(link.to);
 
-      // [wiki-link-text]: path/to/file.md "Page title"
-      return {
-        label: link.link.slug,
-        url: pathToNote,
-        title: target.title || target.slug,
-      };
-    })
-    .filter(Boolean)
-    .sort() as NoteLinkDefinition[];
+        // if we don't find the target by ID we search the graph by slug
+        if (!target) {
+          const candidates = graph.getNotes({ slug: linkExpression.slug });
+          if (candidates.length > 1) {
+            console.log(
+              `Warning: Slug ${linkExpression.slug} matches ${candidates.length} documents. Picking one.`
+            );
+          }
+          target = candidates.length > 0 ? candidates[0] : null;
+        }
+
+        // We are dropping links to non-existent notes here,
+        // but in the future we may want to surface these too
+        if (!target) {
+          console.log(
+            `Warning: Link '${link.to}' in '${noteId}' points to a non-existing note.`
+          );
+          return null;
+        }
+
+        const relativePath = path.relative(
+          path.dirname(source.source.uri),
+          target.source.uri
+        );
+
+        const pathToNote = includeExtension
+          ? relativePath
+          : dropExtension(relativePath);
+
+        // [wiki-link-text]: path/to/file.md "Page title"
+        return {
+          label: linkExpression.literalContent,
+          url: pathToNote,
+          title: linkExpression.alias || target.title || target.slug,
+        };
+      })
+
+      // remove empty items
+      .filter(Boolean)
+
+      // sort by label, ascending
+      .sort((a, b) => (a!.label < b!.label ? -1 : 1)) as NoteLinkDefinition[]
+  );
 }

--- a/packages/foam-core/src/markdown-provider.ts
+++ b/packages/foam-core/src/markdown-provider.ts
@@ -165,7 +165,7 @@ export function createMarkdownReferences(
 
   const forwardLinks = graph.getForwardLinks(noteId);
 
-  // Try to generate a definition for each [[link]] in the note. 
+  // Try to generate a definition for each [[link]] in the note.
   //
   // A note may have multiple [[link]] expressions to the same target
   // note with different aliases.s
@@ -175,7 +175,6 @@ export function createMarkdownReferences(
   return (
     note.links
       .map(linkExpression => {
-
         // find the link between this and other document
         const link = forwardLinks.find(
           note => note.link.slug === linkExpression.slug

--- a/packages/foam-core/src/note-graph.ts
+++ b/packages/foam-core/src/note-graph.ts
@@ -14,7 +14,7 @@ export interface NoteSource {
 export interface WikiLink {
   type: 'wikilink';
   slug: string;
-  alias: string | null,
+  alias: string | null;
   literalContent: string;
   position: Position;
 }

--- a/packages/foam-core/src/note-graph.ts
+++ b/packages/foam-core/src/note-graph.ts
@@ -14,6 +14,8 @@ export interface NoteSource {
 export interface WikiLink {
   type: 'wikilink';
   slug: string;
+  alias: string | null,
+  literalContent: string;
   position: Position;
 }
 


### PR DESCRIPTION
Note: See [Problems](#problems) below.

## Summary

This PR adds basic support for using aliased link syntax `[[link|alias]]`. 

- The alias is used as the link title text in any tool that supports link reference definition titles.
- This work mirrors @thomaskoppelaar's work to add the same functionality to markdown notes in https://github.com/kortina/vscode-markdown-notes/pull/73.
- This work is happening out-of-band with the [Linking and Embedding proposal](https://github.com/foambubble/rfcs/pull/3), but it's fully compatible with the current line of thinking of piped aliases and should not introduce any new technical debt.


Input:
```md
- ✅ Aliases: [[inbox|link alias]]
- ✅ Different aliases to same document: [[inbox|different alias]]
- ✅ Aliases with spaces on either side of the pipe: [[inbox | yet another alias]]
- ✅ Links with no aliases [[inbox]]
```

Output:
```md
[//begin]: # "Autogenerated link references for markdown compatibility"
[inbox]: inbox "Inbox"
[inbox | yet another alias]: inbox "yet another alias"
[inbox|different alias]: inbox "different alias"
[inbox|link alias]: inbox "link alias"
[//end]: # "Autogenerated link references"
```

GitHub:
![image](https://user-images.githubusercontent.com/1203949/89958201-3e014400-dc31-11ea-999d-321dbfec0346.png)

## Problems

On GitHub pages, piped wikilinks are getting incorrectly parsed to tables 🤦‍♂️

![image](https://user-images.githubusercontent.com/1203949/89958362-98020980-dc31-11ea-810c-338e5ea03a30.png)

But only inside lists:

![image](https://user-images.githubusercontent.com/1203949/89959238-cf71b580-dc33-11ea-8b6f-8fd94bf97f11.png)

This appears to be an implementation issue in Jekyll and not with GFM. Here's a gist showing the same content rendering fine: https://gist.github.com/jevakallio/0085469e88c9f3e309bda204a1526c0f

### Possible solutions

We can add piped alias support, but it won't work on websites using the built-in Jekyll instance (unless we can customise it to not parse the links as tables, so it may not make sense to merge this work until we know how to fix it.

- Use an alternative aliasing character ([[remark-wiki-link](https://www.npmjs.com/package/remark-wiki-link) default is ":")
- Override syntax parsing in Jekyll somehow