### PR TITLE
Added support for direct links

### DIFF
--- a/packages/foam-core/src/markdown-provider.ts
+++ b/packages/foam-core/src/markdown-provider.ts
@@ -11,7 +11,12 @@ import os from 'os';
 import { NoteGraphAPI } from './model/note-graph';
 import { NoteLinkDefinition, Note, NoteParser } from './model/note';
 import { dropExtension, extractHashtags, extractTagsFromProp } from './utils';
-import { uriToSlug, computeRelativePath, getBasename } from './utils/uri';
+import {
+  uriToSlug,
+  computeRelativePath,
+  getBasename,
+  parseUri,
+} from './utils/uri';
 import { ParserPlugin } from './plugins';
 import { Logger } from './utils/log';
 import { URI } from './common/uri';
@@ -74,15 +79,16 @@ const wikilinkPlugin: ParserPlugin = {
     }
     if (node.type === 'link') {
       const targetUri = (node as any).url;
-      const uri = URI.parse(targetUri);
-      if (uri.scheme === 'file') {
-        const label = getTextFromChildren(node);
-        note.links.push({
-          type: 'link',
-          target: targetUri,
-          label: label,
-        });
+      const uri = parseUri(note.uri, targetUri);
+      if (uri.scheme !== 'file' || uri.path === note.uri.path) {
+        return;
       }
+      const label = getTextFromChildren(node);
+      note.links.push({
+        type: 'link',
+        target: targetUri,
+        label: label,
+      });
     }
   },
 };

--- a/packages/foam-core/src/markdown-provider.ts
+++ b/packages/foam-core/src/markdown-provider.ts
@@ -11,15 +11,26 @@ import os from 'os';
 import { NoteGraphAPI } from './model/note-graph';
 import { NoteLinkDefinition, Note, NoteParser } from './model/note';
 import { dropExtension, extractHashtags, extractTagsFromProp } from './utils';
-import {
-  uriToSlug,
-  computeRelativePath,
-  getBasename,
-  parseUri,
-} from './utils/uri';
+import { uriToSlug, computeRelativePath, getBasename } from './utils/uri';
 import { ParserPlugin } from './plugins';
 import { Logger } from './utils/log';
 import { URI } from './common/uri';
+
+/**
+ * Traverses all the children of the given node, extracts
+ * the text from them, and returns it concatenated.
+ *
+ * @param root the node from which to start collecting text
+ */
+const getTextFromChildren = (root: Node): string => {
+  let text = '';
+  visit(root, 'text', node => {
+    if (node.type === 'text') {
+      text = text + node.value;
+    }
+  });
+  return text;
+};
 
 const tagsPlugin: ParserPlugin = {
   name: 'tags',
@@ -49,16 +60,6 @@ const titlePlugin: ParserPlugin = {
       note.title = getBasename(note.uri);
     }
   },
-};
-
-const getTextFromChildren = (root: Node): string => {
-  let text = '';
-  visit(root, 'text', node => {
-    if (node.type === 'text') {
-      text = text + node.value;
-    }
-  });
-  return text;
 };
 
 const wikilinkPlugin: ParserPlugin = {

--- a/packages/foam-core/src/markdown-provider.ts
+++ b/packages/foam-core/src/markdown-provider.ts
@@ -1,3 +1,4 @@
+import { Node } from 'unist';
 import unified from 'unified';
 import markdownParse from 'remark-parse';
 import wikiLinkPlugin from 'remark-wiki-link';
@@ -50,6 +51,16 @@ const titlePlugin: ParserPlugin = {
   },
 };
 
+const getTextFromChildren = (root: Node): string => {
+  let text = '';
+  visit(root, 'text', node => {
+    if (node.type === 'text') {
+      text = text + node.value;
+    }
+  });
+  return text;
+};
+
 const wikilinkPlugin: ParserPlugin = {
   name: 'wikilink',
   visit: (node, note) => {
@@ -62,7 +73,7 @@ const wikilinkPlugin: ParserPlugin = {
     }
     if (node.type === 'link') {
       const targetUri = (node as any).url;
-      const label = (node as any).children[0].value;
+      const label = getTextFromChildren(node);
       note.links.push({
         type: 'link',
         target: targetUri,

--- a/packages/foam-core/src/markdown-provider.ts
+++ b/packages/foam-core/src/markdown-provider.ts
@@ -74,12 +74,15 @@ const wikilinkPlugin: ParserPlugin = {
     }
     if (node.type === 'link') {
       const targetUri = (node as any).url;
-      const label = getTextFromChildren(node);
-      note.links.push({
-        type: 'link',
-        target: targetUri,
-        label: label,
-      });
+      const uri = URI.parse(targetUri);
+      if (uri.scheme === 'file') {
+        const label = getTextFromChildren(node);
+        note.links.push({
+          type: 'link',
+          target: targetUri,
+          label: label,
+        });
+      }
     }
   },
 };

--- a/packages/foam-core/src/model/note.ts
+++ b/packages/foam-core/src/model/note.ts
@@ -15,8 +15,13 @@ export interface WikiLink {
   position: Position;
 }
 
-// at the moment we only model wikilink
-export type NoteLink = WikiLink;
+export interface DirectLink {
+  type: 'link';
+  label: string;
+  target: string;
+}
+
+export type NoteLink = WikiLink | DirectLink;
 
 export interface NoteLinkDefinition {
   label: string;

--- a/packages/foam-core/src/utils/uri.ts
+++ b/packages/foam-core/src/utils/uri.ts
@@ -35,3 +35,19 @@ export const computeRelativeURI = (
     path: posix.join(posix.dirname(reference.path), slug),
   });
 };
+
+/**
+ * Parses a URI from value, taking into consideration possible relative paths.
+ *
+ * @param reference the URI to use as reference in case value is a relative path
+ * @param value the value to parse for a URI
+ * @returns the URI from the given value. In case of a relative path, the URI will take into account
+ * the reference from which it is computed
+ */
+export const parseUri = (reference: URI, value: string): URI => {
+  let uri = URI.parse(value);
+  if (uri.scheme === 'file' && !value.startsWith('/')) {
+    uri = computeRelativeURI(reference, value);
+  }
+  return uri;
+};

--- a/packages/foam-core/src/utils/uri.ts
+++ b/packages/foam-core/src/utils/uri.ts
@@ -47,7 +47,13 @@ export const computeRelativeURI = (
 export const parseUri = (reference: URI, value: string): URI => {
   let uri = URI.parse(value);
   if (uri.scheme === 'file' && !value.startsWith('/')) {
-    uri = computeRelativeURI(reference, value);
+    const [path, fragment] = value.split('#');
+    uri = path.length > 0 ? computeRelativeURI(reference, path) : reference;
+    if (fragment) {
+      uri = uri.with({
+        fragment: fragment,
+      });
+    }
   }
   return uri;
 };

--- a/packages/foam-core/test/markdown-provider.test.ts
+++ b/packages/foam-core/test/markdown-provider.test.ts
@@ -59,24 +59,20 @@ describe('Markdown loader', () => {
     ).toEqual(['page-a', 'page-b', 'page-c', 'page-d', 'page-e']);
   });
 
-  it('Parses external links correctly', () => {
+  it('Ingores external links', () => {
     const note = createNoteFromMarkdown(
       '/path/to/page-a.md',
       `
 this is a [link to google](https://www.google.com)
 `
     );
-    expect(note.links.length).toEqual(1);
-    const link = note.links[0] as DirectLink;
-    expect(link.type).toEqual('link');
-    expect(link.label).toEqual('link to google');
-    expect(link.target).toEqual('https://www.google.com');
+    expect(note.links.length).toEqual(0);
   });
 
-  it('Parses relative internal links correctly', () => {
+  it('Parses internal links correctly', () => {
     const note = createNoteFromMarkdown(
       '/path/to/page-a.md',
-      'this is a relative [link to page b](../doc/page-b.md)'
+      'this is a [link to page b](../doc/page-b.md)'
     );
     expect(note.links.length).toEqual(1);
     const link = note.links[0] as DirectLink;
@@ -88,13 +84,13 @@ this is a [link to google](https://www.google.com)
   it('Parses links that have formatting in label', () => {
     const note = createNoteFromMarkdown(
       '/path/to/page-a.md',
-      'this is [**link** with __formatting__](https://github.com/)'
+      'this is [**link** with __formatting__](../doc/page-b.md)'
     );
     expect(note.links.length).toEqual(1);
     const link = note.links[0] as DirectLink;
     expect(link.type).toEqual('link');
     expect(link.label).toEqual('link with formatting');
-    expect(link.target).toEqual('https://github.com/');
+    expect(link.target).toEqual('../doc/page-b.md');
   });
 
   it('Parses wikilinks correctly', () => {

--- a/packages/foam-core/test/markdown-provider.test.ts
+++ b/packages/foam-core/test/markdown-provider.test.ts
@@ -2,6 +2,7 @@ import {
   createMarkdownParser,
   createMarkdownReferences,
 } from '../src/markdown-provider';
+import { DirectLink } from '../src/model/note';
 import { NoteGraph } from '../src/model/note-graph';
 import { ParserPlugin } from '../src/plugins';
 import { URI } from '../src/common/uri';
@@ -56,6 +57,32 @@ describe('Markdown loader', () => {
         .map(uriToSlug)
         .sort()
     ).toEqual(['page-a', 'page-b', 'page-c', 'page-d', 'page-e']);
+  });
+
+  it('Parses external links correctly', () => {
+    const note = createNoteFromMarkdown(
+      '/path/to/page-a.md',
+      `
+this is a [link to google](https://www.google.com)
+`
+    );
+    expect(note.links.length).toEqual(1);
+    const link = note.links[0] as DirectLink;
+    expect(link.type).toEqual('link');
+    expect(link.label).toEqual('link to google');
+    expect(link.target).toEqual('https://www.google.com');
+  });
+
+  it('Parses relative internal links correctly', () => {
+    const note = createNoteFromMarkdown(
+      '/path/to/page-a.md',
+      'this is a relative [link to page b](../doc/page-b.md)'
+    );
+    expect(note.links.length).toEqual(1);
+    const link = note.links[0] as DirectLink;
+    expect(link.type).toEqual('link');
+    expect(link.label).toEqual('link to page b');
+    expect(link.target).toEqual('../doc/page-b.md');
   });
 
   it('Parses wikilinks correctly', () => {

--- a/packages/foam-core/test/markdown-provider.test.ts
+++ b/packages/foam-core/test/markdown-provider.test.ts
@@ -69,6 +69,16 @@ this is a [link to google](https://www.google.com)
     expect(note.links.length).toEqual(0);
   });
 
+  it('Ignores references to sections in the same file', () => {
+    const note = createNoteFromMarkdown(
+      '/path/to/page-a.md',
+      `
+this is a [link to intro](#introduction)
+`
+    );
+    expect(note.links.length).toEqual(0);
+  });
+
   it('Parses internal links correctly', () => {
     const note = createNoteFromMarkdown(
       '/path/to/page-a.md',

--- a/packages/foam-core/test/markdown-provider.test.ts
+++ b/packages/foam-core/test/markdown-provider.test.ts
@@ -85,6 +85,18 @@ this is a [link to google](https://www.google.com)
     expect(link.target).toEqual('../doc/page-b.md');
   });
 
+  it('Parses links that have formatting in label', () => {
+    const note = createNoteFromMarkdown(
+      '/path/to/page-a.md',
+      'this is [**link** with __formatting__](https://github.com/)'
+    );
+    expect(note.links.length).toEqual(1);
+    const link = note.links[0] as DirectLink;
+    expect(link.type).toEqual('link');
+    expect(link.label).toEqual('link with formatting');
+    expect(link.target).toEqual('https://github.com/');
+  });
+
   it('Parses wikilinks correctly', () => {
     const graph = new NoteGraph();
     const noteA = graph.setNote(createNoteFromMarkdown('/page-a.md', pageA));

--- a/packages/foam-core/test/utils.test.ts
+++ b/packages/foam-core/test/utils.test.ts
@@ -4,6 +4,7 @@ import {
   hashURI,
   computeRelativeURI,
   extractHashtags,
+  parseUri,
 } from '../src/utils';
 import { URI } from '../src/common/uri';
 import { Logger } from '../src/utils/log';
@@ -49,6 +50,27 @@ describe('URI utils', () => {
     expect(
       computeRelativeURI(URI.file('/my/file.markdown'), '../hello')
     ).toEqual(URI.file('/hello.markdown'));
+  });
+
+  describe('URI parsing', () => {
+    const base = URI.file('/path/to/file.md');
+    test.each([
+      ['https://www.google.com', URI.parse('https://www.google.com')],
+      ['/path/to/a/file.md', URI.file('/path/to/a/file.md')],
+      ['../relative/file.md', URI.file('/path/relative/file.md')],
+      ['#section', base.with({ fragment: 'section' })],
+      [
+        '../relative/file.md#section',
+        URI.parse('file:/path/relative/file.md#section'),
+      ],
+    ])('URI Parsing (%s) - %s', (input, exp) => {
+      const result = parseUri(base, input);
+      expect(result.scheme).toEqual(exp.scheme);
+      expect(result.authority).toEqual(exp.authority);
+      expect(result.path).toEqual(exp.path);
+      expect(result.query).toEqual(exp.query);
+      expect(result.fragment).toEqual(exp.fragment);
+    });
   });
 });
 

--- a/packages/foam-vscode/src/features/dataviz.ts
+++ b/packages/foam-vscode/src/features/dataviz.ts
@@ -68,7 +68,10 @@ function generateGraphData(foam: Foam) {
           id: link.to,
           type: "nonExistingNote",
           uri: `virtual:${link.to}`,
-          title: cutTitle(link.link.slug)
+          title:
+            "slug" in link.link
+              ? cutTitle(link.link.slug)
+              : cutTitle(link.link.label)
         };
       }
       graph.edges.add({

--- a/packages/foam-vscode/src/features/dataviz.ts
+++ b/packages/foam-vscode/src/features/dataviz.ts
@@ -118,7 +118,6 @@ async function createGraphPanel(foam: Foam, context: vscode.ExtensionContext) {
           const noteUri = vscode.Uri.parse(message.payload);
           const selectedNote = foam.notes.getNote(noteUri);
 
-          const doc = await vscode.workspace.openTextDocument(
           if (isSome(selectedNote)) {
             const doc = await vscode.workspace.openTextDocument(
               selectedNote.uri.path // vscode doesn't recognize the URI directly

--- a/packages/foam-vscode/src/features/dataviz.ts
+++ b/packages/foam-vscode/src/features/dataviz.ts
@@ -119,9 +119,12 @@ async function createGraphPanel(foam: Foam, context: vscode.ExtensionContext) {
           const selectedNote = foam.notes.getNote(noteUri);
 
           const doc = await vscode.workspace.openTextDocument(
-            selectedNote.uri.path // vscode doesn't recognize the URI directly
-          );
-          vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
+          if (isSome(selectedNote)) {
+            const doc = await vscode.workspace.openTextDocument(
+              selectedNote.uri.path // vscode doesn't recognize the URI directly
+            );
+            vscode.window.showTextDocument(doc, vscode.ViewColumn.One);
+          }
           break;
 
         case "error":


### PR DESCRIPTION
After this PR, connections between notes can be expressed both as `[[wikilink]` and as a regular link to the file `[link](path/to/file.md)`