### PR TITLE
fix #276 - support empty titles in notes

### DIFF
--- a/packages/foam-core/src/markdown-provider.ts
+++ b/packages/foam-core/src/markdown-provider.ts
@@ -35,7 +35,7 @@ const titlePlugin: ParserPlugin = {
   visit: (node, note) => {
     if (note.title == null && node.type === 'heading' && node.depth === 1) {
       note.title =
-        ((node as Parent)!.children[0].value as string) || note.title;
+        ((node as Parent)!.children?.[0]?.value as string) || note.title;
     }
   },
 };

--- a/packages/foam-core/test/markdown-provider.test.ts
+++ b/packages/foam-core/test/markdown-provider.test.ts
@@ -108,6 +108,19 @@ describe('Note Title', () => {
     const pageENoteTitle = graph.getNote(note.id)!.title;
     expect(pageENoteTitle).toBe('Note Title');
   });
+
+  it('should not break on empty titles (see #276)', () => {
+    const note = createNoteFromMarkdown(
+      '/page-e.md',
+      `
+#
+
+this note has an empty title line
+    `,
+      '\n'
+    );
+    expect(note.title).toBeNull();
+  });
 });
 
 describe('frontmatter', () => {


### PR DESCRIPTION
This PR fixes #276 by adding extra checks while parsing the note title