### PR TITLE
Added setting for toggling Link Reference generation.

### DIFF
--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -38,6 +38,11 @@
     "configuration": {
       "title": "Foam",
       "properties": {
+        "foam.edit.linkReferenceEnabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Specifies whether to automatically add Link References upon saving. Defaults to true."
+        },
         "foam.edit.linkReferenceDefinitions": {
           "type": "string",
           "default": "withoutExtensions",

--- a/packages/foam-vscode/src/features/wikilink-reference-generation.ts
+++ b/packages/foam-vscode/src/features/wikilink-reference-generation.ts
@@ -45,7 +45,7 @@ const feature: FoamFeature = {
       ),
 
       workspace.onWillSaveTextDocument(e => {
-        if (e.document.languageId === "markdown") {
+        if (e.document.languageId === "markdown" && workspace.getConfiguration("foam.edit").get("linkReferenceEnabled")) {
           updateDocumentInNoteGraph(foam, e.document);
           e.waitUntil(updateReferenceList(foam.notes));
         }


### PR DESCRIPTION
Adds a setting for toggling Link References. Defaults to "true" as per specifications in the roadmap.

Note, this doesn't affect the janitor script. When you run the janitor with the setting set to false, Link References will still be generated.