### PR TITLE
feat(vscode): add command "Copy To Clipboard Without Brackets 

### DIFF
--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -17,7 +17,8 @@
     "workspaceContains:.vscode/foam.json",
     "onCommand:foam-vscode.update-wikilinks",
     "onCommand:foam-vscode.open-daily-note",
-    "onCommand:foam-vscode.janitor"
+    "onCommand:foam-vscode.janitor",
+    "onCommand:foam-vscode.copy-without-brackets"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -33,6 +34,10 @@
       {
         "command": "foam-vscode.janitor",
         "title": "Foam: Run Janitor (Experimental)"
+      },
+      {
+        "command": "foam-vscode.copy-without-brackets",
+        "title": "Foam: Copy To Clipboard Without Brackets"
       }
     ],
     "configuration": {

--- a/packages/foam-vscode/src/features/copy-without-brackets.ts
+++ b/packages/foam-vscode/src/features/copy-without-brackets.ts
@@ -1,0 +1,40 @@
+import {
+  window,
+  env,
+  ExtensionContext,
+  commands,
+} from "vscode";
+import { FoamFeature } from "../types";
+import { removeBrackets } from "../utils";
+
+const feature: FoamFeature = {
+  activate: (context: ExtensionContext) => {
+    context.subscriptions.push(
+      commands.registerCommand("foam-vscode.copy-without-brackets", copyWithoutBrackets)
+    );
+  },
+};
+
+async function copyWithoutBrackets () {
+  // Get the active text editor
+  const editor = window.activeTextEditor;
+
+  if (editor) {
+    const document = editor.document;
+    const selection = editor.selection;
+
+    // Get the words within the selection
+    const text = document.getText(selection);
+
+    // Remove brackets from text
+    const modifiedText = removeBrackets(text);
+
+    // Copy to the clipboard
+    await env.clipboard.writeText(modifiedText);
+
+    // Alert the user it was successful
+    window.showInformationMessage('Successfully copied to clipboard!');
+  }
+}
+
+export default feature;

--- a/packages/foam-vscode/src/features/index.ts
+++ b/packages/foam-vscode/src/features/index.ts
@@ -1,6 +1,7 @@
 import createReferences from "./wikilink-reference-generation";
 import openDailyNote from "./open-daily-note";
 import janitor from "./janitor";
+import copyWithoutBrackets from './copy-without-brackets';
 import { FoamFeature } from "../types";
 
-export const features: FoamFeature[] = [createReferences, openDailyNote, janitor];
+export const features: FoamFeature[] = [createReferences, openDailyNote, janitor, copyWithoutBrackets];

--- a/packages/foam-vscode/src/utils.ts
+++ b/packages/foam-vscode/src/utils.ts
@@ -103,23 +103,36 @@ export function removeBrackets(s: string): string {
   // loop through words
   const modifiedWords = stringSplitBySpace.map(currentWord => {
     if (currentWord.includes("[[")) {
+
+      // all of these transformations will turn this "[[you-are-awesome]]"
+      // to this "you are awesome"
       let word = currentWord.replace(/(\[\[)/g, "");
       word = word.replace(/(\]\])/g, "");
       word = word.replace(/(.mdx|.md|.markdown)/g, "");
       word = word.replace(/[-]/g, " ");
 
-      // now capitalize every word
-      const modifiedWord = word
-        .split(" ")
-        .map(word => word[0].toUpperCase() + word.substring(1))
-        .join(" ");
+      // then we titlecase the word so "you are awesome"
+      // becomes "You Are Awesome"
+      const titleCasedWord = toTitleCase(word);
 
-      return modifiedWord;
+      return titleCasedWord;
     }
 
     return currentWord;
   });
 
   return modifiedWords.join(" ");
+}
+
+/**
+ * Takes in a string and returns it titlecased
+ *
+ * @example toTitleCase("hello world") -> "Hello World"
+ */
+export function toTitleCase(word: string): string {
+  return word
+        .split(" ")
+        .map(word => word[0].toUpperCase() + word.substring(1))
+        .join(" ");
 }
 

--- a/packages/foam-vscode/src/utils.ts
+++ b/packages/foam-vscode/src/utils.ts
@@ -91,3 +91,35 @@ export function dropExtension(path: string): string {
 export const astPositionToVsCodePosition = (point: Point): Position => {
   return new Position(point.line - 1, point.column - 1);
 };
+
+/**
+ * Used for the "Copy to Clipboard Without Brackets" command
+ *
+ */
+export function removeBrackets(s: string): string {
+  // take in the string, split on space
+  const stringSplitBySpace = s.split(" ");
+
+  // loop through words
+  const modifiedWords = stringSplitBySpace.map(currentWord => {
+    if (currentWord.includes("[[")) {
+      let word = currentWord.replace(/(\[\[)/g, "");
+      word = word.replace(/(\]\])/g, "");
+      word = word.replace(/(.mdx|.md|.markdown)/g, "");
+      word = word.replace(/[-]/g, " ");
+
+      // now capitalize every word
+      const modifiedWord = word
+        .split(" ")
+        .map(word => word[0].toUpperCase() + word.substring(1))
+        .join(" ");
+
+      return modifiedWord;
+    }
+
+    return currentWord;
+  });
+
+  return modifiedWords.join(" ");
+}
+

--- a/packages/foam-vscode/test/utils.test.ts
+++ b/packages/foam-vscode/test/utils.test.ts
@@ -1,7 +1,7 @@
 // @note: This will fail due to utils importing 'vscode'
 // which needs to be mocked in the jest test environment.
 // See: https://github.com/microsoft/vscode-test/issues/37
-import { dropExtension, removeBrackets } from '../src/utils';
+import { dropExtension, removeBrackets, toTitleCase } from '../src/utils';
 
 describe("dropExtension", () => {
   test("returns file name without extension", () => {
@@ -44,6 +44,21 @@ describe("removeBrackets", () => {
     const input = "I am reading this as part of the [[book-club]] put on by [[egghead]] folks (Lauro).";
     const actual = removeBrackets(input);
     const expected = "I am reading this as part of the Book Club put on by Egghead folks (Lauro).";
+    expect(actual).toEqual(expected);
+  });
+});
+
+describe("toTitleCase", () => {
+  it("title cases a word", () => {
+    const input = "look at this really long sentence but I am calling it a word";
+    const actual = toTitleCase(input);
+    const expected = "Look At This Really Long Sentence But I Am Calling It A Word";
+    expect(actual).toEqual(expected);
+  });
+  it("works on one word", () => {
+    const input = "word";
+    const actual = toTitleCase(input);
+    const expected = "Word";
     expect(actual).toEqual(expected);
   });
 });

--- a/packages/foam-vscode/test/utils.test.ts
+++ b/packages/foam-vscode/test/utils.test.ts
@@ -1,10 +1,43 @@
 // @note: This will fail due to utils importing 'vscode'
 // which needs to be mocked in the jest test environment.
 // See: https://github.com/microsoft/vscode-test/issues/37
-import { dropExtension } from '../src/utils';
+import { dropExtension, removeBrackets } from '../src/utils';
 
 describe("dropExtension", () => {
   test("returns file name without extension", () => {
     expect(dropExtension('file.md')).toEqual('file');
+  });
+});
+
+describe("removeBrackets", () => {
+  it("removes the brackets", () => {
+    const input = "hello world [[this-is-it]]";
+    const actual = removeBrackets(input);
+    const expected = "hello world This Is It";
+    expect(actual).toEqual(expected);
+  });
+  it("removes the brackets and the md file extension", () => {
+    const input = "hello world [[this-is-it.md]]";
+    const actual = removeBrackets(input);
+    const expected = "hello world This Is It";
+    expect(actual).toEqual(expected);
+  });
+  it("removes the brackets and the mdx file extension", () => {
+    const input = "hello world [[this-is-it.mdx]]";
+    const actual = removeBrackets(input);
+    const expected = "hello world This Is It";
+    expect(actual).toEqual(expected);
+  });
+  it("removes the brackets and the markdown file extension", () => {
+    const input = "hello world [[this-is-it.markdown]]";
+    const actual = removeBrackets(input);
+    const expected = "hello world This Is It";
+    expect(actual).toEqual(expected);
+  });
+  it("removes the brackets even with numbers", () => {
+    const input = "hello world [[2020-07-21.markdown]]";
+    const actual = removeBrackets(input);
+    const expected = "hello world 2020 07 21";
+    expect(actual).toEqual(expected);
   });
 });

--- a/packages/foam-vscode/test/utils.test.ts
+++ b/packages/foam-vscode/test/utils.test.ts
@@ -40,4 +40,10 @@ describe("removeBrackets", () => {
     const expected = "hello world 2020 07 21";
     expect(actual).toEqual(expected);
   });
+  it("removes brackets for more than one word", () => {
+    const input = "I am reading this as part of the [[book-club]] put on by [[egghead]] folks (Lauro).";
+    const actual = removeBrackets(input);
+    const expected = "I am reading this as part of the Book Club put on by Egghead folks (Lauro).";
+    expect(actual).toEqual(expected);
+  });
 });


### PR DESCRIPTION
This adds a new command for `foam-vscode`  called "Copy To Clipboard Without Brackets". I discussed this in the Foam Discord a [while back](https://discordapp.com/channels/729975036148056075/730056943997288540/739321725967138847), asking if this should be an outside thing (separate extension) or added as a feature to the core extension. It was suggested to do the later. 

## Use Case

Sometimes when drafting messages to people in Foam, I use references. Instead of sending them the messages with the brackets or removing them, I thought it would be nice to have this command which copies to clipboard and removes them for you.

## Demo

![2020-10-02 20 15 34](https://user-images.githubusercontent.com/3806031/94982160-3c475480-04ed-11eb-98c2-24aed5211225.gif)
