### PR TITLE
Added option to disable wikilink definitions generation

### DIFF
--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -48,11 +48,13 @@
           "default": "withoutExtensions",
           "enum": [
             "withExtensions",
-            "withoutExtensions"
+            "withoutExtensions",
+            "off"
           ],
           "enumDescriptions": [
             "Include extension in wikilinks paths",
-            "Remove extension in wikilink paths"
+            "Remove extension in wikilink paths",
+            "Disable wikilink definitions generation"
           ]
         },
         "foam.openDailyNote.fileExtension": {

--- a/packages/foam-vscode/src/features/janitor.ts
+++ b/packages/foam-vscode/src/features/janitor.ts
@@ -15,7 +15,10 @@ import {
   Foam
 } from "foam-core";
 
-import { includeExtensions } from "../settings";
+import {
+  getWikilinkDefinitionSetting,
+  LinkReferenceDefinitionsSetting
+} from "../settings";
 import { astPositionToVsCodePosition } from "../utils";
 
 const feature: FoamFeature = {
@@ -89,6 +92,8 @@ async function runJanitor(foam: Foam) {
     note => !dirtyEditorsFileName.includes(note.source.uri)
   );
 
+  const wikilinkSetting = getWikilinkDefinitionSetting();
+
   // Apply Text Edits to Non Dirty Notes using fs module just like CLI
 
   const fileWritePromises = nonDirtyNotes.map(note => {
@@ -97,11 +102,14 @@ async function runJanitor(foam: Foam) {
       updatedHeadingCount += 1;
     }
 
-    let definitions = generateLinkReferences(
-      note,
-      foam.notes,
-      includeExtensions()
-    );
+    let definitions =
+      wikilinkSetting === LinkReferenceDefinitionsSetting.off
+        ? null
+        : generateLinkReferences(
+            note,
+            foam.notes,
+            wikilinkSetting === LinkReferenceDefinitionsSetting.withExtensions
+          );
     if (definitions) {
       updatedDefinitionListCount += 1;
     }
@@ -132,11 +140,14 @@ async function runJanitor(foam: Foam) {
 
     // Get edits
     const heading = generateHeading(note);
-    let definitions = generateLinkReferences(
-      note,
-      foam.notes,
-      includeExtensions()
-    );
+    let definitions =
+      wikilinkSetting === LinkReferenceDefinitionsSetting.off
+        ? null
+        : generateLinkReferences(
+            note,
+            foam.notes,
+            wikilinkSetting === LinkReferenceDefinitionsSetting.withExtensions
+          );
 
     if (heading || definitions) {
       // Apply Edits

--- a/packages/foam-vscode/src/features/wikilink-reference-generation.ts
+++ b/packages/foam-vscode/src/features/wikilink-reference-generation.ts
@@ -30,7 +30,10 @@ import {
   getText
 } from "../utils";
 import { FoamFeature } from "../types";
-import { includeExtensions } from "../settings";
+import {
+  getWikilinkDefinitionSetting,
+  LinkReferenceDefinitionsSetting
+} from "../settings";
 
 const feature: FoamFeature = {
   activate: async (context: ExtensionContext, foamPromise: Promise<Foam>) => {
@@ -129,6 +132,12 @@ function generateReferenceList(
   foam: NoteGraphAPI,
   doc: TextDocument
 ): string[] {
+  const wikilinkSetting = getWikilinkDefinitionSetting();
+
+  if (wikilinkSetting === LinkReferenceDefinitionsSetting.off) {
+    return [];
+  }
+
   const filePath = doc.fileName;
 
   const note = foam.getNoteByURI(filePath);
@@ -143,9 +152,11 @@ function generateReferenceList(
   }
 
   const references = uniq(
-    createMarkdownReferences(foam, note.id, includeExtensions()).map(
-      stringifyMarkdownLinkReferenceDefinition
-    )
+    createMarkdownReferences(
+      foam,
+      note.id,
+      wikilinkSetting === LinkReferenceDefinitionsSetting.withExtensions
+    ).map(stringifyMarkdownLinkReferenceDefinition)
   );
 
   if (references.length) {

--- a/packages/foam-vscode/src/settings.ts
+++ b/packages/foam-vscode/src/settings.ts
@@ -1,18 +1,16 @@
-import { workspace } from 'vscode';
+import { workspace } from "vscode";
 
 export enum LinkReferenceDefinitionsSetting {
   withExtensions = "withExtensions",
-  withoutExtensions = "withoutExtensions"
-};
-
-export function includeExtensions() {
-  const linkDefinitionSetting: LinkReferenceDefinitionsSetting =
-  workspace
-    .getConfiguration("foam.edit")
-    .get<LinkReferenceDefinitionsSetting>("linkReferenceDefinitions") ??
-  LinkReferenceDefinitionsSetting.withoutExtensions;
-
-  return linkDefinitionSetting === LinkReferenceDefinitionsSetting.withExtensions;
+  withoutExtensions = "withoutExtensions",
+  off = "off"
 }
 
-  
+export function getWikilinkDefinitionSetting(): LinkReferenceDefinitionsSetting {
+  return workspace
+    .getConfiguration("foam.edit")
+    .get<LinkReferenceDefinitionsSetting>(
+      "linkReferenceDefinitions",
+      LinkReferenceDefinitionsSetting.withoutExtensions
+    );
+}


### PR DESCRIPTION
This PR adds a new option to the wikilink definitions generation that disables the feature.

The default behavior is still the same and the change is backwards compatible.