### PR TITLE
Center graph on active note, plus other tweaks

### DIFF
--- a/packages/foam-vscode/src/features/dataviz.ts
+++ b/packages/foam-vscode/src/features/dataviz.ts
@@ -4,6 +4,7 @@ import { FoamFeature } from "../types";
 import { Foam } from "foam-core";
 import { TextDecoder } from "util";
 import { getTitleMaxLength } from "../settings";
+import { isSome } from "../utils";
 
 const feature: FoamFeature = {
   activate: (context: vscode.ExtensionContext, foamPromise: Promise<Foam>) => {
@@ -20,6 +21,17 @@ const feature: FoamFeature = {
         foam.notes.unstable_removeEventListener(onNoteAdded);
       });
 
+      vscode.window.onDidChangeActiveTextEditor(e => {
+        if (e.document.uri.scheme === "file") {
+          const note = foam.notes.getNoteByURI(e.document.uri.fsPath);
+          if (isSome(note)) {
+            panel.webview.postMessage({
+              type: "selected",
+              payload: note.id
+            });
+          }
+        }
+      });
       updateGraph(panel, foam);
     });
   }

--- a/packages/foam-vscode/static/graphs/default/graph.js
+++ b/packages/foam-vscode/static/graphs/default/graph.js
@@ -9,10 +9,18 @@ try {
         const data = message.payload;
         createWebGLGraph(data, vscode);
         break;
+      case "selected":
+        const noteId = message.payload;
+        const node = myGraph.graphData().nodes.find(node => node.id === noteId);
+        if (node) {
+          myGraph.centerAt(node.x, node.y, 300).zoom(3, 300);
+          model = updateModel(node, null);
+        }
+        break;
     }
   });
 } catch {
-  console.log("VSCode not detected");
+  console.log("VsCode not detected");
 }
 
 const CONTAINER_ID = "graph";
@@ -47,12 +55,13 @@ const labelAlpha = d3
 
 const globalFontSize = 12;
 
+const myGraph = ForceGraph();
+let model = updateModel(null, null);
+
 function createWebGLGraph(data, channel) {
   data = convertData(data);
-  let model = updateModel(null, null);
 
   const elem = document.getElementById(CONTAINER_ID);
-  const myGraph = ForceGraph();
   myGraph(elem)
     .graphData(data)
     .backgroundColor(style.backgroundColor)

--- a/packages/foam-vscode/static/graphs/default/graph.js
+++ b/packages/foam-vscode/static/graphs/default/graph.js
@@ -37,14 +37,14 @@ const style = {
   },
   link: {
     highlighted: "#f9c74f",
-    regular: "#277da1"
+    regular: "#055171"
   }
 };
 
 const sizeScale = d3
   .scaleLinear()
   .domain([0, 30])
-  .range([2, 6])
+  .range([1, 3])
   .clamp(true);
 
 const labelAlpha = d3
@@ -69,6 +69,7 @@ function createWebGLGraph(data, channel) {
     .d3Force("x", d3.forceX())
     .d3Force("y", d3.forceY())
     .d3Force("collide", d3.forceCollide(myGraph.nodeRelSize()))
+    .linkWidth(0.5)
     .linkDirectionalParticles(1)
     .linkDirectionalParticleWidth(link =>
       getLinkState(link, model) === "highlighted" ? 1 : 0

--- a/packages/foam-vscode/static/graphs/default/graph.js
+++ b/packages/foam-vscode/static/graphs/default/graph.js
@@ -41,7 +41,7 @@ const sizeScale = d3
 
 const labelAlpha = d3
   .scaleLinear()
-  .domain([1.7, 4])
+  .domain([1.2, 2])
   .range([0, 1])
   .clamp(true);
 
@@ -85,7 +85,10 @@ function createWebGLGraph(data, channel) {
       ctx.textAlign = "center";
       ctx.textBaseline = "top";
       let textColor = d3.rgb(fill);
-      textColor.opacity = labelAlpha(globalScale);
+      textColor.opacity =
+        getNodeState(node, model) === "highlighted"
+          ? 1
+          : labelAlpha(globalScale);
       ctx.fillStyle = textColor;
       ctx.fillText(node.name, node.x, node.y + size + 1);
     })


### PR DESCRIPTION
Selecting a note in the editor will now highlight it in the graph, and center on it.

Also added some UX/style improvements:
- show label for highlighted node regardless of zoom
- show labels earlier (in terms of zoom)
- thinner edges for lighter visual impact of graph
- reduced relative size of nodes