### PR TITLE
improved error handling when parsing markdown files

### DIFF
--- a/packages/foam-core/src/markdown-provider.ts
+++ b/packages/foam-core/src/markdown-provider.ts
@@ -4,7 +4,7 @@ import wikiLinkPlugin from 'remark-wiki-link';
 import frontmatterPlugin from 'remark-frontmatter';
 import { parse as parseYAML } from 'yaml';
 import visit from 'unist-util-visit';
-import { Parent, Point } from 'unist';
+import { Parent, Point, Position } from 'unist';
 import * as path from 'path';
 import { NoteGraphAPI } from './note-graph';
 import { NoteLinkDefinition, Note, NoteParser } from './types';
@@ -18,6 +18,7 @@ import { ID } from './types';
 import { ParserPlugin } from './plugins';
 
 const tagsPlugin: ParserPlugin = {
+  name: 'tags',
   onWillVisitTree: (tree, note) => {
     note.tags = extractHashtags(note.source.text);
   },
@@ -28,6 +29,7 @@ const tagsPlugin: ParserPlugin = {
 };
 
 const titlePlugin: ParserPlugin = {
+  name: 'title',
   visit: (node, note) => {
     if (note.title == null && node.type === 'heading' && node.depth === 1) {
       note.title =
@@ -46,6 +48,7 @@ const titlePlugin: ParserPlugin = {
 };
 
 const wikilinkPlugin: ParserPlugin = {
+  name: 'wikilink',
   visit: (node, note) => {
     if (node.type === 'wikiLink') {
       note.links.push({
@@ -58,6 +61,7 @@ const wikilinkPlugin: ParserPlugin = {
 };
 
 const definitionsPlugin: ParserPlugin = {
+  name: 'definitions',
   visit: (node, note) => {
     if (node.type === 'definition') {
       note.definitions.push({
@@ -71,6 +75,19 @@ const definitionsPlugin: ParserPlugin = {
   onDidVisitTree: (tree, note) => {
     note.definitions = getFoamDefinitions(note.definitions, note.source.end);
   },
+};
+
+const handleError = (
+  plugin: ParserPlugin,
+  fnName: string,
+  uri: string | undefined,
+  e: Error
+): void => {
+  const name = plugin.name || '';
+  console.warn(
+    `Error while executing [${fnName}] in plugin [${name}] for file [${uri}]`,
+    e
+  );
 };
 
 export function createMarkdownParser(extraPlugins: ParserPlugin[]): NoteParser {
@@ -87,12 +104,23 @@ export function createMarkdownParser(extraPlugins: ParserPlugin[]): NoteParser {
     ...extraPlugins,
   ];
 
-  plugins.forEach(plugin => plugin.onDidInitializeParser?.(parser));
+  plugins.forEach(plugin => {
+    try {
+      plugin.onDidInitializeParser?.(parser);
+    } catch (e) {
+      handleError(plugin, 'onDidInitializeParser', undefined, e);
+    }
+  });
 
   return {
     parse: (uri: string, markdown: string, eol: string): Note => {
       markdown = plugins.reduce((acc, plugin) => {
-        return plugin.onWillParseMarkdown?.(acc) || acc;
+        try {
+          return plugin.onWillParseMarkdown?.(acc) || acc;
+        } catch (e) {
+          handleError(plugin, 'onWillParseMarkdown', uri, e);
+          return acc;
+        }
       }, markdown);
       const tree = parser.parse(markdown);
 
@@ -112,34 +140,57 @@ export function createMarkdownParser(extraPlugins: ParserPlugin[]): NoteParser {
         },
       };
 
-      plugins.forEach(plugin => plugin.onWillVisitTree?.(tree, note));
+      plugins.forEach(plugin => {
+        try {
+          plugin.onWillVisitTree?.(tree, note);
+        } catch (e) {
+          handleError(plugin, 'onWillVisitTree', uri, e);
+        }
+      });
       visit(tree, node => {
         if (node.type === 'yaml') {
-          const props = parseYAML(node.value as string) ?? {};
-          note.properties = {
-            ...note.properties,
-            ...props,
-          };
-          // Give precendence to the title from the frontmatter if it exists
-          note.title = note.properties.title ?? note.title;
-          // Update the start position of the note by exluding the metadata
-          note.source.contentStart = {
-            line: node.position!.end.line! + 1,
-            column: 1,
-            offset: node.position!.end.offset! + 1,
-          };
+          try {
+            const yamlProperties = parseYAML(node.value as string) ?? {};
+            note.properties = {
+              ...note.properties,
+              ...yamlProperties,
+            };
+            // Give precendence to the title from the frontmatter if it exists
+            note.title = note.properties.title ?? note.title;
+            // Update the start position of the note by exluding the metadata
+            note.source.contentStart = {
+              line: node.position!.end.line! + 1,
+              column: 1,
+              offset: node.position!.end.offset! + 1,
+            };
 
-          for (let i = 0, len = plugins.length; i < len; i++) {
-            plugins[i].onDidFindProperties?.(props, note);
+            for (let i = 0, len = plugins.length; i < len; i++) {
+              try {
+                plugins[i].onDidFindProperties?.(yamlProperties, note);
+              } catch (e) {
+                handleError(plugins[i], 'onDidFindProperties', uri, e);
+              }
+            }
+          } catch (e) {
+            console.warn(`Error while parsing YAML for [${uri}]`, e);
           }
         }
 
         for (let i = 0, len = plugins.length; i < len; i++) {
-          plugins[i].visit?.(node, note);
+          try {
+            plugins[i].visit?.(node, note);
+          } catch (e) {
+            handleError(plugins[i], 'visit', uri, e);
+          }
         }
       });
-      plugins.forEach(plugin => plugin.onDidVisitTree?.(tree, note));
-
+      plugins.forEach(plugin => {
+        try {
+          plugin.onDidVisitTree?.(tree, note);
+        } catch (e) {
+          handleError(plugin, 'onDidVisitTree', uri, e);
+        }
+      });
       return note;
     },
   };

--- a/packages/foam-core/src/markdown-provider.ts
+++ b/packages/foam-core/src/markdown-provider.ts
@@ -4,7 +4,7 @@ import wikiLinkPlugin from 'remark-wiki-link';
 import frontmatterPlugin from 'remark-frontmatter';
 import { parse as parseYAML } from 'yaml';
 import visit from 'unist-util-visit';
-import { Parent, Point, Position } from 'unist';
+import { Parent, Point } from 'unist';
 import * as path from 'path';
 import { NoteGraphAPI } from './note-graph';
 import { NoteLinkDefinition, Note, NoteParser } from './types';

--- a/packages/foam-core/src/plugins/index.ts
+++ b/packages/foam-core/src/plugins/index.ts
@@ -15,6 +15,7 @@ export interface FoamPlugin {
 }
 
 export interface ParserPlugin {
+  name?: string;
   visit?: (node: Node, note: Note) => void;
   onDidInitializeParser?: (parser: unified.Processor) => void;
   onWillParseMarkdown?: (markdown: string) => string;

--- a/packages/foam-core/test/markdown-provider.test.ts
+++ b/packages/foam-core/test/markdown-provider.test.ts
@@ -22,26 +22,6 @@ const pageC = `
 # Page C
 `;
 
-const pageD = `
-This file has no heading.
-`;
-
-const pageE = `
----
-title: Note Title
-date: 20-12-12
----
-
-# Other Note Title
-`;
-
-const pageF = `
----
----
-
-# Empty Frontmatter
-`;
-
 const createNoteFromMarkdown = createMarkdownParser([]).parse;
 
 describe('Markdown loader', () => {
@@ -92,7 +72,13 @@ describe('Note Title', () => {
   it('should default to file name if heading does not exist', () => {
     const graph = new NoteGraph();
     const note = graph.setNote(
-      createNoteFromMarkdown('/page-d.md', pageD, '\n')
+      createNoteFromMarkdown(
+        '/page-d.md',
+        `
+This file has no heading.
+      `,
+        '\n'
+      )
     );
 
     const pageANoteTitle = graph.getNote(note.id)!.title;
@@ -102,7 +88,18 @@ describe('Note Title', () => {
   it('should give precedence to frontmatter title over other headings', () => {
     const graph = new NoteGraph();
     const note = graph.setNote(
-      createNoteFromMarkdown('/page-e.md', pageE, '\n')
+      createNoteFromMarkdown(
+        '/page-e.md',
+        `
+---
+title: Note Title
+date: 20-12-12
+---
+
+# Other Note Title
+      `,
+        '\n'
+      )
     );
 
     const pageENoteTitle = graph.getNote(note.id)!.title;
@@ -127,7 +124,17 @@ describe('frontmatter', () => {
   it('should parse yaml frontmatter', () => {
     const graph = new NoteGraph();
     const note = graph.setNote(
-      createNoteFromMarkdown('/page-e.md', pageE, '\n')
+      createNoteFromMarkdown(
+        '/page-e.md',
+        `
+---
+title: Note Title
+date: 20-12-12
+---
+
+# Other Note Title`,
+        '\n'
+      )
     );
 
     const expected = {
@@ -144,7 +151,40 @@ describe('frontmatter', () => {
   it('should parse empty frontmatter', () => {
     const graph = new NoteGraph();
     const note = graph.setNote(
-      createNoteFromMarkdown('/page-f.md', pageF, '\n')
+      createNoteFromMarkdown(
+        '/page-f.md',
+        `
+---
+---
+
+# Empty Frontmatter
+`,
+        '\n'
+      )
+    );
+
+    const expected = {};
+
+    const actual = graph.getNote(note.id)!.properties;
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('should not fail when there are issues with parsing frontmatter', () => {
+    const graph = new NoteGraph();
+    const note = graph.setNote(
+      createNoteFromMarkdown(
+        '/page-f.md',
+        `
+---
+title: - one
+ - two
+ - #
+---
+
+`,
+        '\n'
+      )
     );
 
     const expected = {};


### PR DESCRIPTION
This fix makes the parsing more friendly towards badly formatted md files (error occurring especially in YAML parsing).
will address #317 (and part of #316)

The PR does the following:
- add a `name` property to plugins, to better identify the source of problems
- wrap all the calls to plugin functions in `try/catch` blocks, so to report any error occurred in there (and continue)
- wraps the yaml parsing in a `try/catch` block, to report any error, for now in the console, and continue with the parsing