### PR TITLE
add inital template for bug type issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us be foamier
+labels: bug, awaiting triage
+title: [BUG]
+---
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is.-->
+
+**Affected package**
+<!-- Its ok if you don't know! -->
+- [ ] `foam-cli`
+- [ ] `foam-core`
+- [ ] `foam-vscode`
+- [ ] `other/meta/???`
+
+**To Reproduce**
+<!-- Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error -->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Screenshots**
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+**Additional context**
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true


### PR DESCRIPTION
While reporting #229 I noticed that there was not any issue templates. I thought I had read about someone wanting one created but was unable to find any supporting documentation to that point. In any case I think they are generally helpful. Feel free to add any feedback and if you would like other use case templates made I'd be happy to oblige. 