### PR TITLE
Add file ignore setting (issue #300)

### DIFF
--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -48,6 +48,13 @@
     "configuration": {
       "title": "Foam",
       "properties": {
+        "foam.files.ignore": {
+          "type": [
+            "array"
+          ],
+          "default": [],
+          "description": "List of files/folders Foam should ignore. Paths are relative to the workspace root."
+        },
         "foam.edit.linkReferenceDefinitions": {
           "type": "string",
           "default": "withoutExtensions",

--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -52,7 +52,10 @@
           "type": [
             "array"
           ],
-          "default": [],
+          "default": [
+            ".vscode/*",
+            "_layouts/*"
+          ],
           "description": "List of files/folders Foam should ignore. Paths are relative to the workspace root."
         },
         "foam.edit.linkReferenceDefinitions": {

--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -56,7 +56,7 @@
             ".vscode/*",
             "_layouts/*"
           ],
-          "description": "List of files/folders Foam should ignore. Paths are relative to the workspace root."
+          "description": "Specifies the list of globs that will be ignored by Foam (e.g. they will not be considered when creating the graph)."
         },
         "foam.edit.linkReferenceDefinitions": {
           "type": "string",

--- a/packages/foam-vscode/src/extension.ts
+++ b/packages/foam-vscode/src/extension.ts
@@ -62,51 +62,22 @@ async function registerFile(foam: Foam, localUri: Uri) {
   return note;
 }
 
-/**
- * Tests if a file is not ignored
- * @param root the workspace root folder
- * @param ignoredPaths the list of ignored paths
- * @param file the file to be tested
- */
-function isNotIgnored(root: string, ignoredPaths: string[], file: string) {
-  if (!ignoredPaths) {
-    return true;
+async function filterIgnored(files: Uri[]) {
+  const excludedPaths = getIgnoredFilesSetting();
+  const includedFiles: Map<String, Uri> = new Map();
+  for (const included of files) {
+    includedFiles.set(included.fsPath, included);
   }
-  const path = file.substring(root.length); // maybe discard the /
-  let notIgnored = true;
-  for (const ignored of ignoredPaths) {
-    notIgnored = notIgnored && !path.startsWith(ignored);
-    if (!notIgnored) {
-      // short circuit the loop
-      return false;
+  for (const excluded of excludedPaths) {
+    for (const file of await workspace.findFiles(excluded)) {
+      includedFiles.delete(file.fsPath);
     }
   }
-  return true;
-}
-
-function filterIgnoredFiles(files: Uri[]) : Uri[] {
-  if (!workspace.workspaceFolders) {
-    return files;
-  }
-
-  const root = workspace.workspaceFolders[0].uri.path;
-  if (!root) {
-    return files;
-  }
-
-  const excludedPaths = getIgnoredFilesSetting();
-  if (!excludedPaths) {
-    return files;
-  }
-
-  const res = files.filter(v => {
-    return isNotIgnored(root, excludedPaths, v.path);
-  });
-  return res;
+  return [...includedFiles.values()];
 }
 
 const bootstrap = async () => {
-  const files = await workspace.findFiles("**/*").then(filterIgnoredFiles);
+  const files = await workspace.findFiles("**/*").then(filterIgnored);
   const config: FoamConfig = getConfig();
   const foam = await foamBootstrap(config);
   const addFile = (uri: Uri) => registerFile(foam, uri);

--- a/packages/foam-vscode/src/settings.ts
+++ b/packages/foam-vscode/src/settings.ts
@@ -14,3 +14,7 @@ export function getWikilinkDefinitionSetting(): LinkReferenceDefinitionsSetting 
       LinkReferenceDefinitionsSetting.withoutExtensions
     );
 }
+
+export function getIgnoredFilesSetting(): string[] {
+  return workspace.getConfiguration("foam.files").get("ignore")
+}

--- a/packages/foam-vscode/tsconfig.json
+++ b/packages/foam-vscode/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "out",
     "lib": ["es6"],
     "sourceMap": true,
-    "strict": false
+    "strict": false,
+    "downlevelIteration": true
   },
   "include": ["src"],
   "exclude": ["node_modules", ".vscode-test"],


### PR DESCRIPTION
This PR is related to issue #300, the issue will be closed and discussion moved here.

This serves as a basic implementation for an ignore mechanism for Foam related files, this is useful to avoid files appearing in the graph (see below).

Before:
![image](https://user-images.githubusercontent.com/15343819/97486728-c4394680-1953-11eb-8d5c-581694d7524f.png)

After:
![image](https://user-images.githubusercontent.com/15343819/97486785-d4e9bc80-1953-11eb-85bf-77615e23409a.png)


Standing problems:
- [X] Maybe this should be glob based, to be discussed.

- [ ] Settings do not refresh, this also happens for other Foam things, such as the graph. 

