### PR TITLE
Welcome screen for Tag Explorer

### DIFF
--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -48,7 +48,7 @@
     "viewsWelcome": [
       {
         "view": "foam-vscode.tags-explorer",
-        "contents": "No tags found. Notes that contain tags (#tag) will show up here."
+        "contents": "No tags found. Notes that contain tags will show up here. You may add tags to a note with a hashtag (#tag) or by adding a tag list to the front matter (tags: tag1, tag2)."
       },
       {
         "view": "foam-vscode.orphans",

--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -47,6 +47,10 @@
     },
     "viewsWelcome": [
       {
+        "view": "foam-vscode.tags-explorer",
+        "contents": "No tags found. Notes that contain tags (#tag) will show up here."
+      },
+      {
         "view": "foam-vscode.orphans",
         "contents": "No orphans found. Notes that have no backlinks nor links will show up here."
       }


### PR DESCRIPTION
Adds a welcome screen for the Tag Explorer when no tags are found.

![tag-explorer](https://user-images.githubusercontent.com/19996318/105899756-5d433080-601b-11eb-86d9-6232c4da730c.png)
