### PR TITLE
Dataviz: graph smooth update and theme

### DIFF
--- a/packages/foam-vscode/src/features/dataviz.ts
+++ b/packages/foam-vscode/src/features/dataviz.ts
@@ -34,7 +34,6 @@ const feature: FoamFeature = {
           }
         }
       });
-      updateGraph(panel, foam);
     });
   }
 };
@@ -81,8 +80,8 @@ function generateGraphData(foam: Foam) {
     });
   });
   return {
-    nodes: Array.from(Object.values(graph.nodes)),
-    edges: Array.from(graph.edges)
+    nodes: graph.nodes,
+    links: Array.from(graph.edges)
   };
 }
 
@@ -109,14 +108,20 @@ async function createGraphPanel(foam: Foam, context: vscode.ExtensionContext) {
 
   panel.webview.onDidReceiveMessage(
     message => {
-      if (message.type === "selected") {
-        const noteId = message.payload;
-        const noteUri = foam.notes.getNote(noteId).source.uri;
-        const openPath = vscode.Uri.file(noteUri);
+      switch (message.type) {
+        case "ready":
+          updateGraph(panel, foam);
+          break;
 
-        vscode.workspace.openTextDocument(openPath).then(doc => {
-          vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
-        });
+        case "selected":
+          const noteId = message.payload;
+          const noteUri = foam.notes.getNote(noteId).source.uri;
+          const openPath = vscode.Uri.file(noteUri);
+
+          vscode.workspace.openTextDocument(openPath).then(doc => {
+            vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
+          });
+          break;
       }
     },
     undefined,

--- a/packages/foam-vscode/src/features/dataviz.ts
+++ b/packages/foam-vscode/src/features/dataviz.ts
@@ -12,12 +12,16 @@ const feature: FoamFeature = {
       const foam = await foamPromise;
       const panel = await createGraphPanel(foam, context);
 
-      const onNoteAdded = _ => {
+      const onFoamChanged = _ => {
         updateGraph(panel, foam);
       };
 
-      const noteAddedListener = foam.notes.onDidAddNote(onNoteAdded);
-      panel.onDidDispose(() => noteAddedListener.dispose());
+      const noteAddedListener = foam.notes.onDidAddNote(onFoamChanged);
+      const noteUpdatedListener = foam.notes.onDidUpdateNote(onFoamChanged);
+      panel.onDidDispose(() => {
+        noteAddedListener.dispose();
+        noteUpdatedListener.dispose();
+      });
 
       vscode.window.onDidChangeActiveTextEditor(e => {
         if (e.document.uri.scheme === "file") {

--- a/packages/foam-vscode/static/dataviz.html
+++ b/packages/foam-vscode/static/dataviz.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <script data-replace src="./g6.min.js"></script>
     <script data-replace src="./d3.v6.min.js"></script>
     <script data-replace src="./force-graph.1.34.1.min.js"></script>
   </head>

--- a/packages/foam-vscode/static/graphs/default/graph.js
+++ b/packages/foam-vscode/static/graphs/default/graph.js
@@ -1,16 +1,26 @@
 const CONTAINER_ID = "graph";
 
-function getStyle(name) {
-  return getComputedStyle(document.documentElement).getPropertyValue(name);
+function getStyle(name, fallback) {
+  return (
+    getComputedStyle(document.documentElement).getPropertyValue(name) ||
+    fallback
+  );
 }
 
 const style = {
-  background: getStyle(`--vscode-panel-background`),
-  fontSize: parseInt(getStyle(`--vscode-font-size`)),
-  highlightedForeground: getStyle("--vscode-list-highlightForeground"),
+  background: getStyle(`--vscode-panel-background`, "#202020"),
+  fontSize: parseInt(getStyle(`--vscode-font-size`, 12)),
+  highlightedForeground: getStyle(
+    "--vscode-list-highlightForeground",
+    "#f9c74f"
+  ),
   node: {
-    note: getStyle("--vscode-editor-foreground"),
-    nonExistingNote: getStyle("--vscode-list-deemphasizedForeground")
+    note: getStyle("--vscode-editor-foreground", "#277da1"),
+    nonExistingNote: getStyle(
+      "--vscode-list-deemphasizedForeground",
+      "#545454"
+    ),
+    unknown: getStyle("--vscode-editor-foreground", "#f94144")
   }
 };
 


### PR DESCRIPTION
Addresses #358 and #322 

- Refactored `graph.js` to have some sort of design (still lightweight and with a few corners cut). 
- Simplified and consolidated styling, while picking properties from vscode theme
- Completely changed the way the graph data is updated, to support the fact that the simulation requires objects to stay constant. The approach was to make the simulation object as small as possible (it only contains the ID of the nodes), and the rest of the data is looked up in a separate object. On refresh we perform a diff of just the IDs in the graph.
- Added support for multiple node selection in graph by pressing SHIFT key while clicking on nodes