### PR TITLE
Updating the GistPad recipe

### DIFF
--- a/docs/gistpad.md
+++ b/docs/gistpad.md
@@ -10,9 +10,9 @@ To start using GistPad for your Foam-based knowledge base, simply perform the fo
 
 1. Download the [GistPad extension](https://aka.ms/gistpad) and then re-start Visual Studio Code
 
-1. Run the `GistPad: Sign In` command, and provide a [GitHub token](https://github.com/settings/tokens/new) that includes the `repo` scope (and optionally `gist` and `delete_repo` scope, if you'd like to use GistPad for managing your GitHub content more holistically)
+1. Run the `GistPad: Sign In` command and then complete the authentication flow using your GitHub account
 
-1. Run the `GistPad: Manage Repository` command and select the `Create repo from template...` or `Create private repo from template...` depending on your preference
+1. Run the `GistPad: Open Repository` command and select the `Create repo from template...` or `Create private repo from template...` depending on your preference
 
 1. Select the `Foam-style wiki` template, and then specify a name for your Foam workspace (e.g. `my-foam-notes`, `johns-knowledge-base`)
 


### PR DESCRIPTION
This PR simply updates the GistPad recipe, to account for the fact that GistPad now integrates with VS Code's native GitHub auth, and no longer requires manually creating a token 🚀 

Additionally, the `GistPad: Manage Repository` command has been renamed to `GistPad: Open Repository`.