### PR TITLE
Add ability to launch a daily note on startup

### DIFF
--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -169,6 +169,11 @@
             "Disable wikilink definitions generation"
           ]
         },
+        "foam.openDailyNote.onStartup": {
+          "type": "boolean",
+          "scope": "resource",
+          "default": false
+        },
         "foam.openDailyNote.fileExtension": {
           "type": "string",
           "scope": "resource",

--- a/packages/foam-vscode/src/features/open-daily-note.ts
+++ b/packages/foam-vscode/src/features/open-daily-note.ts
@@ -1,4 +1,4 @@
-import { ExtensionContext, commands } from 'vscode';
+import { ExtensionContext, commands, workspace } from 'vscode';
 import { FoamFeature } from '../types';
 import { openDailyNoteFor } from '../dated-notes';
 
@@ -7,6 +7,9 @@ const feature: FoamFeature = {
     context.subscriptions.push(
       commands.registerCommand('foam-vscode.open-daily-note', openDailyNoteFor)
     );
+    if (workspace.getConfiguration('foam.openDailyNote.onStartup')) {
+      commands.executeCommand('foam-vscode.open-daily-note');
+    }
   },
 };
 


### PR DESCRIPTION
I had this idea this morning that I'd like my foam notes to open on startup

It then got me thinking "hey, it would be cool if it would land on my daily note on startup too!"

So, here's that feature.

Update to docs following shortly...