### PR TITLE
Fix link references spacing when there is no trailing newline

### DIFF
--- a/packages/foam-vscode/src/features/wikilink-reference-generation.ts
+++ b/packages/foam-vscode/src/features/wikilink-reference-generation.ts
@@ -87,7 +87,7 @@ async function createReferenceList(foam: NoteGraph) {
   if (refs && refs.length) {
     await editor.edit(function(editBuilder) {
       if (editor) {
-        const spacing = hasEmptyTrailing
+        const spacing = hasEmptyTrailing(editor.document)
           ? docConfig.eol
           : docConfig.eol + docConfig.eol;
 
@@ -128,16 +128,13 @@ async function updateReferenceList(foam: NoteGraph) {
   }
 }
 
-function generateReferenceList(
-  foam: NoteGraph,
-  doc: TextDocument
-): string[] {
+function generateReferenceList(foam: NoteGraph, doc: TextDocument): string[] {
   const filePath = doc.fileName;
 
   const note = foam.getNoteByURI(filePath);
 
   // Should never happen as `doc` is usually given by `editor.document`, which
-  // binds to an opened note. 
+  // binds to an opened note.
   if (!note) {
     console.warn(
       `Can't find note for URI ${filePath} before attempting to generate its markdown reference list`


### PR DESCRIPTION
fixes #226 

## Summary

There was a typo in the code where the `hasEmptyTrailing` function was not being called and it always returned true. Thus, even when there was no trailing newline, the extension added only one newline instead of two. 

## Test Plan

1. Update VS Code setting `"files.insertFinalNewline": false` 
2. Open a note. Which contains unmaterialized link references. 
3. Delete any trailing newline.
4. Save the file to generate link references.
5. It should add two newlines between the content and the link references.



