### PR TITLE
Refactor the bootstrap function to be simpler

### DIFF
--- a/packages/foam-vscode/src/extension.ts
+++ b/packages/foam-vscode/src/extension.ts
@@ -69,9 +69,10 @@ async function registerFile(foam: Foam, localUri: Uri) {
 }
 
 /**
- * Filter the files according to:
- * 1. Extension (currently `.md`, `.mdx`, `.markdown`).
- * 2. Excluded globs set by the user in `foam.files.ignore`.
+ * Filter the files and register them in the Foam object.
+ * Filtering is done according to:
+ * 1. Extension (currently `.md`, `.mdx`, `.markdown`)
+ * 2. Excluded globs set by the user in `foam.files.ignore`
  * @param foam the Foam object.
  * @param files the list of files to be filtered and registered.
  */

--- a/packages/foam-vscode/src/extension.ts
+++ b/packages/foam-vscode/src/extension.ts
@@ -48,7 +48,7 @@ function isLocalMarkdownFile(uri: Uri) {
 
 async function registerFiles(foam: Foam, localUri: Iterable<Uri>) {
   for (const uri of localUri) {
-    registerFile(foam, uri)
+    registerFile(foam, uri);
   }
 }
 
@@ -68,8 +68,15 @@ async function registerFile(foam: Foam, localUri: Uri) {
   return note;
 }
 
-async function filterAndRegister(foam:Foam, files: Uri[]) {
-  const excludedPaths = getIgnoredFilesSetting();
+/**
+ * Filter the files according to:
+ * 1. Extension (currently `.md`, `.mdx`, `.markdown`).
+ * 2. Excluded globs set by the user in `foam.files.ignore`.
+ * @param foam the Foam object.
+ * @param files the list of files to be filtered and registered.
+ */
+async function filterAndRegister(foam: Foam, files: Uri[]) {
+  const excludedPaths: string[] = getIgnoredFilesSetting();
   const includedFiles: Map<String, Uri> = new Map();
   for (const included of files) {
     if (isLocalMarkdownFile(included)) {
@@ -86,8 +93,10 @@ async function filterAndRegister(foam:Foam, files: Uri[]) {
 
 const bootstrap = async () => {
   const config: FoamConfig = getConfig();
-  const foam = await foamBootstrap(config);
-  await workspace.findFiles("**/*").then((files) => filterAndRegister(foam, files));
+  const foam: Foam = await foamBootstrap(config);
+  await workspace
+    .findFiles("**/*")
+    .then(files => filterAndRegister(foam, files));
 
   workspaceWatcher = workspace.createFileSystemWatcher(
     "**/*",

--- a/packages/foam-vscode/src/settings.ts
+++ b/packages/foam-vscode/src/settings.ts
@@ -15,10 +15,12 @@ export function getWikilinkDefinitionSetting(): LinkReferenceDefinitionsSetting 
     );
 }
 
+/** Retrieve the list of file ignoring globs. */
 export function getIgnoredFilesSetting(): string[] {
   return workspace.getConfiguration("foam.files").get("ignore")
 }
 
+/** Retrieves the maximum length for a Graph node title. */
 export function getTitleMaxLength(): number {
   return workspace.getConfiguration("foam.graph").get("titleMaxLength")
 }


### PR DESCRIPTION
Currently the bootstrap function has a lot of bloat.
It makes the files go around several times instead of applying the filters in one go.

This PR aims to reduce the bloat and with it add some documentation (a starting effort!)

I'd also like to add that file registering would make more sense as: `foam.registerFile(file)` instead of `registerFile(foam, file)`.