### PR TITLE
Add title cutting after given length

### DIFF
--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -125,6 +125,11 @@
             "Navigates to the note, creating it following your daily note settings if it does not exist"
           ],
           "description": "Whether or not to navigate to the target daily note when a daily note snippet is selected."
+        },
+        "foam.graph.titleMaxLength": {
+          "type": "number",
+          "default": 24,
+          "description": "The maximum title length before being abbreviated. Set to 0 or less to disable."
         }
       }
     },

--- a/packages/foam-vscode/src/features/dataviz.ts
+++ b/packages/foam-vscode/src/features/dataviz.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import { FoamFeature } from "../types";
 import { Foam } from "foam-core";
 import { TextDecoder } from "util";
+import { getTitleMaxLength } from "../settings";
 
 const feature: FoamFeature = {
   activate: (context: vscode.ExtensionContext, foamPromise: Promise<Foam>) => {
@@ -44,7 +45,7 @@ function generateGraphData(foam: Foam) {
       id: n.id,
       type: "note",
       uri: n.source.uri,
-      title: n.title,
+      title: cutTitle(n.title),
       nOutLinks: links.length,
       nInLinks: graph.nodes[n.id]?.nInLinks ?? 0
     };
@@ -69,6 +70,14 @@ function generateGraphData(foam: Foam) {
     nodes: Array.from(Object.values(graph.nodes)),
     edges: Array.from(graph.edges)
   };
+}
+
+function cutTitle(title: string): string {
+  const maxLen = getTitleMaxLength();
+  if (maxLen > 0 && title.length > maxLen) {
+    return title.substring(0, maxLen).concat("...");
+  }
+  return title;
 }
 
 async function createGraphPanel(foam: Foam, context: vscode.ExtensionContext) {

--- a/packages/foam-vscode/src/settings.ts
+++ b/packages/foam-vscode/src/settings.ts
@@ -18,3 +18,7 @@ export function getWikilinkDefinitionSetting(): LinkReferenceDefinitionsSetting 
 export function getIgnoredFilesSetting(): string[] {
   return workspace.getConfiguration("foam.files").get("ignore")
 }
+
+export function getTitleMaxLength(): number {
+  return workspace.getConfiguration("foam.graph").get("titleMaxLength")
+}


### PR DESCRIPTION
This PR is related with https://github.com/foambubble/foam/issues/325, the approach is the same as https://github.com/tchayen/markdown-links/pull/67/
The graph now looks like this (with length of 24)

![image](https://user-images.githubusercontent.com/15343819/98581955-2b42ed80-22ba-11eb-8ccd-ae9a50ba6d10.png)

I tried to wrap lines, however `\n` gets translated to a space.

