### PR TITLE
Add custom graph styling support 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,6 @@
         "**/node_modules/**/*"
     ],
     "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.formatOnSave": true,
+    // "editor.formatOnSave": true,
     "prettier.requireConfig": true
 }

--- a/docs/features/graph-visualisation.md
+++ b/docs/features/graph-visualisation.md
@@ -7,10 +7,28 @@ The graph will:
 - to navigate to a note by clicking on it while pressing `CTRL` or `CMD`
 - automatically center the graph on the currently edited note, to immediately see it's connections
 
+## Custom Graph Styles
+
+Currently, custom graph styles are supported through the `foam.graph.style` setting.
+
+![Graph style demo](../assets/images/graph-style.gif)
+
+A sample configuration object is provided below:
+
+```json
+"background": "#202020",
+"fontSize": 12,
+"highlightedForeground": "#f9c74f",
+"node": {
+    "note": "#277da1",
+    "placeholder": "#545454",
+    "unknown": "#f94144"
+}
+```
+
 ### Markdown Links
 Another extension that provides a great graph visualisation is [Markdown Links](https://marketplace.visualstudio.com/items?itemName=tchayen.markdown-links).
 The extension doesn't use the Foam model, so discrepancies might arise, but it's a great visualisation extension nonetheless!
 
 - Use the `Markdown Links: Show Graph` command to see the graph
 ![Demo of graph visualiser](../assets/images/foam-navigation-demo.gif)
-

--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -156,6 +156,20 @@
           "type": "number",
           "default": 24,
           "description": "The maximum title length before being abbreviated. Set to 0 or less to disable."
+        },
+        "foam.graph.customStyle": {
+          "type": "object",
+          "description": "Custom graph styling settings.",
+          "default": {
+            "background": "#202020",
+            "fontSize": 12,
+            "highlightedForeground": "#f9c74f",
+            "node": {
+              "note": "#277da1",
+              "nonExistingNote": "#545454",
+              "unknown": "#f94144"
+            }
+          }
         }
       }
     },

--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -160,16 +160,7 @@
         "foam.graph.customStyle": {
           "type": "object",
           "description": "Custom graph styling settings.",
-          "default": {
-            "background": "#202020",
-            "fontSize": 12,
-            "highlightedForeground": "#f9c74f",
-            "node": {
-              "note": "#277da1",
-              "nonExistingNote": "#545454",
-              "unknown": "#f94144"
-            }
-          }
+          "default": {}
         }
       }
     },

--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -159,7 +159,7 @@
         },
         "foam.graph.style": {
           "type": "object",
-          "description": "Graph styling settings.",
+          "description": "Custom graph styling settings. An example is present in the documentation.",
           "default": {}
         }
       }

--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -157,9 +157,9 @@
           "default": 24,
           "description": "The maximum title length before being abbreviated. Set to 0 or less to disable."
         },
-        "foam.graph.customStyle": {
+        "foam.graph.style": {
           "type": "object",
-          "description": "Custom graph styling settings.",
+          "description": "Graph styling settings.",
           "default": {}
         }
       }

--- a/packages/foam-vscode/src/features/dataviz.ts
+++ b/packages/foam-vscode/src/features/dataviz.ts
@@ -7,11 +7,11 @@ import { getGraphStyle, getTitleMaxLength } from "../settings";
 import { isSome } from "../utils";
 
 const feature: FoamFeature = {
-  activate: async (context: vscode.ExtensionContext, foamPromise: Promise<Foam>) => {
-    const foam = await foamPromise;
-    const panel = await createGraphPanel(foam, context);
+  activate: (context: vscode.ExtensionContext, foamPromise: Promise<Foam>) => {
 
     vscode.workspace.onDidChangeConfiguration(async event => {
+      const foam = await foamPromise;
+      const panel = await createGraphPanel(foam, context);
       if (event.affectsConfiguration('foam.graph.style')) {
         const style = getGraphStyle();
         panel.webview.postMessage({
@@ -22,6 +22,8 @@ const feature: FoamFeature = {
     });
 
     vscode.commands.registerCommand("foam-vscode.show-graph", async () => {
+      const foam = await foamPromise;
+      const panel = await createGraphPanel(foam, context);
       const onFoamChanged = _ => {
         updateGraph(panel, foam);
       };

--- a/packages/foam-vscode/src/features/dataviz.ts
+++ b/packages/foam-vscode/src/features/dataviz.ts
@@ -112,7 +112,6 @@ async function createGraphPanel(foam: Foam, context: vscode.ExtensionContext) {
       switch (message.type) {
         case "webviewStyleRequest":
           const style = getGraphStyle();
-          console.log(style)
           panel.webview.postMessage({
             type: "didUpdateStyle",
             payload: style,

--- a/packages/foam-vscode/src/features/dataviz.ts
+++ b/packages/foam-vscode/src/features/dataviz.ts
@@ -77,7 +77,7 @@ function generateGraphData(foam: Foam) {
       if (!(link.to.path in graph.nodes)) {
         graph.nodes[link.to.path] = {
           id: link.to,
-          type: "nonExistingNote",
+          type: "placeholder",
           uri: `virtual:${link.to}`,
           title:
             "slug" in link.link

--- a/packages/foam-vscode/src/features/dataviz.ts
+++ b/packages/foam-vscode/src/features/dataviz.ts
@@ -8,10 +8,8 @@ import { isSome } from "../utils";
 
 const feature: FoamFeature = {
   activate: (context: vscode.ExtensionContext, foamPromise: Promise<Foam>) => {
-
+    let panel: vscode.WebviewPanel | undefined = undefined;
     vscode.workspace.onDidChangeConfiguration(async event => {
-      const foam = await foamPromise;
-      const panel = await createGraphPanel(foam, context);
       if (event.affectsConfiguration('foam.graph.style')) {
         const style = getGraphStyle();
         panel.webview.postMessage({
@@ -23,7 +21,7 @@ const feature: FoamFeature = {
 
     vscode.commands.registerCommand("foam-vscode.show-graph", async () => {
       const foam = await foamPromise;
-      const panel = await createGraphPanel(foam, context);
+      panel = await createGraphPanel(foam, context);
       const onFoamChanged = _ => {
         updateGraph(panel, foam);
       };
@@ -35,6 +33,7 @@ const feature: FoamFeature = {
         noteAddedListener.dispose();
         noteUpdatedListener.dispose();
         noteDeletedListener.dispose();
+        panel = undefined;
       });
 
       vscode.window.onDidChangeActiveTextEditor(e => {

--- a/packages/foam-vscode/src/features/dataviz.ts
+++ b/packages/foam-vscode/src/features/dataviz.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 import { FoamFeature } from "../types";
 import { Foam, Logger } from "foam-core";
 import { TextDecoder } from "util";
-import { getTitleMaxLength } from "../settings";
+import { getGraphStyle, getTitleMaxLength } from "../settings";
 import { isSome } from "../utils";
 
 const feature: FoamFeature = {
@@ -110,6 +110,15 @@ async function createGraphPanel(foam: Foam, context: vscode.ExtensionContext) {
   panel.webview.onDidReceiveMessage(
     async message => {
       switch (message.type) {
+        case "webviewStyleRequest":
+          const style = getGraphStyle();
+          console.log(style)
+          panel.webview.postMessage({
+            type: "graphStyle",
+            payload: style,
+          });
+          break;
+
         case "webviewDidLoad":
           updateGraph(panel, foam);
           break;

--- a/packages/foam-vscode/src/features/dataviz.ts
+++ b/packages/foam-vscode/src/features/dataviz.ts
@@ -121,14 +121,6 @@ async function createGraphPanel(foam: Foam, context: vscode.ExtensionContext) {
   panel.webview.onDidReceiveMessage(
     async message => {
       switch (message.type) {
-        case "webviewStyleRequest":
-          const style = getGraphStyle();
-          panel.webview.postMessage({
-            type: "didUpdateStyle",
-            payload: style,
-          });
-          break;
-
         case "webviewDidLoad":
           const styles = getGraphStyle();
           panel.webview.postMessage({

--- a/packages/foam-vscode/src/features/dataviz.ts
+++ b/packages/foam-vscode/src/features/dataviz.ts
@@ -114,7 +114,7 @@ async function createGraphPanel(foam: Foam, context: vscode.ExtensionContext) {
           const style = getGraphStyle();
           console.log(style)
           panel.webview.postMessage({
-            type: "graphStyle",
+            type: "didUpdateStyle",
             payload: style,
           });
           break;

--- a/packages/foam-vscode/src/features/dataviz.ts
+++ b/packages/foam-vscode/src/features/dataviz.ts
@@ -9,7 +9,7 @@ import { isSome } from "../utils";
 const feature: FoamFeature = {
   activate: (context: vscode.ExtensionContext, foamPromise: Promise<Foam>) => {
     let panel: vscode.WebviewPanel | undefined = undefined;
-    vscode.workspace.onDidChangeConfiguration(async event => {
+    vscode.workspace.onDidChangeConfiguration(event => {
       if (event.affectsConfiguration('foam.graph.style')) {
         const style = getGraphStyle();
         panel.webview.postMessage({

--- a/packages/foam-vscode/src/settings.ts
+++ b/packages/foam-vscode/src/settings.ts
@@ -31,7 +31,7 @@ export function getTitleMaxLength(): number {
 
 /** Retrive the graph's style object */
 export function getGraphStyle(): object {
-  return workspace.getConfiguration('foam.graph').get('customStyle');
+  return workspace.getConfiguration('foam.graph').get('style');
 }
 
 export function getFoamLoggerLevel(): LogLevel {

--- a/packages/foam-vscode/src/settings.ts
+++ b/packages/foam-vscode/src/settings.ts
@@ -26,7 +26,12 @@ export function getIgnoredFilesSetting(): GlobPattern[] {
 
 /** Retrieves the maximum length for a Graph node title. */
 export function getTitleMaxLength(): number {
-  return workspace.getConfiguration("foam.graph").get("titleMaxLength");
+  return workspace.getConfiguration('foam.graph').get('titleMaxLength');
+}
+
+/** Retrive the graph's style object */
+export function getGraphStyle(): object {
+  return workspace.getConfiguration('foam.graph').get('customStyle');
 }
 
 export function getFoamLoggerLevel(): LogLevel {

--- a/packages/foam-vscode/src/settings.ts
+++ b/packages/foam-vscode/src/settings.ts
@@ -1,17 +1,17 @@
-import { workspace, GlobPattern } from "vscode";
-import { LogLevel } from "foam-core";
+import { workspace, GlobPattern } from 'vscode';
+import { LogLevel } from 'foam-core';
 
 export enum LinkReferenceDefinitionsSetting {
-  withExtensions = "withExtensions",
-  withoutExtensions = "withoutExtensions",
-  off = "off"
+  withExtensions = 'withExtensions',
+  withoutExtensions = 'withoutExtensions',
+  off = 'off',
 }
 
 export function getWikilinkDefinitionSetting(): LinkReferenceDefinitionsSetting {
   return workspace
-    .getConfiguration("foam.edit")
+    .getConfiguration('foam.edit')
     .get<LinkReferenceDefinitionsSetting>(
-      "linkReferenceDefinitions",
+      'linkReferenceDefinitions',
       LinkReferenceDefinitionsSetting.withoutExtensions
     );
 }
@@ -19,8 +19,8 @@ export function getWikilinkDefinitionSetting(): LinkReferenceDefinitionsSetting 
 /** Retrieve the list of file ignoring globs. */
 export function getIgnoredFilesSetting(): GlobPattern[] {
   return [
-    ...workspace.getConfiguration().get("foam.files.ignore", []),
-    ...Object.keys(workspace.getConfiguration().get("files.exclude", {}))
+    ...workspace.getConfiguration().get('foam.files.ignore', []),
+    ...Object.keys(workspace.getConfiguration().get('files.exclude', {})),
   ];
 }
 
@@ -35,5 +35,5 @@ export function getGraphStyle(): object {
 }
 
 export function getFoamLoggerLevel(): LogLevel {
-  return workspace.getConfiguration("foam.logging").get("level") ?? "info";
+  return workspace.getConfiguration('foam.logging').get('level') ?? 'info';
 }

--- a/packages/foam-vscode/static/graphs/default/graph.js
+++ b/packages/foam-vscode/static/graphs/default/graph.js
@@ -340,6 +340,7 @@ try {
         vscode.postMessage({
           type: "webviewDidLoad"
         });
+        break;
     }
   });
 } catch {

--- a/packages/foam-vscode/static/graphs/default/graph.js
+++ b/packages/foam-vscode/static/graphs/default/graph.js
@@ -328,7 +328,7 @@ try {
           Actions.selectNode(noteId);
         }
         break;
-      case "graphStyle":
+      case "didUpdateStyle":
         const style = message.payload;
         updateStyle(style);
         initDataviz(vscode);

--- a/packages/foam-vscode/static/graphs/default/graph.js
+++ b/packages/foam-vscode/static/graphs/default/graph.js
@@ -7,7 +7,7 @@ const styleFallback = {
   highlightedForeground: "#f9c74f",
   node: {
     note: "#277da1",
-    nonExistingNote: "#545454",
+    placeholder: "#545454",
     unknown: "#f94144"
   }
 };
@@ -51,8 +51,8 @@ let model = {
     node: {
       note: getStyle("--vscode-editor-foreground")
         ?? styleFallback.node.note,
-      nonExistingNote: getStyle("--vscode-list-deemphasizedForeground")
-        ?? styleFallback.node.nonExistingNote,
+      placeholder: getStyle("--vscode-list-deemphasizedForeground")
+        ?? styleFallback.node.placeholder,
       unknown: getStyle("--vscode-editor-foreground")
         ?? styleFallback.node.unknown
     }
@@ -152,9 +152,9 @@ const Actions = {
         note: newStyle.node?.note
           ?? getStyle("--vscode-editor-foreground")
           ?? styleFallback.node.note,
-        nonExistingNote: newStyle.node?.nonExistingNote
+        placeholder: newStyle.node?.placeholder
           ?? getStyle("--vscode-list-deemphasizedForeground")
-          ?? styleFallback.node.nonExistingNote,
+          ?? styleFallback.node.placeholder,
         unknown: newStyle.node?.unknown
           ?? getStyle("--vscode-editor-foreground")
           ?? styleFallback.node.unknow,

--- a/packages/foam-vscode/static/graphs/default/graph.js
+++ b/packages/foam-vscode/static/graphs/default/graph.js
@@ -41,22 +41,15 @@ function updateStyle(newStyle) {
   if (!newStyle) {
     return;
   }
-  let node = style.node;
-  if (newStyle.node !== undefined
-    && newStyle.node !== null
-    && JSON.stringify(newStyle.node) !== JSON.stringify({})
-  ) {
-    node = {
-      note: newStyle.node.note ?? style.node.note,
-      nonExistingNote: newStyle.node.nonExistingNote ?? style.node.nonExistingNote,
-      unknown: newStyle.node.unknown ?? style.node.unknown,
-    }
-  }
   style = {
     background: newStyle.background ?? style.background,
     fontSize: newStyle.fontSize ?? style.fontSize,
     highlightedForeground: newStyle.highlightedForeground ?? style.highlightedForeground,
-    node: node,
+    node: {
+      note: newStyle.node?.note ?? style.node.note,
+      nonExistingNote: newStyle.node?.nonExistingNote ?? style.node.nonExistingNote,
+      unknown: newStyle.node?.unknown ?? style.node.unknown,
+    },
   }
 }
 

--- a/packages/foam-vscode/static/graphs/default/graph.js
+++ b/packages/foam-vscode/static/graphs/default/graph.js
@@ -293,7 +293,6 @@ try {
   const vscode = acquireVsCodeApi();
 
   window.onload = () => {
-    console.log("post webviewStyleRequest");
     vscode.postMessage({
       type: "webviewStyleRequest",
     });
@@ -332,7 +331,6 @@ try {
       case "graphStyle":
         const style = message.payload;
         updateStyle(style);
-        console.log("received graphStyle message");
         initDataviz(vscode);
         console.log("ready");
         vscode.postMessage({


### PR DESCRIPTION
This PR addresses #436 

The implementation makes use of the webview communication mechanism to
switch messages between the webview and the graph.
It works as follows:

- When the webview is loaded, it now sends a single request to VSCode,
the request asks VSCode for the graph style
- When VSCode answers with the style, the graph style is updated and
the webview loading process continues as normal.

The style change does not modify the API, in fact it makes use of the
shadiest programming tatic ever, *global variables* to remain
compatible.

The style object *currently* supports four base fields:
- background: string
- fontSize: int
- highlightedForeground: string
- node: object
  - note: string
  - nonExistingNote: string
  - unknown: string

For an *ugly* example, see below:
![image](https://user-images.githubusercontent.com/15343819/104229876-bc624c00-5444-11eb-9fc8-2fbc161e7d84.png)
