### PR TITLE
Fix: Slug wikilinks with spaces

### DIFF
--- a/packages/foam-core/src/markdown-provider.ts
+++ b/packages/foam-core/src/markdown-provider.ts
@@ -13,6 +13,7 @@ import {
   uriToSlug,
   extractHashtags,
   extractTagsFromProp,
+  nameToSlug,
 } from './utils';
 import { ID } from './types';
 import { ParserPlugin } from './plugins';
@@ -53,7 +54,7 @@ const wikilinkPlugin: ParserPlugin = {
     if (node.type === 'wikiLink') {
       note.links.push({
         type: 'wikilink',
-        slug: node.value as string,
+        slug: nameToSlug(node.value as string),
         position: node.position!,
       });
     }

--- a/packages/foam-core/src/utils/uri.ts
+++ b/packages/foam-core/src/utils/uri.ts
@@ -7,6 +7,10 @@ export const uriToSlug = (noteUri: URI): string => {
   return GithubSlugger.slug(path.parse(noteUri).name);
 };
 
+export const nameToSlug = (noteName: string): string => {
+  return GithubSlugger.slug(noteName);
+};
+
 export const hashURI = (uri: URI): ID => {
   return hash(path.normalize(uri));
 };

--- a/packages/foam-core/test/markdown-provider.test.ts
+++ b/packages/foam-core/test/markdown-provider.test.ts
@@ -11,6 +11,8 @@ const pageA = `
 ## Section
 - [[page-b]]
 - [[page-c]]
+- [[Page D]]
+- [[page e]]
 `;
 
 const pageB = `
@@ -22,6 +24,14 @@ const pageC = `
 # Page C
 `;
 
+const pageD = `
+# Page D
+`;
+
+const pageE = `
+# Page E
+`;
+
 const createNoteFromMarkdown = createMarkdownParser([]).parse;
 
 describe('Markdown loader', () => {
@@ -30,13 +40,15 @@ describe('Markdown loader', () => {
     graph.setNote(createNoteFromMarkdown('/page-a.md', pageA, '\n'));
     graph.setNote(createNoteFromMarkdown('/page-b.md', pageB, '\n'));
     graph.setNote(createNoteFromMarkdown('/page-c.md', pageC, '\n'));
+    graph.setNote(createNoteFromMarkdown('/page-d.md', pageD, '\n'));
+    graph.setNote(createNoteFromMarkdown('/page-e.md', pageE, '\n'));
 
     expect(
       graph
         .getNotes()
         .map(n => n.slug)
         .sort()
-    ).toEqual(['page-a', 'page-b', 'page-c']);
+    ).toEqual(['page-a', 'page-b', 'page-c', 'page-d', 'page-e']);
   });
 
   it('Parses wikilinks correctly', () => {
@@ -48,13 +60,15 @@ describe('Markdown loader', () => {
       createNoteFromMarkdown('/page-b.md', pageB, '\n')
     );
     graph.setNote(createNoteFromMarkdown('/page-c.md', pageC, '\n'));
+    graph.setNote(createNoteFromMarkdown('/page-d.md', pageD, '\n'));
+    graph.setNote(createNoteFromMarkdown('/page-e.md', pageE, '\n'));
 
     expect(
       graph.getBacklinks(noteB.id).map(link => graph.getNote(link.from)!.slug)
     ).toEqual(['page-a']);
     expect(
       graph.getForwardLinks(noteA.id).map(link => graph.getNote(link.to)!.slug)
-    ).toEqual(['page-b', 'page-c']);
+    ).toEqual(['page-b', 'page-c', 'page-d', 'page-e']);
   });
 });
 

--- a/packages/foam-core/test/utils.test.ts
+++ b/packages/foam-core/test/utils.test.ts
@@ -1,5 +1,6 @@
 import {
   uriToSlug,
+  nameToSlug,
   hashURI,
   computeRelativeURI,
   extractHashtags,
@@ -12,6 +13,13 @@ describe('URI utils', () => {
     expect(uriToSlug('another/relative/path.md')).toEqual('path');
     expect(uriToSlug('no-directory.markdown')).toEqual('no-directory');
     expect(uriToSlug('many.dots.name.markdown')).toEqual('manydotsname');
+  });
+
+  it('converts a name to a slug', () => {
+    expect(nameToSlug('this.has.dots')).toEqual('thishasdots');
+    expect(nameToSlug('title')).toEqual('title');
+    expect(nameToSlug('this is a title')).toEqual('this-is-a-title');
+    expect(nameToSlug('this is a title/slug')).toEqual('this-is-a-titleslug');
   });
 
   it('normalizes URI before hashing', () => {


### PR DESCRIPTION
In a previous feature PR, the ability to define wikilinks with
spaces was not converted into slugs, causing the link references
generation code to not find these wikilinks.

Fixes #323 

Let me know if I have missed any tests!