### PR TITLE
Fix error in cli command janitor & migrate

### DIFF
--- a/packages/foam-cli/src/commands/janitor.ts
+++ b/packages/foam-cli/src/commands/janitor.ts
@@ -38,7 +38,7 @@ export default class Janitor extends Command {
     const { workspacePath = './' } = args;
 
     if (isValidDirectory(workspacePath)) {
-      const graph = (await bootstrap(createConfigFromFolders(workspacePath)))
+      const graph = (await bootstrap(createConfigFromFolders([workspacePath])))
         .notes;
 
       const notes = graph.getNotes().filter(Boolean); // removes undefined notes

--- a/packages/foam-cli/src/commands/migrate.ts
+++ b/packages/foam-cli/src/commands/migrate.ts
@@ -40,7 +40,7 @@ Successfully generated link references and heading!
     const { args, flags } = this.parse(Migrate);
 
     const { workspacePath = './' } = args;
-    const config = createConfigFromFolders(workspacePath);
+    const config = createConfigFromFolders([workspacePath]);
 
     if (isValidDirectory(workspacePath)) {
       let graph = (await bootstrap(config)).notes;

--- a/packages/foam-core/src/config.ts
+++ b/packages/foam-core/src/config.ts
@@ -23,8 +23,11 @@ export const createConfigFromObject = (
 };
 
 export const createConfigFromFolders = (
-  workspaceFolders: string[]
+  workspaceFolders: string[] | string
 ): FoamConfig => {
+  if (!Array.isArray(workspaceFolders)) {
+    workspaceFolders = [workspaceFolders]
+  }
   const workspaceConfig: any = workspaceFolders.reduce(
     (acc, f) => merge(acc, parseConfig(`${f}/config.json`)),
     {}

--- a/packages/foam-core/src/config.ts
+++ b/packages/foam-core/src/config.ts
@@ -26,7 +26,7 @@ export const createConfigFromFolders = (
   workspaceFolders: string[] | string
 ): FoamConfig => {
   if (!Array.isArray(workspaceFolders)) {
-    workspaceFolders = [workspaceFolders]
+    workspaceFolders = [workspaceFolders];
   }
   const workspaceConfig: any = workspaceFolders.reduce(
     (acc, f) => merge(acc, parseConfig(`${f}/config.json`)),


### PR DESCRIPTION
I got `workspaceFolders.reduce is not a function` error during calling command 'migrate' from 'foam-cli'.

Turns out it was caused by calling 'createConfigFromFolders' with `string` while the function signature requires `string[]`.