### PR TITLE
Add ability to open a random note

### DIFF
--- a/packages/foam-vscode/README.md
+++ b/packages/foam-vscode/README.md
@@ -31,6 +31,7 @@ This will also install `Foam for VSCode`, but if you already have it installed, 
 - See how your notes are connected via a graph with the `Foam: Show Graph` command
 - Tag your notes and navigate them with the Tag Explorer
 - Make your notes navigable both in GitHub UI as well as GitHub Pages
+- Explore your knowledge base with the `Foam: Open Random Note` command
 
 ## Requirements
 

--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -23,6 +23,7 @@
     "onView:foam-vscode.tags-explorer",
     "onCommand:foam-vscode.update-wikilinks",
     "onCommand:foam-vscode.open-daily-note",
+    "onCommand:foam-vscode.open-random-note",
     "onCommand:foam-vscode.janitor",
     "onCommand:foam-vscode.copy-without-brackets",
     "onCommand:foam-vscode.show-graph"
@@ -55,6 +56,10 @@
       {
         "command": "foam-vscode.open-daily-note",
         "title": "Foam: Open Daily Note"
+      },
+      {
+        "command": "foam-vscode.open-random-note",
+        "title": "Foam: Open Random Note"
       },
       {
         "command": "foam-vscode.janitor",

--- a/packages/foam-vscode/src/features/index.ts
+++ b/packages/foam-vscode/src/features/index.ts
@@ -1,20 +1,22 @@
-import createReferences from "./wikilink-reference-generation";
-import openDailyNote from "./open-daily-note";
-import janitor from "./janitor";
-import dataviz from "./dataviz";
-import copyWithoutBrackets from "./copy-without-brackets";
-import openDatedNote from "./open-dated-note";
-import tagsExplorer from "./tags-tree-view";
-import createFromTemplate from "./create-from-template";
-import { FoamFeature } from "../types";
+import createReferences from './wikilink-reference-generation';
+import openDailyNote from './open-daily-note';
+import janitor from './janitor';
+import dataviz from './dataviz';
+import copyWithoutBrackets from './copy-without-brackets';
+import openDatedNote from './open-dated-note';
+import tagsExplorer from './tags-tree-view';
+import createFromTemplate from './create-from-template';
+import openRandomNote from './open-random-note';
+import { FoamFeature } from '../types';
 
 export const features: FoamFeature[] = [
   tagsExplorer,
   createReferences,
   openDailyNote,
+  openRandomNote,
   janitor,
   dataviz,
   copyWithoutBrackets,
   openDatedNote,
-  createFromTemplate
+  createFromTemplate,
 ];

--- a/packages/foam-vscode/src/features/open-random-note.ts
+++ b/packages/foam-vscode/src/features/open-random-note.ts
@@ -9,21 +9,20 @@ const feature: FoamFeature = {
       commands.registerCommand('foam-vscode.open-random-note', async () => {
         const foam = await foamPromise;
         const currentFile = window.activeTextEditor?.document.uri.path;
-        const notes = foam.notes.getNotes().map(note => note.uri.path);
-
-        let randomNoteIndex = Math.floor(Math.random() * notes.length);
-        if (notes[randomNoteIndex] === currentFile) {
-          notes.splice(randomNoteIndex, 1);
-          randomNoteIndex = Math.floor(Math.random() * notes.length);
-        }
-
-        if (notes.length > 0) {
-          focusNote(notes[randomNoteIndex], false);
-        } else {
+        const notes = foam.notes.getNotes();
+        if (notes.length <= 1) {
           window.showInformationMessage(
             'Could not find another note to open. If you believe this is a bug, please file an issue.'
           );
+          return;
         }
+
+        let randomNoteIndex = Math.floor(Math.random() * notes.length);
+        if (notes[randomNoteIndex].uri.path === currentFile) {
+          randomNoteIndex = (randomNoteIndex + 1) % notes.length;
+        }
+
+        focusNote(notes[randomNoteIndex].uri.path, false);
       })
     );
   },

--- a/packages/foam-vscode/src/features/open-random-note.ts
+++ b/packages/foam-vscode/src/features/open-random-note.ts
@@ -1,0 +1,23 @@
+import { Foam } from 'foam-core';
+import { ExtensionContext, commands, window } from 'vscode';
+import { FoamFeature } from '../types';
+import { focusNote } from '../utils';
+
+const feature: FoamFeature = {
+  activate: (context: ExtensionContext, foamPromise: Promise<Foam>) => {
+    context.subscriptions.push(
+      commands.registerCommand('foam-vscode.open-random-note', async () => {
+        const foam = await foamPromise;
+        const currentFile = window.activeTextEditor?.document.uri.path;
+        const notes = foam.notes
+          .getNotes()
+          .map(note => note.uri.path)
+          .filter(notePath => notePath !== currentFile);
+        const randomNote = notes[Math.floor(Math.random() * notes.length)];
+        focusNote(randomNote, false);
+      })
+    );
+  },
+};
+
+export default feature;

--- a/packages/foam-vscode/src/features/open-random-note.ts
+++ b/packages/foam-vscode/src/features/open-random-note.ts
@@ -9,18 +9,21 @@ const feature: FoamFeature = {
       commands.registerCommand('foam-vscode.open-random-note', async () => {
         const foam = await foamPromise;
         const currentFile = window.activeTextEditor?.document.uri.path;
-        const notes = foam.notes
-          .getNotes()
-          .map(note => note.uri.path)
-          .filter(notePath => notePath !== currentFile);
-        if (notes.length === 0) {
+        const notes = foam.notes.getNotes().map(note => note.uri.path);
+
+        let randomNoteIndex = Math.floor(Math.random() * notes.length);
+        if (notes[randomNoteIndex] === currentFile) {
+          notes.splice(randomNoteIndex, 1);
+          randomNoteIndex = Math.floor(Math.random() * notes.length);
+        }
+
+        if (notes.length > 0) {
+          focusNote(notes[randomNoteIndex], false);
+        } else {
           window.showInformationMessage(
             'Could not find another note to open. If you believe this is a bug, please file an issue.'
           );
-          return;
         }
-        const randomNote = notes[Math.floor(Math.random() * notes.length)];
-        focusNote(randomNote, false);
       })
     );
   },

--- a/packages/foam-vscode/src/features/open-random-note.ts
+++ b/packages/foam-vscode/src/features/open-random-note.ts
@@ -13,6 +13,12 @@ const feature: FoamFeature = {
           .getNotes()
           .map(note => note.uri.path)
           .filter(notePath => notePath !== currentFile);
+        if (notes.length === 0) {
+          window.showInformationMessage(
+            'Could not find another note to open. If you believe this is a bug, please file an issue.'
+          );
+          return;
+        }
         const randomNote = notes[Math.floor(Math.random() * notes.length)];
         focusNote(randomNote, false);
       })


### PR DESCRIPTION
Adds a `Foam: Open Random Note` command. It will open any random note in the knowledge base. It is guaranteed to not open the note that you're already viewing

This will implement the basic case outlined in #422 but more work will be needed for any sort of prioritization.