### PR TITLE
Added line width and line color to graph settings

### DIFF
--- a/packages/foam-vscode/src/features/dataviz.ts
+++ b/packages/foam-vscode/src/features/dataviz.ts
@@ -83,7 +83,7 @@ function generateGraphData(foam: Foam) {
     links.forEach(link => {
       if (!(link.to.path in graph.nodes)) {
         graph.nodes[link.to.path] = {
-          id: link.to,
+          id: link.to.path,
           type: 'placeholder',
           uri: `virtual:${link.to}`,
           title:

--- a/packages/foam-vscode/static/graphs/default/graph.js
+++ b/packages/foam-vscode/static/graphs/default/graph.js
@@ -4,7 +4,6 @@ const CONTAINER_ID = 'graph';
 const styleFallback = {
   background: '#202020',
   fontSize: 12,
-  lineColor: '#e0e0e0',
   lineWidth: 0.2,
   particleWidth: 1.0,
   highlightedForeground: '#f9c74f',
@@ -34,7 +33,7 @@ const defaultStyle = {
   background: getStyle(`--vscode-panel-background`) ?? styleFallback.background,
   fontSize:
     parseInt(getStyle(`--vscode-font-size`) ?? styleFallback.fontSize) - 2,
-  lineColor: getStyle('--vscode-editor-foreground') ?? styleFallback.lineColor,
+  lineColor: getStyle('--vscode-editor-foreground') ?? styleFallback.node.note,
   lineWidth: parseFloat(styleFallback.lineWidth),
   particleWidth: parseFloat(styleFallback.particleWidth),
   highlightedForeground:

--- a/packages/foam-vscode/static/graphs/default/graph.js
+++ b/packages/foam-vscode/static/graphs/default/graph.js
@@ -33,7 +33,6 @@ const defaultStyle = {
   background: getStyle(`--vscode-panel-background`) ?? styleFallback.background,
   fontSize:
     parseInt(getStyle(`--vscode-font-size`) ?? styleFallback.fontSize) - 2,
-  lineColor: getStyle('--vscode-editor-foreground') ?? styleFallback.node.note,
   lineWidth: parseFloat(styleFallback.lineWidth),
   particleWidth: parseFloat(styleFallback.particleWidth),
   highlightedForeground:
@@ -253,11 +252,15 @@ function getLinkColor(link, model) {
   const style = model.style;
   switch (getLinkState(link, model)) {
     case 'regular':
-      return style.lineColor;
+      return (
+        style.lineColor || d3.hsl(style.node['note']).copy({ opacity: 0.8 })
+      );
     case 'highlighted':
       return style.highlightedForeground;
     case 'lessened':
-      return d3.hsl(style.lineColor).copy({ opacity: 0.5 });
+      return style.lineColor
+        ? d3.hsl(style.lineColor).copy({ opacity: 0.5 })
+        : d3.hsl(style.node['note']).copy({ opacity: 0.4 });
     default:
       throw new Error('Unknown type for link', link);
   }

--- a/packages/foam-vscode/static/graphs/default/graph.js
+++ b/packages/foam-vscode/static/graphs/default/graph.js
@@ -34,8 +34,7 @@ const defaultStyle = {
   background: getStyle(`--vscode-panel-background`) ?? styleFallback.background,
   fontSize:
     parseInt(getStyle(`--vscode-font-size`) ?? styleFallback.fontSize) - 2,
-  lineColor:
-    getStyle('--vscode-list-deemphasizedForeground') ?? styleFallback.lineColor,
+  lineColor: getStyle('--vscode-editor-foreground') ?? styleFallback.lineColor,
   lineWidth: parseFloat(styleFallback.lineWidth),
   particleWidth: parseFloat(styleFallback.particleWidth),
   highlightedForeground:
@@ -169,8 +168,10 @@ function initDataviz(channel) {
     .d3Force('collide', d3.forceCollide(graph.nodeRelSize()))
     .linkWidth(() => model.style.lineWidth || styleFallback.lineWidth)
     .linkDirectionalParticles(1)
-    .linkDirectionalParticleWidth(
-      () => model.style.particleWidth || styleFallback.particleWidth
+    .linkDirectionalParticleWidth(link =>
+      getLinkState(link, model) === 'highlighted'
+        ? model.style.particleWidth || styleFallback.particleWidth
+        : 0
     )
     .nodeCanvasObject((node, ctx, globalScale) => {
       const info = model.nodeInfo[node.id];

--- a/packages/foam-vscode/static/graphs/default/graph.js
+++ b/packages/foam-vscode/static/graphs/default/graph.js
@@ -1,9 +1,10 @@
 const CONTAINER_ID = 'graph';
 
-/** The style fallback. This values should only be set when all else failed. */
+/** The style fallback. These values should only be used when all else fails. */
 const styleFallback = {
   background: '#202020',
   fontSize: 12,
+  lineColor: '#277da1',
   lineWidth: 0.2,
   particleWidth: 1.0,
   highlightedForeground: '#f9c74f',
@@ -33,6 +34,7 @@ const defaultStyle = {
   background: getStyle(`--vscode-panel-background`) ?? styleFallback.background,
   fontSize:
     parseInt(getStyle(`--vscode-font-size`) ?? styleFallback.fontSize) - 2,
+  lineColor: getStyle('--vscode-editor-foreground') ?? styleFallback.lineColor,
   lineWidth: parseFloat(styleFallback.lineWidth),
   particleWidth: parseFloat(styleFallback.particleWidth),
   highlightedForeground:
@@ -146,6 +148,7 @@ const Actions = {
     model.style = {
       ...defaultStyle,
       ...newStyle,
+      lineColor: newStyle.lineColor || ( newStyle.node && newStyle.node.note ) || defaultStyle.lineColor,
       node: {
         ...defaultStyle.node,
         ...newStyle.node,
@@ -252,15 +255,11 @@ function getLinkColor(link, model) {
   const style = model.style;
   switch (getLinkState(link, model)) {
     case 'regular':
-      return (
-        style.lineColor || d3.hsl(style.node['note']).copy({ opacity: 0.8 })
-      );
+      return style.lineColor;
     case 'highlighted':
       return style.highlightedForeground;
     case 'lessened':
-      return style.lineColor
-        ? d3.hsl(style.lineColor).copy({ opacity: 0.5 })
-        : d3.hsl(style.node['note']).copy({ opacity: 0.4 });
+      return d3.hsl(style.lineColor).copy({ opacity: 0.5 });
     default:
       throw new Error('Unknown type for link', link);
   }


### PR DESCRIPTION
Suggested changes inspired by [Issue 455](https://github.com/foambubble/foam/issues/455)

- Added `foreground` setting to define line colors 
- Use transparency to shade lines and nodes instead of just using d3...darker: my suggested approach for handling highlighting regardless of dark or light mode themes
- Added `lineWidth` setting to define line width and particle width, can be useful when using light mode themes
- Bug workaround for placeholder notes not being highlighted correctly - this bug workaround is presumably caused by a deeper bug that I couldn't track down

First time working with VS Code extensions - so appologies if this PR is of poor quality, feedback most welcome!
