### PR TITLE
Fallback to word-based suggestions when not triggered by trigger character

### DIFF
--- a/packages/foam-vscode/src/features/open-dated-note.ts
+++ b/packages/foam-vscode/src/features/open-dated-note.ts
@@ -6,7 +6,8 @@ import {
   CompletionItemProvider,
   CompletionItem,
   CompletionItemKind,
-  CompletionList
+  CompletionList,
+  CompletionTriggerKind
 } from "vscode";
 import {
   createDailyNoteIfNotExists,
@@ -171,6 +172,12 @@ const computedSnippets: ((number: number) => DateSnippet)[] = [
 
 const completions: CompletionItemProvider = {
   provideCompletionItems: (_document, _position, _token, _context) => {
+    if (_context.triggerKind === CompletionTriggerKind.Invoke) {
+      // if completion was triggered without trigger character then we return [] to fallback
+      // to vscode word-based suggestions (see https://github.com/foambubble/foam/pull/417)
+      return [];
+    }
+
     const completionItems = [
       ...snippets.map(item => createCompletionItem(item())),
       ...generateDayOfWeekSnippets().map(item => createCompletionItem(item))
@@ -181,6 +188,12 @@ const completions: CompletionItemProvider = {
 
 const computedCompletions: CompletionItemProvider = {
   provideCompletionItems: (document, position, _token, _context) => {
+    if (_context.triggerKind === CompletionTriggerKind.Invoke) {
+      // if completion was triggered without trigger character then we return [] to fallback
+      // to vscode word-based suggestions (see https://github.com/foambubble/foam/pull/417)
+      return [];
+    }
+
     const range = document.getWordRangeAtPosition(position, /\S+/);
     const snippetString = document.getText(range);
     const matches = snippetString.match(/(\d+)/);


### PR DESCRIPTION
Fixes #415 

So this is somewhat of an open issue with vscode discussed here: https://github.com/Microsoft/vscode/issues/21611

The TLDR is that currently you have to return undefined or an empty array for suggestions in order for vscode to fallback to word-based suggestions, which is what other markdown extensions I looked at do.

Since all of our snippets start with `/` I assume our intent is to primarily show them as suggestions when the user starts typing a `/` (or `+` for the computed snippets). Since this is handled with the trigger characters we specify, a simple solution for us is to only return suggestions if triggered by trigger character instead of during normal typing of words.

This change means that if a user starts typing `/yes` they will see the suggestion for the `/yesterday` snippet but not if they just `yes` or `yesterday`.

Let me know your thoughts.