### PR TITLE
fix(dataviz): Don't delete node for note on update - #393

### DIFF
--- a/packages/foam-core/src/note-graph.ts
+++ b/packages/foam-core/src/note-graph.ts
@@ -59,7 +59,7 @@ export class NoteGraph implements NoteGraphAPI {
 
   public setNote(note: Note): GraphNote {
     const id = this.createIdFromURI(note.source.uri);
-    const oldNote = this.doDelete(id, false);
+    const oldNote = this.getNote(id);
     const graphNote: GraphNote = {
       ...note,
       id: id,

--- a/packages/foam-core/src/note-graph.ts
+++ b/packages/foam-core/src/note-graph.ts
@@ -60,6 +60,9 @@ export class NoteGraph implements NoteGraphAPI {
   public setNote(note: Note): GraphNote {
     const id = this.createIdFromURI(note.source.uri);
     const oldNote = this.getNote(id);
+    if (isSome(oldNote)) {
+      this.removeForwardLinks(id);
+    }
     const graphNote: GraphNote = {
       ...note,
       id: id,
@@ -91,9 +94,7 @@ export class NoteGraph implements NoteGraphAPI {
     const note = this.getNote(noteId);
     if (isSome(note)) {
       this.graph.removeNode(noteId);
-      (this.graph.outEdges(noteId) || []).forEach(edge => {
-        this.graph.removeEdge(edge);
-      });
+      this.removeForwardLinks(noteId);
       fireEvent && this.onDidDeleteEmitter.fire(note);
     }
     return note;
@@ -131,6 +132,12 @@ export class NoteGraph implements NoteGraphAPI {
     return (this.graph.outEdges(noteId) || []).map(edge =>
       this.graph.edge(edge.v, edge.w)
     );
+  }
+
+  public removeForwardLinks(noteId: ID) {
+    (this.graph.outEdges(noteId) || []).forEach(edge => {
+      this.graph.removeEdge(edge);
+    });
   }
 
   public getBacklinks(noteId: ID): GraphConnection[] {

--- a/packages/foam-core/src/note-graph.ts
+++ b/packages/foam-core/src/note-graph.ts
@@ -93,8 +93,11 @@ export class NoteGraph implements NoteGraphAPI {
   private doDelete(noteId: ID, fireEvent: boolean): GraphNote | null {
     const note = this.getNote(noteId);
     if (isSome(note)) {
-      this.graph.removeNode(noteId);
-      this.removeForwardLinks(noteId);
+      if (this.getBacklinks(noteId).length >= 1) {
+        this.graph.setNode(noteId, null); // Changes node to the "no file" style
+      } else {
+        this.graph.removeNode(noteId);
+      }
       fireEvent && this.onDidDeleteEmitter.fire(note);
     }
     return note;

--- a/packages/foam-core/test/core.test.ts
+++ b/packages/foam-core/test/core.test.ts
@@ -146,11 +146,10 @@ describe('Note graph', () => {
     ).toEqual(['page-b']);
 
     // Tests #393: page-a should not lose its links when updated
-    graph.setNote(createTestNote({ title: "Test-C", uri: '/page-c.md' }));
+    graph.setNote(createTestNote({ title: 'Test-C', uri: '/page-c.md' }));
     expect(
       graph.getBacklinks(noteC.id).map(link => graph.getNote(link.from)?.slug)
     ).toEqual(['page-b']);
-
   });
 });
 

--- a/packages/foam-core/test/core.test.ts
+++ b/packages/foam-core/test/core.test.ts
@@ -165,17 +165,23 @@ describe('Note graph', () => {
         links: [{ slug: 'page-a' }],
       })
     );
-    const noteC = graph.setNote(createTestNote({ 
-      uri: '/page-c.md',
-      links: [{ slug: 'page-a' }],
-    }));
+    const noteC = graph.setNote(
+      createTestNote({
+        uri: '/page-c.md',
+        links: [{ slug: 'page-a' }],
+      })
+    );
 
     graph.deleteNote(noteA.id);
-    expect(graph.getForwardLinks(noteB.id).map(link => link?.link?.slug)).toEqual(['page-a']);
+    expect(
+      graph.getForwardLinks(noteB.id).map(link => link?.link?.slug)
+    ).toEqual(['page-a']);
     expect(graph.getNote(noteA.id)).toBeNull();
-   
+
     graph.deleteNote(noteC.id);
-    expect(graph.getForwardLinks(noteC.id).map(link => link?.link?.slug)).toEqual([]);
+    expect(
+      graph.getForwardLinks(noteC.id).map(link => link?.link?.slug)
+    ).toEqual([]);
     expect(graph.getNotes().map(note => note.slug)).toEqual(['page-b']);
   });
 });

--- a/packages/foam-core/test/core.test.ts
+++ b/packages/foam-core/test/core.test.ts
@@ -151,6 +151,33 @@ describe('Note graph', () => {
       graph.getBacklinks(noteC.id).map(link => graph.getNote(link.from)?.slug)
     ).toEqual(['page-b']);
   });
+
+  it('Updates the graph properly when deleting a note', () => {
+    // B should still link out to A after A is deleted. (#393)
+    // C links out to A, like B, but should no longer link out once deleted.
+    // Ensure B is only remaining note after A + C are deleted.
+    const graph = new NoteGraph();
+
+    const noteA = graph.setNote(createTestNote({ uri: '/page-a.md' }));
+    const noteB = graph.setNote(
+      createTestNote({
+        uri: '/page-b.md',
+        links: [{ slug: 'page-a' }],
+      })
+    );
+    const noteC = graph.setNote(createTestNote({ 
+      uri: '/page-c.md',
+      links: [{ slug: 'page-a' }],
+    }));
+
+    graph.deleteNote(noteA.id);
+    expect(graph.getForwardLinks(noteB.id).map(link => link?.link?.slug)).toEqual(['page-a']);
+    expect(graph.getNote(noteA.id)).toBeNull();
+   
+    graph.deleteNote(noteC.id);
+    expect(graph.getForwardLinks(noteC.id).map(link => link?.link?.slug)).toEqual([]);
+    expect(graph.getNotes().map(note => note.slug)).toEqual(['page-b']);
+  });
 });
 
 describe('Graph querying', () => {

--- a/packages/foam-core/test/core.test.ts
+++ b/packages/foam-core/test/core.test.ts
@@ -144,6 +144,13 @@ describe('Note graph', () => {
     expect(
       graph.getBacklinks(noteC.id).map(link => graph.getNote(link.from)?.slug)
     ).toEqual(['page-b']);
+
+    // Tests #393: page-a should not lose its links when updated
+    graph.setNote(createTestNote({ title: "Test-C", uri: '/page-c.md' }));
+    expect(
+      graph.getBacklinks(noteC.id).map(link => graph.getNote(link.from)?.slug)
+    ).toEqual(['page-b']);
+
   });
 });
 


### PR DESCRIPTION
Will resolve #393 

Looks like as part of `0.7.2` a `deleteNote` call was added to `setNote`. ([View changes](https://github.com/foambubble/foam/commit/26ab27e06fb7747bb58b39c311ff54c674b70f52#diff-139497fe1094e55b5ad85d381b423b985ba4040dd5adbdf75ac89adf934c99a9R62))

Doing so causes graphlib to delete the inbound links from other nodes so when this node is re-created it will not have its inbound links. ([View relevant graphlib source](https://github.com/dagrejs/graphlib/blob/master/lib/graph.js#L456))

I switched the `doDelete` back to `getNote` so it still satisfies finding if the note already existed for the sake of triggering the onUpdate / onAdd events-- it seems to be behaving as expected.

That said, I noticed the _original_ approach was to delete the outbound links for the note so they can be re-created. That looked like this:
```
if (noteExists) {	
      (this.graph.outEdges(id) || []).forEach(edge => {	
        this.graph.removeEdge(edge);	
      });	
    }
```

In that previous code, the actual node for the note was not being deleted nor its inbound references. 

I can update this PR to restore that code if it seems necessary. Once I have feedback on that I'll check on the tests.

- [x] Awaiting initial feedback
- [x] Tests passing in `foam-core`
- [x] Tests passing in `foam-vscode`

