### PR TITLE
Add date snippets for daily notes

### DIFF
--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -84,6 +84,11 @@
           ],
           "default": null,
           "description": "The directory into which daily notes should be created. Defaults to the workspace root."
+        },
+        "foam.snippets.navigateOnSelect": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether or not to navigate to the target daily note when a daily note snippet is selected."
         }
       }
     },

--- a/packages/foam-vscode/src/dated-notes.ts
+++ b/packages/foam-vscode/src/dated-notes.ts
@@ -10,7 +10,7 @@ import dateFormat from "dateformat";
 import * as fs from "fs";
 import { docConfig } from "./utils";
 
-async function openDatedNote(date?: Date) {
+async function openDailyNoteFor(date?: Date) {
   const foamConfiguration = workspace.getConfiguration("foam");
   const currentDate = date !== undefined ? date : new Date();
 
@@ -98,4 +98,4 @@ function pathExists(path: string) {
     .catch(() => false);
 }
 
-export { openDatedNote, getDailyNoteFileName };
+export { openDailyNoteFor, getDailyNoteFileName };

--- a/packages/foam-vscode/src/dated-notes.ts
+++ b/packages/foam-vscode/src/dated-notes.ts
@@ -21,7 +21,7 @@ async function openDailyNoteFor(date?: Date) {
     dailyNotePath,
     currentDate
   );
-  await focusDailyNote(dailyNotePath, isNew);
+  await focusNote(dailyNotePath, isNew);
 }
 function getDailyNotePath(configuration: WorkspaceConfiguration, date: Date) {
   const rootDirectory = workspace.workspaceFolders[0].uri.fsPath;
@@ -79,8 +79,8 @@ async function createDailyNoteDirectoryIfNotExists(dailyNotePath: string) {
   }
 }
 
-async function focusDailyNote(dailyNotePath: string, isNewNote: boolean) {
-  const document = await workspace.openTextDocument(Uri.file(dailyNotePath));
+async function focusNote(notePath: string, isNewNote: boolean) {
+  const document = await workspace.openTextDocument(Uri.file(notePath));
   const editor = await window.showTextDocument(document);
 
   // Move the cursor to end of the file

--- a/packages/foam-vscode/src/dated-notes.ts
+++ b/packages/foam-vscode/src/dated-notes.ts
@@ -8,7 +8,7 @@ import {
 import { dirname, join } from "path";
 import dateFormat from "dateformat";
 import * as fs from "fs";
-import { docConfig } from "./utils";
+import { docConfig, pathExists } from "./utils";
 
 async function openDailyNoteFor(date?: Date) {
   const foamConfiguration = workspace.getConfiguration("foam");
@@ -89,13 +89,6 @@ async function focusNote(notePath: string, isNewNote: boolean) {
     const { range } = editor.document.lineAt(lineCount - 1);
     editor.selection = new Selection(range.end, range.end);
   }
-}
-
-function pathExists(path: string) {
-  return fs.promises
-    .access(path, fs.constants.F_OK)
-    .then(() => true)
-    .catch(() => false);
 }
 
 export { openDailyNoteFor, getDailyNoteFileName };

--- a/packages/foam-vscode/src/dated-notes.ts
+++ b/packages/foam-vscode/src/dated-notes.ts
@@ -1,0 +1,101 @@
+import {
+  Selection,
+  Uri,
+  window,
+  workspace,
+  WorkspaceConfiguration
+} from "vscode";
+import { dirname, join } from "path";
+import dateFormat from "dateformat";
+import * as fs from "fs";
+import { docConfig } from "./utils";
+
+async function openDatedNote(date?: Date) {
+  const foamConfiguration = workspace.getConfiguration("foam");
+  const currentDate = date !== undefined ? date : new Date();
+
+  const dailyNotePath = getDailyNotePath(foamConfiguration, currentDate);
+
+  const isNew = await createDailyNoteIfNotExists(
+    foamConfiguration,
+    dailyNotePath,
+    currentDate
+  );
+  await focusDailyNote(dailyNotePath, isNew);
+}
+function getDailyNotePath(configuration: WorkspaceConfiguration, date: Date) {
+  const rootDirectory = workspace.workspaceFolders[0].uri.fsPath;
+  const dailyNoteDirectory: string =
+    configuration.get("openDailyNote.directory") ?? ".";
+  const dailyNoteFilename = getDailyNoteFileName(configuration, date);
+
+  return join(rootDirectory, dailyNoteDirectory, dailyNoteFilename);
+}
+
+function getDailyNoteFileName(
+  configuration: WorkspaceConfiguration,
+  date: Date
+): string {
+  const filenameFormat: string = configuration.get(
+    "openDailyNote.filenameFormat"
+  );
+  const fileExtension: string = configuration.get(
+    "openDailyNote.fileExtension"
+  );
+
+  return `${dateFormat(date, filenameFormat, false)}.${fileExtension}`;
+}
+
+async function createDailyNoteIfNotExists(
+  configuration: WorkspaceConfiguration,
+  dailyNotePath: string,
+  currentDate: Date
+) {
+  if (await pathExists(dailyNotePath)) {
+    return false;
+  }
+
+  await createDailyNoteDirectoryIfNotExists(dailyNotePath);
+
+  const titleFormat: string =
+    configuration.get("openDailyNote.titleFormat") ??
+    configuration.get("openDailyNote.filenameFormat");
+
+  await fs.promises.writeFile(
+    dailyNotePath,
+    `# ${dateFormat(currentDate, titleFormat, false)}${docConfig.eol}${
+      docConfig.eol
+    }`
+  );
+
+  return true;
+}
+
+async function createDailyNoteDirectoryIfNotExists(dailyNotePath: string) {
+  const dailyNoteDirectory = dirname(dailyNotePath);
+
+  if (!(await pathExists(dailyNoteDirectory))) {
+    await fs.promises.mkdir(dailyNoteDirectory, { recursive: true });
+  }
+}
+
+async function focusDailyNote(dailyNotePath: string, isNewNote: boolean) {
+  const document = await workspace.openTextDocument(Uri.file(dailyNotePath));
+  const editor = await window.showTextDocument(document);
+
+  // Move the cursor to end of the file
+  if (isNewNote) {
+    const { lineCount } = editor.document;
+    const { range } = editor.document.lineAt(lineCount - 1);
+    editor.selection = new Selection(range.end, range.end);
+  }
+}
+
+function pathExists(path: string) {
+  return fs.promises
+    .access(path, fs.constants.F_OK)
+    .then(() => true)
+    .catch(() => false);
+}
+
+export { openDatedNote, getDailyNoteFileName };

--- a/packages/foam-vscode/src/features/index.ts
+++ b/packages/foam-vscode/src/features/index.ts
@@ -1,7 +1,14 @@
 import createReferences from "./wikilink-reference-generation";
 import openDailyNote from "./open-daily-note";
 import janitor from "./janitor";
-import copyWithoutBrackets from './copy-without-brackets';
+import copyWithoutBrackets from "./copy-without-brackets";
+import openDatedNote from "./open-dated-note";
 import { FoamFeature } from "../types";
 
-export const features: FoamFeature[] = [createReferences, openDailyNote, janitor, copyWithoutBrackets];
+export const features: FoamFeature[] = [
+  createReferences,
+  openDailyNote,
+  janitor,
+  copyWithoutBrackets,
+  openDatedNote
+];

--- a/packages/foam-vscode/src/features/open-daily-note.ts
+++ b/packages/foam-vscode/src/features/open-daily-note.ts
@@ -1,107 +1,13 @@
-import {
-  window,
-  workspace,
-  Uri,
-  WorkspaceConfiguration,
-  ExtensionContext,
-  commands,
-  Selection
-} from "vscode";
-import { dirname, join } from "path";
-import dateFormat from "dateformat";
-import * as fs from "fs";
+import { ExtensionContext, commands } from "vscode";
 import { FoamFeature } from "../types";
-import { docConfig } from '../utils';
+import { openDatedNote } from "../dated-notes";
 
 const feature: FoamFeature = {
   activate: (context: ExtensionContext) => {
     context.subscriptions.push(
-      commands.registerCommand("foam-vscode.open-daily-note", openDailyNote)
+      commands.registerCommand("foam-vscode.open-daily-note", openDatedNote)
     );
-  },
+  }
 };
-
-async function openDailyNote() {
-  const foamConfiguration = workspace.getConfiguration("foam");
-  const currentDate = new Date();
-
-  const dailyNotePath = getDailyNotePath(foamConfiguration, currentDate);
-
-  const isNew = await createDailyNoteIfNotExists(foamConfiguration, dailyNotePath, currentDate);
-  await focusDailyNote(dailyNotePath, isNew);
-}
-
-function getDailyNotePath(configuration: WorkspaceConfiguration, date: Date) {
-  const rootDirectory = workspace.workspaceFolders[0].uri.fsPath;
-  const dailyNoteDirectory: string =
-    configuration.get("openDailyNote.directory") ?? ".";
-  const dailyNoteFilename = getDailyNoteFileName(configuration, date);
-
-  return join(rootDirectory, dailyNoteDirectory, dailyNoteFilename);
-}
-
-function getDailyNoteFileName(
-  configuration: WorkspaceConfiguration,
-  date: Date
-): string {
-  const filenameFormat: string = configuration.get(
-    "openDailyNote.filenameFormat"
-  );
-  const fileExtension: string = configuration.get(
-    "openDailyNote.fileExtension"
-  );
-
-  return `${dateFormat(date, filenameFormat, false)}.${fileExtension}`;
-}
-
-async function createDailyNoteIfNotExists(
-  configuration: WorkspaceConfiguration,
-  dailyNotePath: string,
-  currentDate: Date
- ) {
-  if (await pathExists(dailyNotePath)) {
-    return false;
-  }
-
-  await createDailyNoteDirectoryIfNotExists(dailyNotePath);
-
-  const titleFormat: string =
-    configuration.get("openDailyNote.titleFormat") ??
-    configuration.get("openDailyNote.filenameFormat");
-
-  await fs.promises.writeFile(
-    dailyNotePath,
-    `# ${dateFormat(currentDate, titleFormat, false)}${docConfig.eol}${docConfig.eol}`
-  );
-
-  return true;
-}
-
-async function createDailyNoteDirectoryIfNotExists(dailyNotePath: string) {
-  const dailyNoteDirectory = dirname(dailyNotePath);
-
-  if (!(await pathExists(dailyNoteDirectory))) {
-    await fs.promises.mkdir(dailyNoteDirectory, { recursive: true });
-  }
-}
-
-async function focusDailyNote(dailyNotePath: string, isNewNote: boolean) {
-  const document = await workspace.openTextDocument(Uri.file(dailyNotePath));
-  const editor = await window.showTextDocument(document);
-
-  // Move the cursor to end of the file
-  if (isNewNote) {
-    const { lineCount } = editor.document;
-    const { range } = editor.document.lineAt(lineCount - 1);
-    editor.selection = new Selection(range.end, range.end);
-  }
-}
-
-function pathExists(path: string) {
-  return fs.promises
-    .access(path, fs.constants.F_OK)
-    .then(() => true)
-    .catch(() => false);
-}
 
 export default feature;

--- a/packages/foam-vscode/src/features/open-daily-note.ts
+++ b/packages/foam-vscode/src/features/open-daily-note.ts
@@ -1,11 +1,11 @@
 import { ExtensionContext, commands } from "vscode";
 import { FoamFeature } from "../types";
-import { openDatedNote } from "../dated-notes";
+import { openDailyNoteFor } from "../dated-notes";
 
 const feature: FoamFeature = {
   activate: (context: ExtensionContext) => {
     context.subscriptions.push(
-      commands.registerCommand("foam-vscode.open-daily-note", openDatedNote)
+      commands.registerCommand("foam-vscode.open-daily-note", openDailyNoteFor)
     );
   }
 };

--- a/packages/foam-vscode/src/features/open-dated-note.ts
+++ b/packages/foam-vscode/src/features/open-dated-note.ts
@@ -5,17 +5,38 @@ import {
   languages,
   CompletionItemProvider,
   CompletionItem,
-  CompletionItemKind
+  CompletionItemKind,
+  Range,
+  Position
 } from "vscode";
-import { getDailyNoteFileName, openDatedNote } from "../dated-notes";
+import { getDailyNoteFileName, openDailyNoteFor } from "../dated-notes";
+import { LinkReferenceDefinitionsSetting } from "../settings";
 import { FoamFeature } from "../types";
+import { astPositionToVsCodePosition } from "../utils";
 
 interface DateSnippet {
   snippet: string;
   date: Date;
   detail: string;
 }
+
 const foamConfig = workspace.getConfiguration("foam");
+
+const getDailyNoteLink = (
+  date: Date,
+  extension: string,
+  linkReferenceDefinitions: LinkReferenceDefinitionsSetting
+) => {
+  let name = getDailyNoteFileName(foamConfig, date);
+  if (
+    linkReferenceDefinitions ===
+    LinkReferenceDefinitionsSetting.withoutExtensions
+  ) {
+    name = name.replace(`.${extension}`, "");
+  }
+  return `[[${name}]]`;
+};
+
 const snippets: (() => DateSnippet)[] = [
   () => ({
     detail: "Insert a link to today's daily note",
@@ -32,21 +53,87 @@ const snippets: (() => DateSnippet)[] = [
   }
 ];
 
+/**
+ * I think to start working with this you should take a look at emmet
+ * https://github.com/Microsoft/vscode/tree/master/extensions/emmet
+ * Also, snippet string: https://code.visualstudio.com/api/references/vscode-api#SnippetString
+ */
+const computedSnippets: ((number: number) => DateSnippet)[] = [
+  (days: number) => {
+    const today = new Date();
+    return {
+      detail: "Insert a link to tomorrow's daily note",
+      snippet: `/${days}d`,
+      date: new Date(
+        today.getFullYear(),
+        today.getMonth(),
+        today.getDate() + days
+      )
+    };
+  },
+  (weeks: number) => {
+    const today = new Date();
+    return {
+      detail: "Insert a link to tomorrow's daily note",
+      snippet: `/${weeks}w`,
+      date: new Date(
+        today.getFullYear(),
+        today.getMonth(),
+        today.getDate() + 7 * weeks
+      )
+    };
+  }
+];
+
 const completions: CompletionItemProvider = {
-  provideCompletionItems: (document, position, token, context) => {
-    const completionItems = snippets.map(snippet => {
+  provideCompletionItems: (_document, _position, _token, _context) => {
+    const completionItems = snippets.map(item => {
+      const { snippet, date, detail } = item();
       const completionItem = new CompletionItem(
-        snippet().snippet,
+        snippet,
         CompletionItemKind.Snippet
       );
-      completionItem.insertText = `[[${getDailyNoteFileName(
-        foamConfig,
-        snippet().date
-      )}]]`;
+      completionItem.insertText = getDailyNoteLink(
+        date,
+        foamConfig.get("openDailyNote.fileExtension"),
+        foamConfig.get("edit.linkReferenceDefinitions")
+      );
       completionItem.command = {
         command: "foam-vscode.open-dated-note",
         title: "Open a note for the given date",
-        arguments: [snippet().date]
+        arguments: [date]
+      };
+      return completionItem;
+    });
+    return completionItems;
+  }
+};
+
+const computedCompletions: CompletionItemProvider = {
+  provideCompletionItems: (document, position, token, context) => {
+    const offsetPosition = document.offsetAt(position) - 1;
+    const number = document.getText().charAt(offsetPosition);
+    const range = document.getWordRangeAtPosition(
+      position,
+      /~!@#$%^&*()-=[{]}\|;:'",.<>?/
+    );
+    const completionItems = computedSnippets.map(item => {
+      const { snippet, detail, date } = item(parseInt(number));
+      const completionItem = new CompletionItem(
+        snippet,
+        CompletionItemKind.Snippet
+      );
+      completionItem.range = range;
+      completionItem.insertText = getDailyNoteLink(
+        date,
+        foamConfig.get("openDailyNote.fileExtension"),
+        foamConfig.get("edit.linkReferenceDefinitions")
+      );
+      completionItem.detail = `${completionItem.insertText}`;
+      completionItem.command = {
+        command: "foam-vscode.open-dated-note",
+        title: "Open a note for the given date",
+        arguments: [date]
       };
       return completionItem;
     });
@@ -58,10 +145,15 @@ const feature: FoamFeature = {
   activate: (context: ExtensionContext) => {
     context.subscriptions.push(
       commands.registerCommand("foam-vscode.open-dated-note", date =>
-        openDatedNote(date)
+        openDailyNoteFor(date)
       )
     );
     languages.registerCompletionItemProvider("markdown", completions, "/");
+    languages.registerCompletionItemProvider(
+      "markdown",
+      computedCompletions,
+      "/"
+    );
   }
 };
 

--- a/packages/foam-vscode/src/features/open-dated-note.ts
+++ b/packages/foam-vscode/src/features/open-dated-note.ts
@@ -122,11 +122,14 @@ const completions: CompletionItemProvider = {
 const computedCompletions: CompletionItemProvider = {
   provideCompletionItems: (document, position, token, context) => {
     return new Promise((resolve, reject) => {
-      document.offsetAt(position);
+      // Convert the current position to a range, so that we can see what the user has typed
       const range = document.getWordRangeAtPosition(position);
+      // Now get what the user has typed. If we don't have a number yet, we still want VS Code to keep "listening"
       const snippetString = document.getText(range);
+      // Try get a number out of the current snippet string
       const matches = snippetString.match(/(\d+)/);
       const number = matches ? matches[0] : undefined;
+      // If we haven't got a number, we return an incomplete list because we want VS Code to keep generating this list
       if (number === undefined) {
         return resolve(
           new CompletionList(
@@ -135,6 +138,7 @@ const computedCompletions: CompletionItemProvider = {
           )
         );
       }
+      // Now if we get here, we have a number we can work with. Lets build a list of possible snippets
       const completionItems = computedSnippets.map(item => {
         const { snippet, detail, date } = item(parseInt(number));
         const completionItem = new CompletionItem(
@@ -155,6 +159,7 @@ const computedCompletions: CompletionItemProvider = {
         };
         return completionItem;
       });
+      // We still want the list to be treated as "incomplete", because the user may add another number
       return resolve(
         new CompletionList(
           [

--- a/packages/foam-vscode/src/features/open-dated-note.ts
+++ b/packages/foam-vscode/src/features/open-dated-note.ts
@@ -1,3 +1,4 @@
+import { SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS } from "constants";
 import {
   workspace,
   ExtensionContext,
@@ -20,18 +21,18 @@ interface DateSnippet {
 }
 
 const foamConfig = workspace.getConfiguration("foam");
+const foamExtension = foamConfig.get("openDailyNote.fileExtension");
+const foamLinkReferenceDefinitions = foamConfig.get(
+  "edit.linkReferenceDefinitions"
+);
 
-const getDailyNoteLink = (
-  date: Date,
-  extension: string,
-  linkReferenceDefinitions: LinkReferenceDefinitionsSetting
-) => {
+const getDailyNoteLink = (date: Date) => {
   let name = getDailyNoteFileName(foamConfig, date);
   if (
-    linkReferenceDefinitions ===
+    foamLinkReferenceDefinitions ===
     LinkReferenceDefinitionsSetting.withoutExtensions
   ) {
-    name = name.replace(`.${extension}`, "");
+    name = name.replace(`.${foamExtension}`, "");
   }
   return `[[${name}]]`;
 };
@@ -40,6 +41,11 @@ const snippets: (() => DateSnippet)[] = [
   () => ({
     detail: "Insert a link to today's daily note",
     snippet: "/day",
+    date: new Date()
+  }),
+  () => ({
+    detail: "Insert a link to today's daily note",
+    snippet: "/today",
     date: new Date()
   }),
   () => {
@@ -52,11 +58,6 @@ const snippets: (() => DateSnippet)[] = [
   }
 ];
 
-/**
- * I think to start working with this you should take a look at emmet
- * https://github.com/Microsoft/vscode/tree/master/extensions/emmet
- * Also, snippet string: https://code.visualstudio.com/api/references/vscode-api#SnippetString
- */
 const computedSnippets: ((number: number) => DateSnippet)[] = [
   (days: number) => {
     const today = new Date();
@@ -82,6 +83,18 @@ const computedSnippets: ((number: number) => DateSnippet)[] = [
       )
     };
   },
+  (months: number) => {
+    const today = new Date();
+    return {
+      detail: `Insert a date ${months} month(s) from now`,
+      snippet: `/+${months}m`,
+      date: new Date(
+        today.getFullYear(),
+        today.getMonth() + months,
+        today.getDate()
+      )
+    };
+  },
   (years: number) => {
     const today = new Date();
     return {
@@ -104,11 +117,8 @@ const completions: CompletionItemProvider = {
         snippet,
         CompletionItemKind.Snippet
       );
-      completionItem.insertText = getDailyNoteLink(
-        date,
-        foamConfig.get("openDailyNote.fileExtension"),
-        foamConfig.get("edit.linkReferenceDefinitions")
-      );
+      completionItem.insertText = getDailyNoteLink(date);
+      completionItem.detail = `${completionItem.insertText} - ${detail}`;
       completionItem.command = {
         command: "foam-vscode.open-dated-note",
         title: "Open a note for the given date",
@@ -121,56 +131,29 @@ const completions: CompletionItemProvider = {
 };
 
 const computedCompletions: CompletionItemProvider = {
-  provideCompletionItems: (document, position, token, context) => {
-    return new Promise((resolve, reject) => {
-      // Convert the current position to a range, so that we can see what the user has typed
-      const range = document.getWordRangeAtPosition(position, /\S+/);
-      // Now get what the user has typed. If we don't have a number yet, we still want VS Code to keep "listening"
-      const snippetString = document.getText(range);
-      // Try get a number out of the current snippet string
-      const matches = snippetString.match(/(\d+)/);
-      const number = matches ? matches[0] : undefined;
-      // If we haven't got a number, we return an incomplete list because we want VS Code to keep generating this list
-      if (number === undefined) {
-        return resolve(
-          new CompletionList(
-            [new CompletionItem(snippetString, CompletionItemKind.Snippet)],
-            true
-          )
-        );
-      }
-      // Now if we get here, we have a number we can work with. Lets build a list of possible snippets
-      const completionItems = computedSnippets.map(item => {
-        const { snippet, detail, date } = item(parseInt(number));
-        const completionItem = new CompletionItem(
-          snippet,
-          CompletionItemKind.Snippet
-        );
-        completionItem.range = range;
-        completionItem.insertText = getDailyNoteLink(
-          date,
-          foamConfig.get("openDailyNote.fileExtension"),
-          foamConfig.get("edit.linkReferenceDefinitions")
-        );
-        completionItem.detail = `${completionItem.insertText} - ${detail}`;
-        completionItem.command = {
-          command: "foam-vscode.open-dated-note",
-          title: "Open a note for the given date",
-          arguments: [date]
-        };
-        return completionItem;
-      });
-      // We still want the list to be treated as "incomplete", because the user may add another number
-      return resolve(
-        new CompletionList(
-          [
-            new CompletionItem("/+", CompletionItemKind.Snippet),
-            ...completionItems
-          ],
-          true
-        )
+  provideCompletionItems: (document, position, _token, _context) => {
+    const range = document.getWordRangeAtPosition(position, /\S+/);
+    const snippetString = document.getText(range);
+    const matches = snippetString.match(/(\d+)/);
+    const number: string = matches ? matches[0] : "1";
+    const completionItems = computedSnippets.map(item => {
+      const { snippet, detail, date } = item(parseInt(number));
+      const completionItem = new CompletionItem(
+        snippet,
+        CompletionItemKind.Snippet
       );
+      completionItem.range = range;
+      completionItem.insertText = getDailyNoteLink(date);
+      completionItem.detail = `${completionItem.insertText} - ${detail}`;
+      completionItem.command = {
+        command: "foam-vscode.open-dated-note",
+        title: "Open a note for the given date",
+        arguments: [date]
+      };
+      return completionItem;
     });
+    // We still want the list to be treated as "incomplete", because the user may add another number
+    return new CompletionList(completionItems, true);
   }
 };
 

--- a/packages/foam-vscode/src/features/open-dated-note.ts
+++ b/packages/foam-vscode/src/features/open-dated-note.ts
@@ -1,41 +1,56 @@
 import {
-  window,
   workspace,
-  Uri,
-  WorkspaceConfiguration,
   ExtensionContext,
   commands,
-  Selection,
   languages,
   CompletionItemProvider,
   CompletionItem,
   CompletionItemKind
 } from "vscode";
-import { dirname, join } from "path";
-import dateFormat from "dateformat";
-import * as fs from "fs";
+import { getDailyNoteFileName, openDatedNote } from "../dated-notes";
 import { FoamFeature } from "../types";
-import { docConfig } from "../utils";
 
-const completion: CompletionItemProvider = {
-  provideCompletionItems: (document, position, token, context) => {
+interface DateSnippet {
+  snippet: string;
+  date: Date;
+  detail: string;
+}
+const foamConfig = workspace.getConfiguration("foam");
+const snippets: (() => DateSnippet)[] = [
+  () => ({
+    detail: "Insert a link to today's daily note",
+    snippet: "/day",
+    date: new Date()
+  }),
+  () => {
     const today = new Date();
-    const tomorrow = new CompletionItem(
-      "/tomorrow",
-      CompletionItemKind.Snippet
-    );
-    tomorrow.insertText = `[[${getDailyNoteFileName(
-      workspace.getConfiguration("foam"),
-      new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1)
-    )}]]`;
-    tomorrow.command = {
-      command: "foam-vscode.open-dated-note",
-      title: "Open a note for the given date",
-      arguments: [
-        new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1)
-      ]
+    return {
+      detail: "Insert a link to tomorrow's daily note",
+      snippet: "/tomorrow",
+      date: new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1)
     };
-    return [tomorrow];
+  }
+];
+
+const completions: CompletionItemProvider = {
+  provideCompletionItems: (document, position, token, context) => {
+    const completionItems = snippets.map(snippet => {
+      const completionItem = new CompletionItem(
+        snippet().snippet,
+        CompletionItemKind.Snippet
+      );
+      completionItem.insertText = `[[${getDailyNoteFileName(
+        foamConfig,
+        snippet().date
+      )}]]`;
+      completionItem.command = {
+        command: "foam-vscode.open-dated-note",
+        title: "Open a note for the given date",
+        arguments: [snippet().date]
+      };
+      return completionItem;
+    });
+    return completionItems;
   }
 };
 
@@ -46,102 +61,8 @@ const feature: FoamFeature = {
         openDatedNote(date)
       )
     );
-    languages.registerCompletionItemProvider(
-      "markdown",
-      completion,
-      "/",
-      "/today",
-      "/tomorrow"
-    );
+    languages.registerCompletionItemProvider("markdown", completions, "/");
   }
 };
-
-async function openDatedNote(date: Date) {
-  const foamConfiguration = workspace.getConfiguration("foam");
-  const currentDate = date ? date : new Date();
-
-  const dailyNotePath = getDailyNotePath(foamConfiguration, currentDate);
-
-  const isNew = await createDailyNoteIfNotExists(
-    foamConfiguration,
-    dailyNotePath,
-    currentDate
-  );
-  await focusDailyNote(dailyNotePath, isNew);
-}
-function getDailyNotePath(configuration: WorkspaceConfiguration, date: Date) {
-  const rootDirectory = workspace.workspaceFolders[0].uri.fsPath;
-  const dailyNoteDirectory: string =
-    configuration.get("openDailyNote.directory") ?? ".";
-  const dailyNoteFilename = getDailyNoteFileName(configuration, date);
-
-  return join(rootDirectory, dailyNoteDirectory, dailyNoteFilename);
-}
-
-function getDailyNoteFileName(
-  configuration: WorkspaceConfiguration,
-  date: Date
-): string {
-  const filenameFormat: string = configuration.get(
-    "openDailyNote.filenameFormat"
-  );
-  const fileExtension: string = configuration.get(
-    "openDailyNote.fileExtension"
-  );
-
-  return `${dateFormat(date, filenameFormat, false)}.${fileExtension}`;
-}
-
-async function createDailyNoteIfNotExists(
-  configuration: WorkspaceConfiguration,
-  dailyNotePath: string,
-  currentDate: Date
-) {
-  if (await pathExists(dailyNotePath)) {
-    return false;
-  }
-
-  await createDailyNoteDirectoryIfNotExists(dailyNotePath);
-
-  const titleFormat: string =
-    configuration.get("openDailyNote.titleFormat") ??
-    configuration.get("openDailyNote.filenameFormat");
-
-  await fs.promises.writeFile(
-    dailyNotePath,
-    `# ${dateFormat(currentDate, titleFormat, false)}${docConfig.eol}${
-      docConfig.eol
-    }`
-  );
-
-  return true;
-}
-
-async function createDailyNoteDirectoryIfNotExists(dailyNotePath: string) {
-  const dailyNoteDirectory = dirname(dailyNotePath);
-
-  if (!(await pathExists(dailyNoteDirectory))) {
-    await fs.promises.mkdir(dailyNoteDirectory, { recursive: true });
-  }
-}
-
-async function focusDailyNote(dailyNotePath: string, isNewNote: boolean) {
-  const document = await workspace.openTextDocument(Uri.file(dailyNotePath));
-  const editor = await window.showTextDocument(document);
-
-  // Move the cursor to end of the file
-  if (isNewNote) {
-    const { lineCount } = editor.document;
-    const { range } = editor.document.lineAt(lineCount - 1);
-    editor.selection = new Selection(range.end, range.end);
-  }
-}
-
-function pathExists(path: string) {
-  return fs.promises
-    .access(path, fs.constants.F_OK)
-    .then(() => true)
-    .catch(() => false);
-}
 
 export default feature;

--- a/packages/foam-vscode/src/features/open-dated-note.ts
+++ b/packages/foam-vscode/src/features/open-dated-note.ts
@@ -33,6 +33,7 @@ const foamExtension = foamConfig.get("openDailyNote.fileExtension");
 const foamLinkReferenceDefinitions = foamConfig.get(
   "edit.linkReferenceDefinitions"
 );
+const foamNavigateOnSelect = foamConfig.get("snippets.navigateOnSelect");
 
 const generateDayOfWeekSnippets = (): DateSnippet[] => {
   const getTarget = (day: number) => {
@@ -60,11 +61,13 @@ const createCompletionItem = ({ snippet, date, detail }: DateSnippet) => {
   );
   completionItem.insertText = getDailyNoteLink(date);
   completionItem.detail = `${completionItem.insertText} - ${detail}`;
-  completionItem.command = {
-    command: "foam-vscode.open-dated-note",
-    title: "Open a note for the given date",
-    arguments: [date]
-  };
+  if (foamNavigateOnSelect) {
+    completionItem.command = {
+      command: "foam-vscode.open-dated-note",
+      title: "Open a note for the given date",
+      arguments: [date]
+    };
+  }
   return completionItem;
 };
 

--- a/packages/foam-vscode/src/features/open-dated-note.ts
+++ b/packages/foam-vscode/src/features/open-dated-note.ts
@@ -1,0 +1,147 @@
+import {
+  window,
+  workspace,
+  Uri,
+  WorkspaceConfiguration,
+  ExtensionContext,
+  commands,
+  Selection,
+  languages,
+  CompletionItemProvider,
+  CompletionItem,
+  CompletionItemKind
+} from "vscode";
+import { dirname, join } from "path";
+import dateFormat from "dateformat";
+import * as fs from "fs";
+import { FoamFeature } from "../types";
+import { docConfig } from "../utils";
+
+const completion: CompletionItemProvider = {
+  provideCompletionItems: (document, position, token, context) => {
+    const today = new Date();
+    const tomorrow = new CompletionItem(
+      "/tomorrow",
+      CompletionItemKind.Snippet
+    );
+    tomorrow.insertText = `[[${getDailyNoteFileName(
+      workspace.getConfiguration("foam"),
+      new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1)
+    )}]]`;
+    tomorrow.command = {
+      command: "foam-vscode.open-dated-note",
+      title: "Open a note for the given date",
+      arguments: [
+        new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1)
+      ]
+    };
+    return [tomorrow];
+  }
+};
+
+const feature: FoamFeature = {
+  activate: (context: ExtensionContext) => {
+    context.subscriptions.push(
+      commands.registerCommand("foam-vscode.open-dated-note", date =>
+        openDatedNote(date)
+      )
+    );
+    languages.registerCompletionItemProvider(
+      "markdown",
+      completion,
+      "/",
+      "/today",
+      "/tomorrow"
+    );
+  }
+};
+
+async function openDatedNote(date: Date) {
+  const foamConfiguration = workspace.getConfiguration("foam");
+  const currentDate = date ? date : new Date();
+
+  const dailyNotePath = getDailyNotePath(foamConfiguration, currentDate);
+
+  const isNew = await createDailyNoteIfNotExists(
+    foamConfiguration,
+    dailyNotePath,
+    currentDate
+  );
+  await focusDailyNote(dailyNotePath, isNew);
+}
+function getDailyNotePath(configuration: WorkspaceConfiguration, date: Date) {
+  const rootDirectory = workspace.workspaceFolders[0].uri.fsPath;
+  const dailyNoteDirectory: string =
+    configuration.get("openDailyNote.directory") ?? ".";
+  const dailyNoteFilename = getDailyNoteFileName(configuration, date);
+
+  return join(rootDirectory, dailyNoteDirectory, dailyNoteFilename);
+}
+
+function getDailyNoteFileName(
+  configuration: WorkspaceConfiguration,
+  date: Date
+): string {
+  const filenameFormat: string = configuration.get(
+    "openDailyNote.filenameFormat"
+  );
+  const fileExtension: string = configuration.get(
+    "openDailyNote.fileExtension"
+  );
+
+  return `${dateFormat(date, filenameFormat, false)}.${fileExtension}`;
+}
+
+async function createDailyNoteIfNotExists(
+  configuration: WorkspaceConfiguration,
+  dailyNotePath: string,
+  currentDate: Date
+) {
+  if (await pathExists(dailyNotePath)) {
+    return false;
+  }
+
+  await createDailyNoteDirectoryIfNotExists(dailyNotePath);
+
+  const titleFormat: string =
+    configuration.get("openDailyNote.titleFormat") ??
+    configuration.get("openDailyNote.filenameFormat");
+
+  await fs.promises.writeFile(
+    dailyNotePath,
+    `# ${dateFormat(currentDate, titleFormat, false)}${docConfig.eol}${
+      docConfig.eol
+    }`
+  );
+
+  return true;
+}
+
+async function createDailyNoteDirectoryIfNotExists(dailyNotePath: string) {
+  const dailyNoteDirectory = dirname(dailyNotePath);
+
+  if (!(await pathExists(dailyNoteDirectory))) {
+    await fs.promises.mkdir(dailyNoteDirectory, { recursive: true });
+  }
+}
+
+async function focusDailyNote(dailyNotePath: string, isNewNote: boolean) {
+  const document = await workspace.openTextDocument(Uri.file(dailyNotePath));
+  const editor = await window.showTextDocument(document);
+
+  // Move the cursor to end of the file
+  if (isNewNote) {
+    const { lineCount } = editor.document;
+    const { range } = editor.document.lineAt(lineCount - 1);
+    editor.selection = new Selection(range.end, range.end);
+  }
+}
+
+function pathExists(path: string) {
+  return fs.promises
+    .access(path, fs.constants.F_OK)
+    .then(() => true)
+    .catch(() => false);
+}
+
+export default feature;

--- a/packages/foam-vscode/src/features/open-dated-note.ts
+++ b/packages/foam-vscode/src/features/open-dated-note.ts
@@ -97,6 +97,14 @@ const snippets: (() => DateSnippet)[] = [
       snippet: "/tomorrow",
       date: new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1)
     };
+  },
+  () => {
+    const today = new Date();
+    return {
+      detail: "Insert a link to yesterday's daily note",
+      snippet: "/yesterday",
+      date: new Date(today.getFullYear(), today.getMonth(), today.getDate() - 1)
+    };
   }
 ];
 

--- a/packages/foam-vscode/src/features/open-dated-note.ts
+++ b/packages/foam-vscode/src/features/open-dated-note.ts
@@ -122,18 +122,15 @@ const completions: CompletionItemProvider = {
 const computedCompletions: CompletionItemProvider = {
   provideCompletionItems: (document, position, token, context) => {
     return new Promise((resolve, reject) => {
-      const offsetPosition = document.offsetAt(position) - 1;
-      const number = document.getText().charAt(offsetPosition);
-      const range = document.getWordRangeAtPosition(position, /_-\s/);
-      if (isNaN(+number)) {
+      document.offsetAt(position);
+      const range = document.getWordRangeAtPosition(position);
+      const snippetString = document.getText(range);
+      const matches = snippetString.match(/(\d+)/);
+      const number = matches ? matches[0] : undefined;
+      if (number === undefined) {
         return resolve(
           new CompletionList(
-            [
-              new CompletionItem(
-                document.getText(range),
-                CompletionItemKind.Snippet
-              )
-            ],
+            [new CompletionItem(snippetString, CompletionItemKind.Snippet)],
             true
           )
         );
@@ -182,8 +179,7 @@ const feature: FoamFeature = {
     languages.registerCompletionItemProvider(
       "markdown",
       computedCompletions,
-      "/",
-      "+"
+      "/"
     );
   }
 };

--- a/packages/foam-vscode/src/features/open-dated-note.ts
+++ b/packages/foam-vscode/src/features/open-dated-note.ts
@@ -1,4 +1,3 @@
-import { SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS } from "constants";
 import {
   workspace,
   ExtensionContext,
@@ -12,7 +11,6 @@ import {
 import { getDailyNoteFileName, openDailyNoteFor } from "../dated-notes";
 import { LinkReferenceDefinitionsSetting } from "../settings";
 import { FoamFeature } from "../types";
-import { astPositionToVsCodePosition } from "../utils";
 
 interface DateSnippet {
   snippet: string;

--- a/packages/foam-vscode/src/features/open-dated-note.ts
+++ b/packages/foam-vscode/src/features/open-dated-note.ts
@@ -11,6 +11,7 @@ import {
 import { getDailyNoteFileName, openDailyNoteFor } from "../dated-notes";
 import { LinkReferenceDefinitionsSetting } from "../settings";
 import { FoamFeature } from "../types";
+import { astPositionToVsCodePosition } from "../utils";
 
 interface DateSnippet {
   snippet: string;
@@ -123,7 +124,7 @@ const computedCompletions: CompletionItemProvider = {
   provideCompletionItems: (document, position, token, context) => {
     return new Promise((resolve, reject) => {
       // Convert the current position to a range, so that we can see what the user has typed
-      const range = document.getWordRangeAtPosition(position);
+      const range = document.getWordRangeAtPosition(position, /\S+/);
       // Now get what the user has typed. If we don't have a number yet, we still want VS Code to keep "listening"
       const snippetString = document.getText(range);
       // Try get a number out of the current snippet string
@@ -184,7 +185,8 @@ const feature: FoamFeature = {
     languages.registerCompletionItemProvider(
       "markdown",
       computedCompletions,
-      "/"
+      "/",
+      "+"
     );
   }
 };

--- a/packages/foam-vscode/src/utils.ts
+++ b/packages/foam-vscode/src/utils.ts
@@ -6,6 +6,7 @@ import {
   Position,
   TextEditor
 } from "vscode";
+import * as fs from "fs";
 
 interface Point {
   line: number;
@@ -103,7 +104,6 @@ export function removeBrackets(s: string): string {
   // loop through words
   const modifiedWords = stringSplitBySpace.map(currentWord => {
     if (currentWord.includes("[[")) {
-
       // all of these transformations will turn this "[[you-are-awesome]]"
       // to this "you are awesome"
       let word = currentWord.replace(/(\[\[)/g, "");
@@ -131,8 +131,19 @@ export function removeBrackets(s: string): string {
  */
 export function toTitleCase(word: string): string {
   return word
-        .split(" ")
-        .map(word => word[0].toUpperCase() + word.substring(1))
-        .join(" ");
+    .split(" ")
+    .map(word => word[0].toUpperCase() + word.substring(1))
+    .join(" ");
 }
 
+/**
+ * Verify the given path exists in the file system
+ *
+ * @param path The path to verify
+ */
+export function pathExists(path: string) {
+  return fs.promises
+    .access(path, fs.constants.F_OK)
+    .then(() => true)
+    .catch(() => false);
+}


### PR DESCRIPTION
Hey

This adds support for daily note date-driven snippets. They all expand out to be the wikilink to the day, and then open the target date's note.

The following snippets are available:

- `/today` or `/day`: Today
- `/tomorrow`: Tomorrow
- `/{dayOfWeek}`: Get the day coming up in the week (e.g. `/monday`)
- `/+nd`: Add n days, where n is a number
- `/+nw`: Add n weeks, where n is a number
- `/+nm`: Add n months, where n is a number
- `/+ny`: Add n years, where n is a number

In future, a weekly/monthly/yearly note should open the configured "weekly note" template (once templates are implemented).

## Today, Tomorrow, +n days/weeks/months/years
![snippets](https://user-images.githubusercontent.com/22981941/97083862-076d7f80-160b-11eb-8cae-a8791334f0d3.gif)

## Days of week
![snippets](https://user-images.githubusercontent.com/22981941/97083929-6df29d80-160b-11eb-8746-266d74c6b7fd.gif)
