### PR TITLE
Numeric tags

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,15 +21,5 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "prettier.requireConfig": true,
   "editor.formatOnSave": true,
-  "jest.debugCodeLens.showWhenTestStateIn": [
-    "fail",
-    "unknown",
-    "pass"
-  ],
-  "cSpell.words": [
-    "exluding",
-    "frontmatter",
-    "precendence",
-    "unist"
-  ]
+  "jest.debugCodeLens.showWhenTestStateIn": ["fail", "unknown", "pass"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,5 +21,15 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "prettier.requireConfig": true,
   "editor.formatOnSave": true,
-  "jest.debugCodeLens.showWhenTestStateIn": ["fail", "unknown", "pass"]
+  "jest.debugCodeLens.showWhenTestStateIn": [
+    "fail",
+    "unknown",
+    "pass"
+  ],
+  "cSpell.words": [
+    "exluding",
+    "frontmatter",
+    "precendence",
+    "unist"
+  ]
 }

--- a/packages/foam-cli/src/commands/janitor.ts
+++ b/packages/foam-cli/src/commands/janitor.ts
@@ -41,7 +41,11 @@ export default class Janitor extends Command {
     const { workspacePath = './' } = args;
 
     if (isValidDirectory(workspacePath)) {
-      const config = createConfigFromFolders([URI.file(workspacePath)]);
+      const config = createConfigFromFolders(
+        [URI.file(workspacePath)],
+        {},
+        false
+      );
       const services: Services = {
         dataStore: new FileDataStore(config),
       };

--- a/packages/foam-cli/src/commands/migrate.ts
+++ b/packages/foam-cli/src/commands/migrate.ts
@@ -42,7 +42,7 @@ Successfully generated link references and heading!
     const { args, flags } = this.parse(Migrate);
 
     const { workspacePath = './' } = args;
-    const config = createConfigFromFolders([workspacePath]);
+    const config = createConfigFromFolders([workspacePath], {}, false);
 
     if (isValidDirectory(workspacePath)) {
       const services: Services = {

--- a/packages/foam-core/src/bootstrap.ts
+++ b/packages/foam-core/src/bootstrap.ts
@@ -10,7 +10,7 @@ export const bootstrap = async (config: FoamConfig, services: Services) => {
   const plugins = await loadPlugins(config);
 
   const parserPlugins = plugins.map(p => p.parser).filter(isSome);
-  const parser = createMarkdownParser(parserPlugins);
+  const parser = createMarkdownParser(parserPlugins, config);
 
   const graphMiddlewares = plugins.map(p => p.graphMiddleware).filter(isSome);
   const graph = createGraph(graphMiddlewares);

--- a/packages/foam-core/src/config.ts
+++ b/packages/foam-core/src/config.ts
@@ -7,6 +7,7 @@ export interface FoamConfig {
   workspaceFolders: URI[];
   includeGlobs: string[];
   ignoreGlobs: string[];
+  numericTaggingEnabled: boolean;
   get<T>(path: string): T | undefined;
   get<T>(path: string, defaultValue: T): T;
 }
@@ -19,12 +20,14 @@ export const createConfigFromObject = (
   workspaceFolders: URI[],
   include: string[],
   ignore: string[],
-  settings: any
+  settings: any,
+  numericTaggingEnabled: boolean
 ) => {
   const config: FoamConfig = {
     workspaceFolders: workspaceFolders,
     includeGlobs: include,
     ignoreGlobs: ignore,
+    numericTaggingEnabled,
     get: <T>(path: string, defaultValue?: T) => {
       const tokens = path.split('.');
       const value = tokens.reduce((acc, t) => acc?.[t], settings);
@@ -39,7 +42,8 @@ export const createConfigFromFolders = (
   options: {
     include?: string[];
     ignore?: string[];
-  } = {}
+  } = {},
+  numericTaggingEnabled: boolean
 ): FoamConfig => {
   if (!Array.isArray(workspaceFolders)) {
     workspaceFolders = [workspaceFolders];
@@ -62,7 +66,8 @@ export const createConfigFromFolders = (
     workspaceFolders,
     options.include ?? DEFAULT_INCLUDES,
     options.ignore ?? DEFAULT_IGNORES,
-    settings
+    settings,
+    numericTaggingEnabled
   );
 };
 

--- a/packages/foam-core/src/markdown-provider.ts
+++ b/packages/foam-core/src/markdown-provider.ts
@@ -20,7 +20,7 @@ import {
 import { ParserPlugin } from './plugins';
 import { Logger } from './utils/log';
 import { URI } from './common/uri';
-import { FoamConfig } from 'index';
+import { FoamConfig } from './config';
 
 /**
  * Traverses all the children of the given node, extracts

--- a/packages/foam-core/src/markdown-provider.ts
+++ b/packages/foam-core/src/markdown-provider.ts
@@ -10,7 +10,7 @@ import detectNewline from 'detect-newline';
 import os from 'os';
 import { NoteGraphAPI } from './model/note-graph';
 import { NoteLinkDefinition, Note, NoteParser } from './model/note';
-import { dropExtension, extractHashtags, extractTagsFromProp } from './utils';
+import { dropExtension, TagExtractor } from './utils';
 import {
   uriToSlug,
   computeRelativePath,
@@ -20,6 +20,7 @@ import {
 import { ParserPlugin } from './plugins';
 import { Logger } from './utils/log';
 import { URI } from './common/uri';
+import { FoamConfig } from 'index';
 
 /**
  * Traverses all the children of the given node, extracts
@@ -35,17 +36,6 @@ const getTextFromChildren = (root: Node): string => {
     }
   });
   return text;
-};
-
-const tagsPlugin: ParserPlugin = {
-  name: 'tags',
-  onWillVisitTree: (tree, note) => {
-    note.tags = extractHashtags(note.source.text);
-  },
-  onDidFindProperties: (props, note) => {
-    const yamlTags = extractTagsFromProp(props.tags);
-    yamlTags.forEach(tag => note.tags.add(tag));
-  },
 };
 
 const titlePlugin: ParserPlugin = {
@@ -123,11 +113,22 @@ const handleError = (
   );
 };
 
-export function createMarkdownParser(extraPlugins: ParserPlugin[]): NoteParser {
+// const tagging = new TagExtractor();
+
+// const tagsPlugin: ParserPlugin = {
+
+// };
+
+export function createMarkdownParser(
+  extraPlugins: ParserPlugin[],
+  config: FoamConfig
+): NoteParser {
   const parser = unified()
     .use(markdownParse, { gfm: true })
     .use(frontmatterPlugin, ['yaml'])
     .use(wikiLinkPlugin);
+
+  const tagsPlugin = new TagExtractor(config);
 
   const plugins = [
     titlePlugin,

--- a/packages/foam-core/src/markdown-provider.ts
+++ b/packages/foam-core/src/markdown-provider.ts
@@ -113,12 +113,6 @@ const handleError = (
   );
 };
 
-// const tagging = new TagExtractor();
-
-// const tagsPlugin: ParserPlugin = {
-
-// };
-
 export function createMarkdownParser(
   extraPlugins: ParserPlugin[],
   config: FoamConfig

--- a/packages/foam-core/src/utils/hashtags.ts
+++ b/packages/foam-core/src/utils/hashtags.ts
@@ -1,16 +1,49 @@
 import { isSome } from './core';
-const HASHTAG_REGEX = /(^|[ ])#([\w_-]*[a-zA-Z][\w_-]*\b)/gm;
-const WORD_REGEX = /(^|[ ])([\w_-]*[a-zA-Z][\w_-]*\b)/gm;
+import { FoamConfig } from '../config';
+import { ParserPlugin } from 'plugins';
+import { Node } from 'unist';
+import { Note } from '../model/note';
 
-export const extractHashtags = (text: string): Set<string> => {
-  return isSome(text)
-    ? new Set(Array.from(text.matchAll(HASHTAG_REGEX), m => m[2].trim()))
-    : new Set();
-};
+export class TagExtractor implements ParserPlugin {
+  private hashtagRegex: RegExp = /(^|[ ])#([\w_-]*[a-zA-Z][\w_-]*\b)/gm;
+  private wordRegex: RegExp = /(^|[ ])([\w_-]*[a-zA-Z][\w_-]*\b)/gm;
 
-export const extractTagsFromProp = (prop: string | string[]): Set<string> => {
-  const text = Array.isArray(prop) ? prop.join(' ') : prop;
-  return isSome(text)
-    ? new Set(Array.from(text.matchAll(WORD_REGEX)).map(m => m[2].trim()))
-    : new Set();
-};
+  constructor(config: FoamConfig) {
+    console.log(config.numericTaggingEnabled);
+    if (config.numericTaggingEnabled) {
+      this.hashtagRegex = /(^|[ ])#([\w_-]*[a-zA-Z0-9][\w_-]*\b)/gm;
+      this.wordRegex = /(^|[ ])([\w_-]*[a-zA-Z0-9][\w_-]*\b)/gm;
+    }
+  }
+
+  name = 'tags';
+
+  onWillVisitTree = (tree: Node, note: Note) => {
+    note.tags = this.extractHashtags(note.source.text);
+  };
+
+  onDidFindProperties = (props: any, note: Note) => {
+    const yamlTags = this.extractTagsFromProp(props.tags);
+    yamlTags.forEach(tag => note.tags.add(tag));
+  };
+
+  onDidInitializeParser = () => {};
+  onWillParseMarkdown = () => {
+    return '';
+  };
+  onDidVisitTree = () => {};
+  visit = () => {};
+
+  extractHashtags = (text: string): Set<string> => {
+    return isSome(text)
+      ? new Set(Array.from(text.matchAll(this.hashtagRegex), m => m[2].trim()))
+      : new Set();
+  };
+
+  extractTagsFromProp = (prop: string | string[]): Set<string> => {
+    const text = Array.isArray(prop) ? prop.join(' ') : prop;
+    return isSome(text)
+      ? new Set(Array.from(text.matchAll(this.wordRegex)).map(m => m[2].trim()))
+      : new Set();
+  };
+}

--- a/packages/foam-core/src/utils/index.ts
+++ b/packages/foam-core/src/utils/index.ts
@@ -1,5 +1,4 @@
 import { titleCase } from 'title-case';
-// export { extractHashtags, extractTagsFromProp } from './hashtags';
 export { TagExtractor } from './hashtags';
 export * from './uri';
 export * from './core';

--- a/packages/foam-core/src/utils/index.ts
+++ b/packages/foam-core/src/utils/index.ts
@@ -1,5 +1,6 @@
 import { titleCase } from 'title-case';
-export { extractHashtags, extractTagsFromProp } from './hashtags';
+// export { extractHashtags, extractTagsFromProp } from './hashtags';
+export { TagExtractor } from './hashtags';
 export * from './uri';
 export * from './core';
 

--- a/packages/foam-core/test/config.test.ts
+++ b/packages/foam-core/test/config.test.ts
@@ -8,9 +8,11 @@ const testFolder = URI.joinPath(URI.file(__dirname), 'test-config');
 
 describe('Foam configuration', () => {
   it('can read settings from config.json', () => {
-    const config = createConfigFromFolders([
-      URI.joinPath(testFolder, 'folder1'),
-    ]);
+    const config = createConfigFromFolders(
+      [URI.joinPath(testFolder, 'folder1')],
+      {},
+      false
+    );
     expect(config.get('feature1.setting1.value')).toBeTruthy();
     expect(config.get('feature2.value')).toEqual(12);
 
@@ -19,10 +21,14 @@ describe('Foam configuration', () => {
   });
 
   it('can merge settings from multiple foam folders', () => {
-    const config = createConfigFromFolders([
-      URI.joinPath(testFolder, 'folder1'),
-      URI.joinPath(testFolder, 'folder2'),
-    ]);
+    const config = createConfigFromFolders(
+      [
+        URI.joinPath(testFolder, 'folder1'),
+        URI.joinPath(testFolder, 'folder2'),
+      ],
+      {},
+      false
+    );
 
     // override value
     expect(config.get('feature1.setting1.value')).toBe(false);
@@ -36,9 +42,11 @@ describe('Foam configuration', () => {
   });
 
   it('cannot activate local plugins from workspace config', () => {
-    const config = createConfigFromFolders([
-      URI.joinPath(testFolder, 'enable-plugins'),
-    ]);
+    const config = createConfigFromFolders(
+      [URI.joinPath(testFolder, 'enable-plugins')],
+      {},
+      false
+    );
     expect(config.get('experimental.localPlugins.enabled')).toBeUndefined();
   });
 });

--- a/packages/foam-core/test/datastore.test.ts
+++ b/packages/foam-core/test/datastore.test.ts
@@ -12,7 +12,8 @@ function makeConfig(params: { include: string[]; ignore: string[] }) {
     [testFolder],
     params.include,
     params.ignore,
-    {}
+    {},
+    false
   );
 }
 

--- a/packages/foam-core/test/janitor/generateHeadings.test.ts
+++ b/packages/foam-core/test/janitor/generateHeadings.test.ts
@@ -13,9 +13,11 @@ Logger.setLevel('error');
 describe('generateHeadings', () => {
   let _graph: NoteGraphAPI;
   beforeAll(async () => {
-    const config = createConfigFromFolders([
-      URI.file(path.join(__dirname, '..', '__scaffold__')),
-    ]);
+    const config = createConfigFromFolders(
+      [URI.file(path.join(__dirname, '..', '__scaffold__'))],
+      {},
+      false
+    );
     const services: Services = {
       dataStore: new FileDataStore(config),
     };

--- a/packages/foam-core/test/janitor/generateLinkReferences.test.ts
+++ b/packages/foam-core/test/janitor/generateLinkReferences.test.ts
@@ -13,9 +13,11 @@ describe('generateLinkReferences', () => {
   let _graph: NoteGraphAPI;
 
   beforeAll(async () => {
-    const config = createConfigFromFolders([
-      URI.file(path.join(__dirname, '..', '__scaffold__')),
-    ]);
+    const config = createConfigFromFolders(
+      [URI.file(path.join(__dirname, '..', '__scaffold__'))],
+      {},
+      false
+    );
     const services: Services = {
       dataStore: new FileDataStore(config),
     };

--- a/packages/foam-core/test/markdown-provider.test.ts
+++ b/packages/foam-core/test/markdown-provider.test.ts
@@ -8,6 +8,7 @@ import { ParserPlugin } from '../src/plugins';
 import { URI } from '../src/common/uri';
 import { Logger } from '../src/utils/log';
 import { uriToSlug } from '../src/utils';
+import { FoamConfig } from '../src/config';
 
 Logger.setLevel('error');
 
@@ -38,8 +39,20 @@ const pageE = `
 # Page E
 `;
 
-const createNoteFromMarkdown = (path: string, content: string) =>
-  createMarkdownParser([]).parse(URI.file(path), content);
+const createNoteFromMarkdown = (path: string, content: string) => {
+  const config: FoamConfig = {
+    workspaceFolders: [URI.from({ scheme: '' })],
+    includeGlobs: [''],
+    ignoreGlobs: [''],
+    numericTaggingEnabled: false,
+    get: <T>(path: string, defaultValue?: T) => {
+      const tokens = path.split('.');
+      const value = tokens.reduce((acc, t) => acc?.[t], {});
+      return value ?? defaultValue;
+    },
+  };
+  return createMarkdownParser([], config).parse(URI.file(path), content);
+};
 
 describe('Markdown loader', () => {
   it('Converts markdown to notes', () => {

--- a/packages/foam-core/test/markdown-provider.test.ts
+++ b/packages/foam-core/test/markdown-provider.test.ts
@@ -46,9 +46,7 @@ const createNoteFromMarkdown = (path: string, content: string) => {
     ignoreGlobs: [''],
     numericTaggingEnabled: false,
     get: <T>(path: string, defaultValue?: T) => {
-      const tokens = path.split('.');
-      const value = tokens.reduce((acc, t) => acc?.[t], {});
-      return value ?? defaultValue;
+      return defaultValue;
     },
   };
   return createMarkdownParser([], config).parse(URI.file(path), content);
@@ -362,7 +360,16 @@ describe('parser plugins', () => {
       }
     },
   };
-  const parser = createMarkdownParser([testPlugin]);
+  const config: FoamConfig = {
+    workspaceFolders: [URI.from({ scheme: '' })],
+    includeGlobs: [''],
+    ignoreGlobs: [''],
+    numericTaggingEnabled: false,
+    get: <T>(path: string, defaultValue?: T) => {
+      return defaultValue;
+    },
+  };
+  const parser = createMarkdownParser([testPlugin], config);
 
   it('can augment the parsing of the file', () => {
     const note1 = parser.parse(

--- a/packages/foam-core/test/plugin.test.ts
+++ b/packages/foam-core/test/plugin.test.ts
@@ -9,35 +9,55 @@ import { Logger } from '../src/utils/log';
 
 Logger.setLevel('error');
 
-const config: FoamConfig = createConfigFromObject([], [], [], {
-  experimental: {
-    localPlugins: {
-      enabled: true,
-      pluginFolders: [path.join(__dirname, 'test-plugin')],
+const config: FoamConfig = createConfigFromObject(
+  [],
+  [],
+  [],
+  {
+    experimental: {
+      localPlugins: {
+        enabled: true,
+        pluginFolders: [path.join(__dirname, 'test-plugin')],
+      },
     },
   },
-});
+  false
+);
 
 describe('Foam plugins', () => {
   it('will not load if feature is not explicitly enabled', async () => {
-    let plugins = await loadPlugins(createConfigFromObject([], [], [], {}));
-    expect(plugins.length).toEqual(0);
-    plugins = await loadPlugins(
-      createConfigFromObject([], [], [], {
-        experimental: {
-          localPlugins: {},
-        },
-      })
+    let plugins = await loadPlugins(
+      createConfigFromObject([], [], [], {}, false)
     );
     expect(plugins.length).toEqual(0);
     plugins = await loadPlugins(
-      createConfigFromObject([], [], [], {
-        experimental: {
-          localPlugins: {
-            enabled: false,
+      createConfigFromObject(
+        [],
+        [],
+        [],
+        {
+          experimental: {
+            localPlugins: {},
           },
         },
-      })
+        false
+      )
+    );
+    expect(plugins.length).toEqual(0);
+    plugins = await loadPlugins(
+      createConfigFromObject(
+        [],
+        [],
+        [],
+        {
+          experimental: {
+            localPlugins: {
+              enabled: false,
+            },
+          },
+        },
+        false
+      )
     );
     expect(plugins.length).toEqual(0);
   });
@@ -61,7 +81,7 @@ describe('Foam plugins', () => {
     const plugins = await loadPlugins(config);
     const parserPlugin = plugins[0].parser;
     expect(parserPlugin).not.toBeUndefined();
-    const parser = createMarkdownParser([parserPlugin!]);
+    const parser = createMarkdownParser([parserPlugin!], config);
 
     const note = parser.parse(
       URI.file('/path/to/a'),

--- a/packages/foam-core/test/utils.test.ts
+++ b/packages/foam-core/test/utils.test.ts
@@ -82,9 +82,7 @@ describe('hashtag extraction', () => {
     ignoreGlobs: [''],
     numericTaggingEnabled: false,
     get: <T>(path: string, defaultValue?: T) => {
-      const tokens = path.split('.');
-      const value = tokens.reduce((acc, t) => acc?.[t], {});
-      return value ?? defaultValue;
+      return defaultValue;
     },
   };
   const tagging = new TagExtractor(config);

--- a/packages/foam-core/test/utils.test.ts
+++ b/packages/foam-core/test/utils.test.ts
@@ -3,11 +3,12 @@ import {
   nameToSlug,
   hashURI,
   computeRelativeURI,
-  extractHashtags,
+  TagExtractor,
   parseUri,
 } from '../src/utils';
 import { URI } from '../src/common/uri';
 import { Logger } from '../src/utils/log';
+import { FoamConfig } from '../src/config';
 
 Logger.setLevel('error');
 
@@ -75,30 +76,44 @@ describe('URI utils', () => {
 });
 
 describe('hashtag extraction', () => {
+  const config: FoamConfig = {
+    workspaceFolders: [URI.from({ scheme: '' })],
+    includeGlobs: [''],
+    ignoreGlobs: [''],
+    numericTaggingEnabled: false,
+    get: <T>(path: string, defaultValue?: T) => {
+      const tokens = path.split('.');
+      const value = tokens.reduce((acc, t) => acc?.[t], {});
+      return value ?? defaultValue;
+    },
+  };
+  const tagging = new TagExtractor(config);
   it('works with simple strings', () => {
-    expect(extractHashtags('hello #world on #this planet')).toEqual(
+    expect(tagging.extractHashtags('hello #world on #this planet')).toEqual(
       new Set(['world', 'this'])
     );
   });
   it('works with tags at beginning or end of text', () => {
-    expect(extractHashtags('#hello world on this #planet')).toEqual(
+    expect(tagging.extractHashtags('#hello world on this #planet')).toEqual(
       new Set(['hello', 'planet'])
     );
   });
   it('supports _ and -', () => {
-    expect(extractHashtags('#hello-world on #this_planet')).toEqual(
+    expect(tagging.extractHashtags('#hello-world on #this_planet')).toEqual(
       new Set(['hello-world', 'this_planet'])
     );
   });
   it('ignores tags that only have numbers in text', () => {
     expect(
-      extractHashtags('this #123 tag should be ignore, but not #123four')
+      tagging.extractHashtags(
+        'this #123 tag should be ignore, but not #123four'
+      )
     ).toEqual(new Set(['123four']));
   });
 
   it('ignores hashes in plain text urls and links', () => {
     expect(
-      extractHashtags(`
+      tagging.extractHashtags(`
         test text with url https://site.com/#section1 https://site.com/home#section2 and
         https://site.com/home/#section3a
         [link](https://site.com/#section4) with [link2](https://site.com/home#section5) #control
@@ -109,7 +124,7 @@ describe('hashtag extraction', () => {
 
   it('ignores hashes in links to sections', () => {
     expect(
-      extractHashtags(`
+      tagging.extractHashtags(`
       this is a wikilink to [[#section1]] in the file and a [[link#section2]] in another
       this is a [link](#section3) to a section
       `)

--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -239,6 +239,11 @@
           "type": "object",
           "description": "Custom graph styling settings. An example is present in the documentation.",
           "default": {}
+        },
+        "foam.tags.includeNumbers": {
+          "type": "boolean",
+          "description": "Index solely numeric tags e.g. #2021",
+          "default": false
         }
       }
     },

--- a/packages/foam-vscode/src/services/config.ts
+++ b/packages/foam-vscode/src/services/config.ts
@@ -1,15 +1,20 @@
 import { workspace } from 'vscode';
 import { FoamConfig, createConfigFromFolders } from 'foam-core';
-import { getIgnoredFilesSetting } from '../settings';
+import { getIgnoredFilesSetting, getNumericTaggingEnabled } from '../settings';
 
 // TODO this is still to be improved - foam config should
 // not be dependent on vscode but at the moment it's convenient
 // to leverage it
 export const getConfigFromVscode = (): FoamConfig => {
+  const numericTaggingEnabled = getNumericTaggingEnabled();
   const workspaceFolders = workspace.workspaceFolders.map(dir => dir.uri);
   const excludeGlobs = getIgnoredFilesSetting();
 
-  return createConfigFromFolders(workspaceFolders, {
-    ignore: excludeGlobs.map(g => g.toString()),
-  });
+  return createConfigFromFolders(
+    workspaceFolders,
+    {
+      ignore: excludeGlobs.map(g => g.toString()),
+    },
+    numericTaggingEnabled
+  );
 };

--- a/packages/foam-vscode/src/settings.ts
+++ b/packages/foam-vscode/src/settings.ts
@@ -24,6 +24,10 @@ export function getIgnoredFilesSetting(): GlobPattern[] {
   ];
 }
 
+export function getNumericTaggingEnabled(): boolean {
+  return workspace.getConfiguration('foam.tags').get('includeNumbers');
+}
+
 /** Retrieves the maximum length for a Graph node title. */
 export function getTitleMaxLength(): number {
   return workspace.getConfiguration('foam.graph').get('titleMaxLength');


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4606342/106372900-a9e77e00-6331-11eb-912f-3107a8c6751f.png)

```json
        "foam.tags.includeNumbers": {
          "type": "boolean",
          "description": "Index solely numeric tags e.g. #2021",
          "default": false
        }
```

Tests are passing. I've included one for just the numeric tags.
Please let me know if this follows standards. This is my first time working with a VSCode extension and passing settings values from `foam-vscode` to `foam-core` was challenging because I only saw it done with the ignore blobs.