### PR TITLE
Fixes typo in recipe docs that I added

### DIFF
--- a/docs/recipes/recipes.md
+++ b/docs/recipes/recipes.md
@@ -82,7 +82,7 @@ A #recipe is a guide, tip or strategy for getting the most out of your Foam work
 ## Workflow
 
 - Capture notes from Drafts app on iOS [[capture-notes-with-drafts-pro]]
-- Capture notes from iOS Shortcuts [[capture-notes-with-shortcuts-and-github-actions.md]]
+- Capture notes from iOS Shortcuts [[capture-notes-with-shortcuts-and-github-actions]]
 
 ## Creative ideas
 


### PR DESCRIPTION
https://github.com/foambubble/foam/pull/430 had a typo that broke the link to my recipe. 

![image](https://user-images.githubusercontent.com/2637602/103800662-e9a89780-5009-11eb-8048-879853e61285.png)
