### PR TITLE
Fix daily note path by using normalized path

### DIFF
--- a/packages/foam-vscode/src/dated-notes.ts
+++ b/packages/foam-vscode/src/dated-notes.ts
@@ -24,7 +24,7 @@ async function openDailyNoteFor(date?: Date) {
   await focusNote(dailyNotePath, isNew);
 }
 function getDailyNotePath(configuration: WorkspaceConfiguration, date: Date) {
-  const rootDirectory = workspace.workspaceFolders[0].uri.path;
+  const rootDirectory = workspace.workspaceFolders[0].uri.fsPath;
   const dailyNoteDirectory: string =
     configuration.get("openDailyNote.directory") ?? ".";
   const dailyNoteFilename = getDailyNoteFileName(configuration, date);


### PR DESCRIPTION
`Uri.path` returns an OS-dependent path. On Windows, this was coming back with a `/` at the beginning which, when resolved, would converts paths like:

```
/c:/path/to/file.md
```

to

```
/C:/c:/path/to/file.md
```

`Uri.fsPath` returns an OS-independent path which does not add an additional slash and works correctly with the `path` module.

Fixes #405 