### PR TITLE
Remove extension in dated snippets

### DIFF
--- a/packages/foam-vscode/src/features/open-dated-note.ts
+++ b/packages/foam-vscode/src/features/open-dated-note.ts
@@ -14,7 +14,6 @@ import {
   openDailyNoteFor,
   getDailyNotePath
 } from "../dated-notes";
-import { LinkReferenceDefinitionsSetting } from "../settings";
 import { FoamFeature } from "../types";
 
 interface DateSnippet {
@@ -34,7 +33,6 @@ const daysOfWeek = [
 ];
 type AfterCompletionOptions = "noop" | "createNote" | "navigateToNote";
 const foamConfig = workspace.getConfiguration("foam");
-const foamExtension = foamConfig.get("openDailyNote.fileExtension");
 const foamNavigateOnSelect: AfterCompletionOptions = foamConfig.get(
   "dateSnippets.afterCompletion"
 );
@@ -76,17 +74,9 @@ const createCompletionItem = ({ snippet, date, detail }: DateSnippet) => {
 };
 
 const getDailyNoteLink = (date: Date) => {
-  const foamLinkReferenceDefinitions = foamConfig.get(
-    "edit.linkReferenceDefinitions"
-  );
-  let name = getDailyNoteFileName(foamConfig, date);
-  if (
-    foamLinkReferenceDefinitions ===
-    LinkReferenceDefinitionsSetting.withoutExtensions
-  ) {
-    name = name.replace(`.${foamExtension}`, "");
-  }
-  return `[[${name}]]`;
+  const foamExtension = foamConfig.get("openDailyNote.fileExtension");
+  const name = getDailyNoteFileName(foamConfig, date);
+  return `[[${name.replace(`.${foamExtension}`, "")}]]`;
 };
 
 const snippets: (() => DateSnippet)[] = [

--- a/packages/foam-vscode/src/features/open-dated-note.ts
+++ b/packages/foam-vscode/src/features/open-dated-note.ts
@@ -35,9 +35,6 @@ const daysOfWeek = [
 type AfterCompletionOptions = "noop" | "createNote" | "navigateToNote";
 const foamConfig = workspace.getConfiguration("foam");
 const foamExtension = foamConfig.get("openDailyNote.fileExtension");
-const foamLinkReferenceDefinitions = foamConfig.get(
-  "edit.linkReferenceDefinitions"
-);
 const foamNavigateOnSelect: AfterCompletionOptions = foamConfig.get(
   "dateSnippets.afterCompletion"
 );
@@ -79,6 +76,9 @@ const createCompletionItem = ({ snippet, date, detail }: DateSnippet) => {
 };
 
 const getDailyNoteLink = (date: Date) => {
+  const foamLinkReferenceDefinitions = foamConfig.get(
+    "edit.linkReferenceDefinitions"
+  );
   let name = getDailyNoteFileName(foamConfig, date);
   if (
     foamLinkReferenceDefinitions ===


### PR DESCRIPTION
Fixes a bug where changing `foam.edit.linkReferenceDefinitions` would not change the way that dated snippets expand.

## Repro

1. Assume `"foam.edit.linkReferenceDefinitions": "withExtensions"`
2. `/today` expands to `[[2020-12-28.md]]`
3. Change to `"foam.edit.linkReferenceDefinitions": "withoutExtensions"`

## Expected

`/today` expands to `[[2020-12-28]]`

## Actual

`/today` still expands to `[[2020-12-28.md]]`

This will be true until the extension is restarted.

## Changes from PR

Fixes this problem by pulling from the config every time a daily note link is generated