### PR TITLE
Backlinks Panel

### DIFF
--- a/packages/foam-core/src/index.ts
+++ b/packages/foam-core/src/index.ts
@@ -22,6 +22,7 @@ export { ILogger };
 export { LogLevel, LogLevelThreshold, Logger, BaseLogger } from './utils/log';
 export { Event, Emitter } from './common/event';
 export { FoamConfig };
+export { isSameUri, parseUri } from './utils/uri';
 
 export { IDisposable, isDisposable };
 

--- a/packages/foam-core/src/markdown-provider.ts
+++ b/packages/foam-core/src/markdown-provider.ts
@@ -96,6 +96,7 @@ const wikilinkPlugin: ParserPlugin = {
         type: 'link',
         target: targetUri,
         label: label,
+        position: node.position!,
       });
     }
   },

--- a/packages/foam-core/src/model/note.ts
+++ b/packages/foam-core/src/model/note.ts
@@ -21,6 +21,7 @@ export interface DirectLink {
   type: 'link';
   label: string;
   target: string;
+  position: Position;
 }
 
 export type NoteLink = WikiLink | DirectLink;

--- a/packages/foam-core/src/model/workspace.ts
+++ b/packages/foam-core/src/model/workspace.ts
@@ -2,7 +2,7 @@ import { diff } from 'fast-array-diff';
 import { isEqual } from 'lodash';
 import * as path from 'path';
 import { URI } from '../common/uri';
-import { Resource, NoteLink, Note } from '../model/note';
+import { Resource, NoteLink, Note, Point, Position } from '../model/note';
 import {
   computeRelativeURI,
   isSome,
@@ -10,6 +10,7 @@ import {
   parseUri,
   placeholderUri,
   isPlaceholder,
+  isSameUri,
 } from '../utils';
 import { Emitter } from '../common/event';
 import { IDisposable } from '../index';
@@ -17,6 +18,7 @@ import { IDisposable } from '../index';
 export type Connection = {
   source: URI;
   target: URI;
+  link: NoteLink;
 };
 
 export function getReferenceType(
@@ -221,12 +223,12 @@ export class FoamWorkspace implements IDisposable {
     ];
   }
 
-  public static getLinks(workspace: FoamWorkspace, uri: URI): URI[] {
-    return workspace.links[uri.path]?.map(c => c.target) ?? [];
+  public static getLinks(workspace: FoamWorkspace, uri: URI): Connection[] {
+    return workspace.links[uri.path] ?? [];
   }
 
-  public static getBacklinks(workspace: FoamWorkspace, uri: URI): URI[] {
-    return workspace.backlinks[uri.path]?.map(c => c.source) ?? [];
+  public static getBacklinks(workspace: FoamWorkspace, uri: URI): Connection[] {
+    return workspace.backlinks[uri.path] ?? [];
   }
 
   public static set(
@@ -350,7 +352,7 @@ export class FoamWorkspace implements IDisposable {
       // prettier-ignore
       resource.links.forEach(link => {
         const targetUri = FoamWorkspace.resolveLink(workspace, resource, link);
-        workspace = FoamWorkspace.connect(workspace, resource.uri, targetUri);
+        workspace = FoamWorkspace.connect(workspace, resource.uri, targetUri, link);
       });
     }
     return workspace;
@@ -374,11 +376,11 @@ export class FoamWorkspace implements IDisposable {
       const patch = diff(oldResource.links, newResource.links, isEqual);
       workspace = patch.removed.reduce((ws, link) => {
         const target = ws.resolveLink(oldResource, link);
-        return FoamWorkspace.disconnect(ws, oldResource.uri, target);
+        return FoamWorkspace.disconnect(ws, oldResource.uri, target, link);
       }, workspace);
       workspace = patch.added.reduce((ws, link) => {
         const target = ws.resolveLink(newResource, link);
-        return FoamWorkspace.connect(ws, newResource.uri, target);
+        return FoamWorkspace.connect(ws, newResource.uri, target, link);
       }, workspace);
     }
     return workspace;
@@ -414,7 +416,8 @@ export class FoamWorkspace implements IDisposable {
     const resourcesPointedByDeletedNote = workspace.links[uri.path] ?? [];
     delete workspace.links[uri.path];
     workspace = resourcesPointedByDeletedNote.reduce(
-      (ws, link) => FoamWorkspace.disconnect(ws, uri, link.target),
+      (ws, connection) =>
+        FoamWorkspace.disconnect(ws, uri, connection.target, connection.link),
       workspace
     );
 
@@ -428,11 +431,13 @@ export class FoamWorkspace implements IDisposable {
     return workspace;
   }
 
-  private static connect(workspace: FoamWorkspace, source: URI, target: URI) {
-    const connection = {
-      source: source,
-      target: target,
-    };
+  private static connect(
+    workspace: FoamWorkspace,
+    source: URI,
+    target: URI,
+    link: NoteLink
+  ) {
+    const connection = { source, target, link };
 
     workspace.links[source.path] = workspace.links[source.path] ?? [];
     workspace.links[source.path].push(connection);
@@ -442,19 +447,36 @@ export class FoamWorkspace implements IDisposable {
     return workspace;
   }
 
+  /**
+   * Removes a connection, or all connections, between the source and
+   * target resources
+   *
+   * @param workspace the Foam workspace
+   * @param source the source resource
+   * @param target the target resource
+   * @param link the link reference, or `true` to remove all links
+   * @returns the updated Foam workspace
+   */
   private static disconnect(
     workspace: FoamWorkspace,
     source: URI,
-    target: URI
+    target: URI,
+    link: NoteLink | true
   ) {
+    const connectionsToKeep =
+      link === true
+        ? (c: Connection) =>
+            !isSameUri(source, c.source) || !isSameUri(target, c.target)
+        : (c: Connection) => !isSameConnection({ source, target, link }, c);
+
     workspace.links[source.path] = workspace.links[source.path]?.filter(
-      c => c.source.path !== source.path || c.target.path !== target.path
+      connectionsToKeep
     );
     if (workspace.links[source.path].length === 0) {
       delete workspace.links[source.path];
     }
     workspace.backlinks[target.path] = workspace.backlinks[target.path]?.filter(
-      c => c.source.path !== source.path || c.target.path !== target.path
+      connectionsToKeep
     );
     if (workspace.backlinks[target.path].length === 0) {
       delete workspace.backlinks[target.path];
@@ -465,3 +487,19 @@ export class FoamWorkspace implements IDisposable {
     return workspace;
   }
 }
+
+// TODO move these utility fns to appropriate places
+
+const isSameConnection = (a: Connection, b: Connection) =>
+  isSameUri(a.source, b.source) &&
+  isSameUri(a.target, b.target) &&
+  isSameLink(a.link, b.link);
+
+const isSameLink = (a: NoteLink, b: NoteLink) =>
+  a.type === b.type && isSamePosition(a.position, b.position);
+
+const isSamePosition = (a: Position, b: Position) =>
+  isSamePoint(a.start, b.start) && isSamePoint(a.end, b.end);
+
+const isSamePoint = (a: Point, b: Point) =>
+  a.column === b.column && a.line === b.line;

--- a/packages/foam-core/src/utils/uri.ts
+++ b/packages/foam-core/src/utils/uri.ts
@@ -68,3 +68,10 @@ export const placeholderUri = (key: string): URI => {
 export const isPlaceholder = (uri: URI): boolean => {
   return uri.scheme === 'placeholder';
 };
+
+export const isSameUri = (a: URI, b: URI) =>
+  a.authority === b.authority &&
+  a.scheme === b.scheme &&
+  a.path === b.path && // Note we don't use fsPath for sameness
+  a.fragment === b.fragment &&
+  a.query === b.query;

--- a/packages/foam-core/test/core.test.ts
+++ b/packages/foam-core/test/core.test.ts
@@ -33,7 +33,9 @@ export const createTestNote = (params: {
   definitions?: NoteLinkDefinition[];
   links?: Array<{ slug: string } | { to: string }>;
   text?: string;
+  root?: URI;
 }): Note => {
+  const root = params.root ?? URI.file('/');
   return {
     uri: strToUri(params.uri),
     type: 'note',
@@ -42,21 +44,29 @@ export const createTestNote = (params: {
     definitions: params.definitions ?? [],
     tags: new Set(),
     links: params.links
-      ? params.links.map(link =>
-          'slug' in link
+      ? params.links.map((link, index) => {
+          const pos = {
+            start: {
+              line: position.start.line + index,
+              column: position.start.column,
+            },
+            end: position.end,
+          };
+          return 'slug' in link
             ? {
                 type: 'wikilink',
                 slug: link.slug,
                 target: link.slug,
-                position: position,
+                position: pos,
                 text: 'link text',
               }
             : {
                 type: 'link',
                 target: link.to,
                 label: 'link text',
-              }
-        )
+                position: pos,
+              };
+        })
       : [],
     source: {
       eol: eol,

--- a/packages/foam-core/test/markdown-provider.test.ts
+++ b/packages/foam-core/test/markdown-provider.test.ts
@@ -119,8 +119,10 @@ this is a [link to intro](#introduction)
       .set(noteE)
       .resolveLinks();
 
-    expect(workspace.getBacklinks(noteB.uri)).toEqual([noteA.uri]);
-    expect(workspace.getLinks(noteA.uri)).toEqual([
+    expect(workspace.getBacklinks(noteB.uri).map(l => l.source)).toEqual([
+      noteA.uri,
+    ]);
+    expect(workspace.getLinks(noteA.uri).map(l => l.target)).toEqual([
       noteB.uri,
       noteC.uri,
       noteD.uri,

--- a/packages/foam-core/test/workspace.test.ts
+++ b/packages/foam-core/test/workspace.test.ts
@@ -93,6 +93,28 @@ describe('Workspace links', () => {
       },
     ]);
   });
+  it('Supports removing a single link amongst several between two resources', () => {
+    const noteA = createTestNote({
+      uri: '/path/to/note-a.md',
+    });
+    const noteB = createTestNote({
+      uri: '/note-b.md',
+      links: [{ to: noteA.uri.path }, { to: noteA.uri.path }],
+    });
+    const ws = new FoamWorkspace();
+    ws.set(noteA)
+      .set(noteB)
+      .resolveLinks(true);
+
+    expect(ws.getBacklinks(noteA.uri).length).toEqual(2);
+
+    const noteBBis = createTestNote({
+      uri: '/note-b.md',
+      links: [{ to: noteA.uri.path }],
+    });
+    ws.set(noteBBis);
+    expect(ws.getBacklinks(noteA.uri).length).toEqual(1);
+  });
 });
 
 describe('Wikilinks', () => {

--- a/packages/foam-core/test/workspace.test.ts
+++ b/packages/foam-core/test/workspace.test.ts
@@ -24,7 +24,7 @@ describe('Reference types', () => {
   });
 });
 
-describe('Notes workspace', () => {
+describe('Workspace resources', () => {
   it('Adds notes to workspace', () => {
     const ws = new FoamWorkspace();
     ws.set(createTestNote({ uri: '/page-a.md' }));
@@ -67,6 +67,34 @@ describe('Notes workspace', () => {
   });
 });
 
+describe('Workspace links', () => {
+  it('Supports multiple connections between the same resources', () => {
+    const noteA = createTestNote({
+      uri: '/path/to/note-a.md',
+    });
+    const noteB = createTestNote({
+      uri: '/note-b.md',
+      links: [{ to: noteA.uri.path }, { to: noteA.uri.path }],
+    });
+    const ws = new FoamWorkspace();
+    ws.set(noteA)
+      .set(noteB)
+      .resolveLinks();
+    expect(ws.getBacklinks(noteA.uri)).toEqual([
+      {
+        source: noteB.uri,
+        target: noteA.uri,
+        link: expect.objectContaining({ type: 'link' }),
+      },
+      {
+        source: noteB.uri,
+        target: noteA.uri,
+        link: expect.objectContaining({ type: 'link' }),
+      },
+    ]);
+  });
+});
+
 describe('Wikilinks', () => {
   it('Can be defined with basename, relative path, absolute path, extension', () => {
     const noteA = createTestNote({
@@ -95,7 +123,7 @@ describe('Wikilinks', () => {
     expect(
       ws
         .getLinks(noteA.uri)
-        .map(link => link.path)
+        .map(link => link.target.path)
         .sort()
     ).toEqual([
       '/absolute/path/page-d.md',
@@ -136,7 +164,7 @@ describe('Wikilinks', () => {
     expect(
       ws
         .getBacklinks(noteA.uri)
-        .map(link => link.path)
+        .map(link => link.source.path)
         .sort()
     ).toEqual(['/path/another/page-c.md', '/somewhere/page-b.md']);
   });
@@ -161,6 +189,7 @@ describe('Wikilinks', () => {
     expect(ws.getAllConnections()[0]).toEqual({
       source: noteA.uri,
       target: noteB.uri,
+      link: expect.objectContaining({ type: 'wikilink', slug: 'page-b' }),
     });
   });
 
@@ -178,7 +207,13 @@ describe('Wikilinks', () => {
       .set(noteB2)
       .resolveLinks();
 
-    expect(ws.getLinks(noteA.uri)).toEqual([noteB1.uri]);
+    expect(ws.getLinks(noteA.uri)).toEqual([
+      {
+        source: noteA.uri,
+        target: noteB1.uri,
+        link: expect.objectContaining({ type: 'wikilink' }),
+      },
+    ]);
   });
 
   it('Resolves path wikilink in case of name conflict', () => {
@@ -197,7 +232,10 @@ describe('Wikilinks', () => {
       .set(noteB3)
       .resolveLinks();
 
-    expect(ws.getLinks(noteA.uri)).toEqual([noteB2.uri, noteB3.uri]);
+    expect(ws.getLinks(noteA.uri).map(l => l.target)).toEqual([
+      noteB2.uri,
+      noteB3.uri,
+    ]);
   });
 
   it('Supports attachments', () => {
@@ -222,8 +260,12 @@ describe('Wikilinks', () => {
       .set(attachmentB)
       .resolveLinks();
 
-    expect(ws.getBacklinks(attachmentA.uri)).toEqual([noteA.uri]);
-    expect(ws.getBacklinks(attachmentB.uri)).toEqual([noteA.uri]);
+    expect(ws.getBacklinks(attachmentA.uri).map(l => l.source)).toEqual([
+      noteA.uri,
+    ]);
+    expect(ws.getBacklinks(attachmentB.uri).map(l => l.source)).toEqual([
+      noteA.uri,
+    ]);
   });
 
   it('Resolves conflicts alphabetically - part 1', () => {
@@ -243,7 +285,9 @@ describe('Wikilinks', () => {
       .set(attachmentABis)
       .resolveLinks();
 
-    expect(ws.getLinks(noteA.uri)).toEqual([attachmentABis.uri]);
+    expect(ws.getLinks(noteA.uri).map(l => l.target)).toEqual([
+      attachmentABis.uri,
+    ]);
   });
 
   it('Resolves conflicts alphabetically - part 2', () => {
@@ -263,7 +307,9 @@ describe('Wikilinks', () => {
       .set(attachmentA)
       .resolveLinks();
 
-    expect(ws.getLinks(noteA.uri)).toEqual([attachmentABis.uri]);
+    expect(ws.getLinks(noteA.uri).map(l => l.target)).toEqual([
+      attachmentABis.uri,
+    ]);
   });
 });
 
@@ -289,16 +335,28 @@ describe('markdown direct links', () => {
     expect(
       ws
         .getLinks(noteA.uri)
-        .map(link => link.path)
+        .map(link => link.target.path)
         .sort()
     ).toEqual(['/path/to/another/page-b.md', '/path/to/more/page-c.md']);
 
-    expect(ws.getLinks(noteB.uri)).toEqual([noteA.uri]);
-    expect(ws.getBacklinks(noteA.uri)).toEqual([noteB.uri]);
+    expect(ws.getLinks(noteB.uri).map(l => l.target)).toEqual([noteA.uri]);
+    expect(ws.getBacklinks(noteA.uri).map(l => l.source)).toEqual([noteB.uri]);
     expect(ws.getConnections(noteA.uri)).toEqual([
-      { source: noteA.uri, target: noteB.uri },
-      { source: noteA.uri, target: noteC.uri },
-      { source: noteB.uri, target: noteA.uri },
+      {
+        source: noteA.uri,
+        target: noteB.uri,
+        link: expect.objectContaining({ type: 'link' }),
+      },
+      {
+        source: noteA.uri,
+        target: noteC.uri,
+        link: expect.objectContaining({ type: 'link' }),
+      },
+      {
+        source: noteB.uri,
+        target: noteA.uri,
+        link: expect.objectContaining({ type: 'link' }),
+      },
     ]);
   });
 });
@@ -315,10 +373,12 @@ describe('Placeholders', () => {
     expect(ws.getAllConnections()[0]).toEqual({
       source: noteA.uri,
       target: placeholderUri('/somewhere/page-b.md'),
+      link: expect.objectContaining({ type: 'link' }),
     });
     expect(ws.getAllConnections()[1]).toEqual({
       source: noteA.uri,
       target: placeholderUri('/path/to/page-c.md'),
+      link: expect.objectContaining({ type: 'link' }),
     });
   });
 
@@ -333,6 +393,7 @@ describe('Placeholders', () => {
     expect(ws.getAllConnections()[0]).toEqual({
       source: noteA.uri,
       target: placeholderUri('page-b'),
+      link: expect.objectContaining({ type: 'wikilink' }),
     });
   });
   it('Treats wikilink with definition to non-existing file as placeholders', () => {
@@ -356,10 +417,12 @@ describe('Placeholders', () => {
     expect(ws.getAllConnections()[0]).toEqual({
       source: noteA.uri,
       target: placeholderUri('/somewhere/page-b.md'),
+      link: expect.objectContaining({ type: 'wikilink' }),
     });
     expect(ws.getAllConnections()[1]).toEqual({
       source: noteA.uri,
       target: placeholderUri('/path/to/page-c.md'),
+      link: expect.objectContaining({ type: 'wikilink' }),
     });
   });
 });
@@ -383,9 +446,9 @@ describe('Updating workspace happy path', () => {
       .set(noteC)
       .resolveLinks();
 
-    expect(ws.getLinks(noteA.uri)).toEqual([noteB.uri]);
-    expect(ws.getBacklinks(noteB.uri)).toEqual([noteA.uri]);
-    expect(ws.getBacklinks(noteC.uri)).toEqual([noteB.uri]);
+    expect(ws.getLinks(noteA.uri).map(l => l.target)).toEqual([noteB.uri]);
+    expect(ws.getBacklinks(noteB.uri).map(l => l.source)).toEqual([noteA.uri]);
+    expect(ws.getBacklinks(noteC.uri).map(l => l.source)).toEqual([noteB.uri]);
 
     // update the note
     const noteABis = createTestNote({
@@ -394,18 +457,18 @@ describe('Updating workspace happy path', () => {
     });
     ws.set(noteABis);
     // change is not propagated immediately
-    expect(ws.getLinks(noteA.uri)).toEqual([noteB.uri]);
-    expect(ws.getBacklinks(noteB.uri)).toEqual([noteA.uri]);
-    expect(ws.getBacklinks(noteC.uri)).toEqual([noteB.uri]);
+    expect(ws.getLinks(noteA.uri).map(l => l.target)).toEqual([noteB.uri]);
+    expect(ws.getBacklinks(noteB.uri).map(l => l.source)).toEqual([noteA.uri]);
+    expect(ws.getBacklinks(noteC.uri).map(l => l.source)).toEqual([noteB.uri]);
 
     // recompute the links
     ws.resolveLinks();
-    expect(ws.getLinks(noteA.uri)).toEqual([noteC.uri]);
-    expect(ws.getBacklinks(noteB.uri)).toEqual([]);
+    expect(ws.getLinks(noteA.uri).map(l => l.target)).toEqual([noteC.uri]);
+    expect(ws.getBacklinks(noteB.uri).map(l => l.source)).toEqual([]);
     expect(
       ws
         .getBacklinks(noteC.uri)
-        .map(link => link.path)
+        .map(link => link.source.path)
         .sort()
     ).toEqual(['/path/to/another/page-b.md', '/path/to/page-a.md']);
   });
@@ -423,8 +486,8 @@ describe('Updating workspace happy path', () => {
       .set(noteB)
       .resolveLinks();
 
-    expect(ws.getLinks(noteA.uri)).toEqual([noteB.uri]);
-    expect(ws.getBacklinks(noteB.uri)).toEqual([noteA.uri]);
+    expect(ws.getLinks(noteA.uri).map(l => l.target)).toEqual([noteB.uri]);
+    expect(ws.getBacklinks(noteB.uri).map(l => l.source)).toEqual([noteA.uri]);
     expect(ws.get(noteB.uri).type).toEqual('note');
 
     // remove note-b
@@ -443,7 +506,9 @@ describe('Updating workspace happy path', () => {
     const ws = new FoamWorkspace();
     ws.set(noteA).resolveLinks();
 
-    expect(ws.getLinks(noteA.uri)).toEqual([placeholderUri('page-b')]);
+    expect(ws.getLinks(noteA.uri).map(l => l.target)).toEqual([
+      placeholderUri('page-b'),
+    ]);
     expect(ws.get(placeholderUri('page-b')).type).toEqual('placeholder');
 
     // add note-b
@@ -471,8 +536,8 @@ describe('Updating workspace happy path', () => {
       .set(noteB)
       .resolveLinks();
 
-    expect(ws.getLinks(noteA.uri)).toEqual([noteB.uri]);
-    expect(ws.getBacklinks(noteB.uri)).toEqual([noteA.uri]);
+    expect(ws.getLinks(noteA.uri).map(l => l.target)).toEqual([noteB.uri]);
+    expect(ws.getBacklinks(noteB.uri).map(l => l.source)).toEqual([noteA.uri]);
     expect(ws.get(noteB.uri).type).toEqual('note');
 
     // remove note-b
@@ -493,7 +558,7 @@ describe('Updating workspace happy path', () => {
     const ws = new FoamWorkspace();
     ws.set(noteA).resolveLinks();
 
-    expect(ws.getLinks(noteA.uri)).toEqual([
+    expect(ws.getLinks(noteA.uri).map(l => l.target)).toEqual([
       placeholderUri('/path/to/another/page-b.md'),
     ]);
     expect(ws.get(placeholderUri('/path/to/another/page-b.md')).type).toEqual(
@@ -555,9 +620,9 @@ describe('Monitoring of workspace state', () => {
       .set(noteC)
       .resolveLinks(true);
 
-    expect(ws.getLinks(noteA.uri)).toEqual([noteB.uri]);
-    expect(ws.getBacklinks(noteB.uri)).toEqual([noteA.uri]);
-    expect(ws.getBacklinks(noteC.uri)).toEqual([noteB.uri]);
+    expect(ws.getLinks(noteA.uri).map(l => l.target)).toEqual([noteB.uri]);
+    expect(ws.getBacklinks(noteB.uri).map(l => l.source)).toEqual([noteA.uri]);
+    expect(ws.getBacklinks(noteC.uri).map(l => l.source)).toEqual([noteB.uri]);
 
     // update the note
     const noteABis = createTestNote({
@@ -566,12 +631,12 @@ describe('Monitoring of workspace state', () => {
     });
     ws.set(noteABis);
 
-    expect(ws.getLinks(noteA.uri)).toEqual([noteC.uri]);
-    expect(ws.getBacklinks(noteB.uri)).toEqual([]);
+    expect(ws.getLinks(noteA.uri).map(l => l.target)).toEqual([noteC.uri]);
+    expect(ws.getBacklinks(noteB.uri).map(l => l.source)).toEqual([]);
     expect(
       ws
         .getBacklinks(noteC.uri)
-        .map(link => link.path)
+        .map(link => link.source.path)
         .sort()
     ).toEqual(['/path/to/another/page-b.md', '/path/to/page-a.md']);
   });
@@ -589,8 +654,8 @@ describe('Monitoring of workspace state', () => {
       .set(noteB)
       .resolveLinks(true);
 
-    expect(ws.getLinks(noteA.uri)).toEqual([noteB.uri]);
-    expect(ws.getBacklinks(noteB.uri)).toEqual([noteA.uri]);
+    expect(ws.getLinks(noteA.uri).map(l => l.target)).toEqual([noteB.uri]);
+    expect(ws.getBacklinks(noteB.uri).map(l => l.source)).toEqual([noteA.uri]);
     expect(ws.get(noteB.uri).type).toEqual('note');
 
     // remove note-b
@@ -608,7 +673,9 @@ describe('Monitoring of workspace state', () => {
     const ws = new FoamWorkspace();
     ws.set(noteA).resolveLinks(true);
 
-    expect(ws.getLinks(noteA.uri)).toEqual([placeholderUri('page-b')]);
+    expect(ws.getLinks(noteA.uri).map(l => l.target)).toEqual([
+      placeholderUri('page-b'),
+    ]);
     expect(ws.get(placeholderUri('page-b')).type).toEqual('placeholder');
 
     // add note-b
@@ -635,8 +702,8 @@ describe('Monitoring of workspace state', () => {
       .set(noteB)
       .resolveLinks(true);
 
-    expect(ws.getLinks(noteA.uri)).toEqual([noteB.uri]);
-    expect(ws.getBacklinks(noteB.uri)).toEqual([noteA.uri]);
+    expect(ws.getLinks(noteA.uri).map(l => l.target)).toEqual([noteB.uri]);
+    expect(ws.getBacklinks(noteB.uri).map(l => l.source)).toEqual([noteA.uri]);
     expect(ws.get(noteB.uri).type).toEqual('note');
 
     // remove note-b
@@ -656,7 +723,7 @@ describe('Monitoring of workspace state', () => {
     const ws = new FoamWorkspace();
     ws.set(noteA).resolveLinks(true);
 
-    expect(ws.getLinks(noteA.uri)).toEqual([
+    expect(ws.getLinks(noteA.uri).map(l => l.target)).toEqual([
       placeholderUri('/path/to/another/page-b.md'),
     ]);
     expect(ws.get(placeholderUri('/path/to/another/page-b.md')).type).toEqual(

--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -35,6 +35,12 @@
     "views": {
       "explorer": [
         {
+          "id": "foam-vscode.backlinks",
+          "name": "Foam Backlinks",
+          "icon": "media/dep.svg",
+          "contextualTitle": "Foam Backlinks"
+        },
+        {
           "id": "foam-vscode.tags-explorer",
           "name": "Tag Explorer",
           "icon": "media/dep.svg",
@@ -58,6 +64,10 @@
       {
         "view": "foam-vscode.tags-explorer",
         "contents": "No tags found. Notes that contain tags will show up here. You may add tags to a note with a hashtag (#tag) or by adding a tag list to the front matter (tags: tag1, tag2)."
+      },
+      {
+        "view": "foam-vscode.backlinks",
+        "contents": "No backlinks found for selected resource."
       },
       {
         "view": "foam-vscode.orphans",

--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -36,9 +36,9 @@
       "explorer": [
         {
           "id": "foam-vscode.backlinks",
-          "name": "Foam Backlinks",
+          "name": "Backlinks",
           "icon": "media/dep.svg",
-          "contextualTitle": "Foam Backlinks"
+          "contextualTitle": "Backlinks"
         },
         {
           "id": "foam-vscode.tags-explorer",

--- a/packages/foam-vscode/src/features/backlinks.spec.ts
+++ b/packages/foam-vscode/src/features/backlinks.spec.ts
@@ -1,5 +1,5 @@
-import { commands, workspace, window } from 'vscode';
-import { URI, FoamWorkspace, IDataStore, Resource, Note } from 'foam-core';
+import { workspace, window } from 'vscode';
+import { URI, FoamWorkspace, IDataStore } from 'foam-core';
 import {
   cleanWorkspace,
   closeEditors,
@@ -122,23 +122,23 @@ describe('Backlinks panel', () => {
     expect(notes.length).toEqual(2);
 
     const noteD = createTestNote({
-      uri: '/note-d.md',
+      root: rootUri,
+      uri: './note-d.md',
     });
     ws.set(noteD);
     notes = (await provider.getChildren()) as ResourceTreeItem[];
     expect(notes.length).toEqual(2);
 
     const noteDBis = createTestNote({
-      uri: '/note-d.md',
+      root: rootUri,
+      uri: './note-d.md',
       links: [{ slug: 'note-a' }],
     });
     ws.set(noteDBis);
     notes = (await provider.getChildren()) as ResourceTreeItem[];
     expect(notes.length).toEqual(3);
-    expect(notes.map(n => n.resource.uri)).toEqual([
-      noteB.uri,
-      noteC.uri,
-      noteD.uri,
-    ]);
+    expect(notes.map(n => n.resource.uri.path)).toEqual(
+      [noteB.uri, noteC.uri, noteD.uri].map(uri => uri.path)
+    );
   });
 });

--- a/packages/foam-vscode/src/features/backlinks.spec.ts
+++ b/packages/foam-vscode/src/features/backlinks.spec.ts
@@ -1,0 +1,144 @@
+import { commands, workspace, window } from 'vscode';
+import { URI, FoamWorkspace, IDataStore, Resource, Note } from 'foam-core';
+import {
+  cleanWorkspace,
+  closeEditors,
+  createNote,
+  createTestNote,
+} from '../test/test-utils';
+import { BacklinksTreeDataProvider, BacklinkTreeItem } from './backlinks';
+import { ResourceTreeItem } from '../utils/grouped-resources-tree-data-provider';
+
+describe('Backlinks panel', () => {
+  beforeAll(async () => {
+    await cleanWorkspace();
+    await createNote(noteA);
+    await createNote(noteB);
+    await createNote(noteC);
+  });
+  afterAll(cleanWorkspace);
+
+  const rootUri = workspace.workspaceFolders[0].uri;
+  const ws = new FoamWorkspace();
+  const dataStore = {
+    read: uri => {
+      return Promise.resolve('');
+    },
+    isMatch: uri => uri.path.endsWith('.md'),
+  } as IDataStore;
+
+  const noteA = createTestNote({
+    root: rootUri,
+    uri: './note-a.md',
+  });
+  const noteB = createTestNote({
+    root: rootUri,
+    uri: './note-b.md',
+    links: [{ slug: 'note-a' }, { slug: 'note-a' }],
+  });
+  const noteC = createTestNote({
+    root: rootUri,
+    uri: './note-c.md',
+    links: [{ slug: 'note-a' }],
+  });
+  ws.set(noteA)
+    .set(noteB)
+    .set(noteC)
+    .resolveLinks(true);
+
+  const provider = new BacklinksTreeDataProvider(ws, dataStore);
+
+  beforeEach(async () => {
+    await closeEditors();
+    provider.target = undefined;
+  });
+
+  // Skipping these as still figuring out how to interact with the provider
+  // running in the test instance of VS Code
+  it.skip('does not target excluded files', async () => {
+    provider.target = URI.file('/excluded-file.txt');
+    expect(await provider.getChildren()).toEqual([]);
+  });
+  it.skip('targets active editor', async () => {
+    const docA = await workspace.openTextDocument(noteA.uri);
+    const docB = await workspace.openTextDocument(noteB.uri);
+
+    await window.showTextDocument(docA);
+    expect(provider.target).toEqual(noteA.uri);
+
+    await window.showTextDocument(docB);
+    expect(provider.target).toEqual(noteB.uri);
+  });
+
+  it('shows linking resources alphaetically by name', async () => {
+    provider.target = noteA.uri;
+    const notes = (await provider.getChildren()) as ResourceTreeItem[];
+    expect(notes.map(n => n.resource.uri.path)).toEqual([
+      noteB.uri.path,
+      noteC.uri.path,
+    ]);
+  });
+  it('shows references in position order', async () => {
+    provider.target = noteA.uri;
+    const notes = (await provider.getChildren()) as ResourceTreeItem[];
+    const linksFromB = (await provider.getChildren(
+      notes[0]
+    )) as BacklinkTreeItem[];
+    expect(linksFromB.map(l => l.link)).toEqual(
+      noteB.links.sort(
+        (a, b) => a.position.start.column - b.position.start.column
+      )
+    );
+  });
+  it('navigates to the document if clicking on note', async () => {
+    provider.target = noteA.uri;
+    const notes = (await provider.getChildren()) as ResourceTreeItem[];
+    expect(notes[0].command).toMatchObject({
+      command: 'vscode.open',
+      arguments: expect.arrayContaining([noteB.uri]),
+    });
+  });
+  it('navigates to document with link selection if clicking on backlink', async () => {
+    provider.target = noteA.uri;
+    const notes = (await provider.getChildren()) as ResourceTreeItem[];
+    const linksFromB = (await provider.getChildren(
+      notes[0]
+    )) as BacklinkTreeItem[];
+    expect(linksFromB[0].command).toMatchObject({
+      command: 'vscode.open',
+      arguments: [
+        noteB.uri,
+        {
+          selection: expect.arrayContaining([]),
+        },
+      ],
+    });
+  });
+  it('refreshes upon changes in the workspace', async () => {
+    let notes: ResourceTreeItem[] = [];
+    provider.target = noteA.uri;
+
+    notes = (await provider.getChildren()) as ResourceTreeItem[];
+    expect(notes.length).toEqual(2);
+
+    const noteD = createTestNote({
+      uri: '/note-d.md',
+    });
+    ws.set(noteD);
+    notes = (await provider.getChildren()) as ResourceTreeItem[];
+    expect(notes.length).toEqual(2);
+
+    const noteDBis = createTestNote({
+      uri: '/note-d.md',
+      links: [{ slug: 'note-a' }],
+    });
+    ws.set(noteDBis);
+    notes = (await provider.getChildren()) as ResourceTreeItem[];
+    expect(notes.length).toEqual(3);
+    expect(notes.map(n => n.resource.uri)).toEqual([
+      noteB.uri,
+      noteC.uri,
+      noteD.uri,
+    ]);
+  });
+});

--- a/packages/foam-vscode/src/features/backlinks.ts
+++ b/packages/foam-vscode/src/features/backlinks.ts
@@ -51,11 +51,11 @@ export class BacklinksTreeDataProvider
   // prettier-ignore
   private _onDidChangeTreeDataEmitter = new vscode.EventEmitter<BacklinkPanelTreeItem | undefined | void>();
   readonly onDidChangeTreeData = this._onDidChangeTreeDataEmitter.event;
-  private readonly getNoteContent: (uri: URI) => Promise<string>;
 
-  constructor(private workspace: FoamWorkspace, private dataStore: IDataStore) {
-    this.getNoteContent = (uri: URI) => dataStore.read(uri);
-  }
+  constructor(
+    private workspace: FoamWorkspace,
+    private dataStore: IDataStore
+  ) {}
 
   refresh(): void {
     this._onDidChangeTreeDataEmitter.fire();

--- a/packages/foam-vscode/src/features/backlinks.ts
+++ b/packages/foam-vscode/src/features/backlinks.ts
@@ -22,10 +22,6 @@ const feature: FoamFeature = {
   ) => {
     const foam = await foamPromise;
 
-    const workspacesURIs = vscode.workspace.workspaceFolders.map(
-      dir => dir.uri
-    );
-
     const provider = new BacklinksTreeDataProvider(
       foam.workspace,
       foam.services.dataStore
@@ -111,7 +107,6 @@ export class BacklinksTreeDataProvider
       b => b.source.path
     );
 
-    // TODO sort links by line
     const resources = Object.keys(backlinksByResourcePath)
       .map(res => backlinksByResourcePath[res][0].source)
       .map(uri => this.workspace.get(uri))
@@ -132,9 +127,7 @@ export class BacklinksTreeDataProvider
     return Promise.resolve(resources);
   }
 
-  async resolveTreeItem(
-    item: BacklinkPanelTreeItem
-  ): Promise<BacklinkPanelTreeItem> {
+  resolveTreeItem(item: BacklinkPanelTreeItem): Promise<BacklinkPanelTreeItem> {
     return item.resolveTreeItem();
   }
 }
@@ -166,8 +159,8 @@ export class BacklinkTreeItem extends vscode.TreeItem {
     };
   }
 
-  async resolveTreeItem(): Promise<BacklinkTreeItem> {
-    return this;
+  resolveTreeItem(): Promise<BacklinkTreeItem> {
+    return Promise.resolve(this);
   }
 }
 

--- a/packages/foam-vscode/src/features/backlinks.ts
+++ b/packages/foam-vscode/src/features/backlinks.ts
@@ -1,0 +1,174 @@
+import * as vscode from 'vscode';
+import { groupBy } from 'lodash';
+import {
+  Foam,
+  FoamWorkspace,
+  IDataStore,
+  isNote,
+  NoteLink,
+  Resource,
+  isSameUri,
+  URI,
+} from 'foam-core';
+import { getNoteTooltip } from '../utils';
+import { FoamFeature } from '../types';
+import { ResourceTreeItem } from '../utils/grouped-resources-tree-data-provider';
+import { Position } from 'unist';
+
+const feature: FoamFeature = {
+  activate: async (
+    context: vscode.ExtensionContext,
+    foamPromise: Promise<Foam>
+  ) => {
+    const foam = await foamPromise;
+
+    const workspacesURIs = vscode.workspace.workspaceFolders.map(
+      dir => dir.uri
+    );
+
+    const provider = new BacklinksTreeDataProvider(
+      foam.workspace,
+      foam.services.dataStore
+    );
+
+    vscode.window.onDidChangeActiveTextEditor(async () => {
+      provider.target = vscode.window.activeTextEditor?.document.uri;
+      await provider.refresh();
+    });
+
+    context.subscriptions.push(
+      vscode.window.registerTreeDataProvider('foam-vscode.backlinks', provider),
+      foam.workspace.onDidAdd(provider.refresh),
+      foam.workspace.onDidUpdate(provider.refresh),
+      foam.workspace.onDidDelete(provider.refresh)
+    );
+  },
+};
+export default feature;
+
+const isBefore = (a: Position, b: Position) =>
+  a.start.column - b.start.column || a.start.line - b.start.line;
+
+export class BacklinksTreeDataProvider
+  implements vscode.TreeDataProvider<BacklinkPanelTreeItem> {
+  public target?: URI = undefined;
+  // prettier-ignore
+  private _onDidChangeTreeDataEmitter = new vscode.EventEmitter<BacklinkPanelTreeItem | undefined | void>();
+  readonly onDidChangeTreeData = this._onDidChangeTreeDataEmitter.event;
+  private readonly getNoteContent: (uri: URI) => Promise<string>;
+
+  constructor(private workspace: FoamWorkspace, private dataStore: IDataStore) {
+    this.getNoteContent = (uri: URI) => dataStore.read(uri);
+  }
+
+  refresh(): void {
+    this._onDidChangeTreeDataEmitter.fire();
+  }
+
+  getTreeItem(item: BacklinkPanelTreeItem): vscode.TreeItem {
+    return item;
+  }
+
+  getChildren(item?: ResourceTreeItem): Thenable<BacklinkPanelTreeItem[]> {
+    const uri = this.target;
+    if (item) {
+      const resource = item.resource;
+      if (!isNote(resource)) {
+        return Promise.resolve([]);
+      }
+
+      const backlinkRefs = Promise.all(
+        resource.links
+          .filter(link =>
+            isSameUri(this.workspace.resolveLink(resource, link), uri)
+          )
+          .map(async link => {
+            const item = new BacklinkTreeItem(resource, link);
+            const lines = (await this.dataStore.read(resource.uri)).split('\n');
+            if (link.position.start.line < lines.length) {
+              const line = lines[link.position.start.line - 1];
+              let start = Math.max(0, link.position.start.column - 15);
+              const ellipsis = start === 0 ? '' : '...';
+
+              item.label = `${
+                link.position.start.line
+              }: ${ellipsis}${line.substr(start, 300)}`;
+              item.tooltip = getNoteTooltip(line);
+            }
+            return item;
+          })
+      );
+
+      return backlinkRefs;
+    }
+
+    if (!uri || !this.dataStore.isMatch(uri)) {
+      return Promise.resolve([]);
+    }
+
+    const backlinksByResourcePath = groupBy(
+      this.workspace.getConnections(uri).filter(c => isSameUri(c.target, uri)),
+      b => b.source.path
+    );
+
+    // TODO sort links by line
+    const resources = Object.keys(backlinksByResourcePath)
+      .map(res => backlinksByResourcePath[res][0].source)
+      .map(uri => this.workspace.get(uri))
+      .filter(isNote)
+      .sort((a, b) => a.title.localeCompare(b.title))
+      .map(note => {
+        const connections = backlinksByResourcePath[
+          note.uri.path
+        ].sort((a, b) => isBefore(a.link.position, b.link.position));
+        const item = new ResourceTreeItem(
+          note,
+          this.dataStore,
+          vscode.TreeItemCollapsibleState.Expanded
+        );
+        item.description = `(${connections.length}) ${item.description}`;
+        return item;
+      });
+    return Promise.resolve(resources);
+  }
+
+  async resolveTreeItem(
+    item: BacklinkPanelTreeItem
+  ): Promise<BacklinkPanelTreeItem> {
+    return item.resolveTreeItem();
+  }
+}
+
+export class BacklinkTreeItem extends vscode.TreeItem {
+  constructor(
+    public readonly resource: Resource,
+    public readonly link: NoteLink
+  ) {
+    super(
+      link.type === 'wikilink' ? link.slug : link.label,
+      vscode.TreeItemCollapsibleState.None
+    );
+    this.label = `${link.position.start.line}: ${this.label}`;
+    const range: vscode.Range = new vscode.Range(
+      new vscode.Position(
+        link.position.start.line - 1,
+        link.position.start.column - 1
+      ),
+      new vscode.Position(
+        link.position.end.line - 1,
+        link.position.end.column - 1
+      )
+    );
+    this.command = {
+      command: 'vscode.open',
+      arguments: [resource.uri, { selection: range }],
+      title: 'Go to link',
+    };
+  }
+
+  async resolveTreeItem(): Promise<BacklinkTreeItem> {
+    return this;
+  }
+}
+
+type BacklinkPanelTreeItem = ResourceTreeItem | BacklinkTreeItem;

--- a/packages/foam-vscode/src/features/index.ts
+++ b/packages/foam-vscode/src/features/index.ts
@@ -9,6 +9,7 @@ import createFromTemplate from './create-from-template';
 import openRandomNote from './open-random-note';
 import orphans from './orphans';
 import placeholders from './placeholders';
+import backlinks from './backlinks';
 import utilityCommands from './utility-commands';
 import { FoamFeature } from '../types';
 
@@ -24,5 +25,6 @@ export const features: FoamFeature[] = [
   createFromTemplate,
   orphans,
   placeholders,
+  backlinks,
   utilityCommands,
 ];

--- a/packages/foam-vscode/src/test/test-utils.ts
+++ b/packages/foam-vscode/src/test/test-utils.ts
@@ -1,13 +1,17 @@
 // TODO: this file has some utility functions also present in foam-core testing
 // they should be consolidated
 
+import * as vscode from 'vscode';
+import path from 'path';
 import {
   URI,
   Attachment,
   NoteLinkDefinition,
   Note,
   Placeholder,
+  parseUri,
 } from 'foam-core';
+import { TextEncoder } from 'util';
 
 const position = {
   start: { line: 1, column: 1 },
@@ -45,30 +49,40 @@ export const createTestNote = (params: {
   definitions?: NoteLinkDefinition[];
   links?: Array<{ slug: string } | { to: string }>;
   text?: string;
+  root?: URI;
 }): Note => {
+  const root = params.root ?? URI.file('/');
   return {
-    uri: strToUri(params.uri),
+    uri: parseUri(root, params.uri),
     type: 'note',
     properties: {},
-    title: params.title ?? null,
+    title: params.title ?? path.parse(strToUri(params.uri).path).base,
     definitions: params.definitions ?? [],
     tags: new Set(),
     links: params.links
-      ? params.links.map(link =>
-          'slug' in link
+      ? params.links.map((link, index) => {
+          const pos = {
+            start: {
+              line: position.start.line + index,
+              column: position.start.column,
+            },
+            end: position.end,
+          };
+          return 'slug' in link
             ? {
                 type: 'wikilink',
                 slug: link.slug,
                 target: link.slug,
-                position: position,
+                position: pos,
                 text: 'link text',
               }
             : {
                 type: 'link',
                 target: link.to,
                 label: 'link text',
-              }
-        )
+                position: pos,
+              };
+        })
       : [],
     source: {
       eol: eol,
@@ -77,4 +91,33 @@ export const createTestNote = (params: {
       text: params.text ?? '',
     },
   };
+};
+
+export const cleanWorkspace = async () => {
+  const files = await vscode.workspace.findFiles('**', '.vscode');
+  await Promise.all(files.map(f => vscode.workspace.fs.delete(f)));
+};
+
+export const wait = (ms: number) =>
+  new Promise(resolve => setTimeout(resolve, ms));
+
+export const closeEditors = async () => {
+  await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+  await wait(100);
+};
+
+export const createNote = (r: Note) => {
+  let content = `# ${r.title}
+
+  some content and ${r.links
+    .map(l =>
+      l.type === 'wikilink' ? `[[${l.slug}]]` : `[${l.label}](${l.target})`
+    )
+    .join(' some content between links.\n')}
+  last line.
+`;
+  return vscode.workspace.fs.writeFile(
+    r.uri,
+    new TextEncoder().encode(content)
+  );
 };

--- a/packages/foam-vscode/src/utils/grouped-resources-tree-data-provider.ts
+++ b/packages/foam-vscode/src/utils/grouped-resources-tree-data-provider.ts
@@ -161,7 +161,7 @@ export class GroupedResourcesTreeDataProvider
     return Promise.resolve(resources);
   }
 
-  async resolveTreeItem(
+  resolveTreeItem(
     item: GroupedResourceTreeItem
   ): Promise<GroupedResourceTreeItem> {
     return item.resolveTreeItem();
@@ -293,7 +293,7 @@ export class DirectoryTreeItem extends vscode.TreeItem {
   iconPath = new vscode.ThemeIcon('folder');
   contextValue = 'directory';
 
-  async resolveTreeItem(): Promise<GroupedResourceTreeItem> {
-    return this;
+  resolveTreeItem(): Promise<GroupedResourceTreeItem> {
+    return Promise.resolve(this);
   }
 }

--- a/packages/foam-vscode/src/utils/grouped-resources-tree-data-provider.ts
+++ b/packages/foam-vscode/src/utils/grouped-resources-tree-data-provider.ts
@@ -234,7 +234,7 @@ export class ResourceTreeItem extends vscode.TreeItem {
   ) {
     super(getTitle(resource), collapsibleState);
     this.contextValue = 'resource';
-    this.description = vscode.workspace.asRelativePath(resource.uri);
+    this.description = vscode.workspace.asRelativePath(resource.uri.path);
     this.tooltip = undefined;
     if (isPlaceholder(resource)) {
       this.command = {

--- a/packages/foam-vscode/src/utils/grouped-resources-tree-data-provider.ts
+++ b/packages/foam-vscode/src/utils/grouped-resources-tree-data-provider.ts
@@ -234,7 +234,10 @@ export class ResourceTreeItem extends vscode.TreeItem {
   ) {
     super(getTitle(resource), collapsibleState);
     this.contextValue = 'resource';
-    this.description = vscode.workspace.asRelativePath(resource.uri.path);
+    this.description = resource.uri.path.replace(
+      vscode.workspace.getWorkspaceFolder(resource.uri)?.uri.path,
+      ''
+    );
     this.tooltip = undefined;
     if (isPlaceholder(resource)) {
       this.command = {

--- a/packages/foam-vscode/src/utils/grouped-resources-tree-data-provider.ts
+++ b/packages/foam-vscode/src/utils/grouped-resources-tree-data-provider.ts
@@ -150,13 +150,13 @@ export class GroupedResourcesTreeDataProvider
 
     if (directory) {
       const resources = directory.resources.map(
-        o => new ResourceTreeItem(o, this.resourceName)
+        o => new ResourceTreeItem(o, this.dataStore)
       );
       return Promise.resolve(resources);
     }
 
     const resources = this.resources.map(
-      o => new ResourceTreeItem(o, this.resourceName)
+      o => new ResourceTreeItem(o, this.dataStore)
     );
     return Promise.resolve(resources);
   }
@@ -164,11 +164,7 @@ export class GroupedResourcesTreeDataProvider
   async resolveTreeItem(
     item: GroupedResourceTreeItem
   ): Promise<GroupedResourceTreeItem> {
-    if (item instanceof ResourceTreeItem) {
-      const content = await this.dataStore.read(item.resource.uri);
-      item.tooltip = getNoteTooltip(content);
-    }
-    return item;
+    return item.resolveTreeItem();
   }
 
   private computeResources(): void {
@@ -230,10 +226,15 @@ type ResourceByDirectory = { [key: string]: Resource[] };
 
 type GroupedResourceTreeItem = ResourceTreeItem | DirectoryTreeItem;
 
-class ResourceTreeItem extends vscode.TreeItem {
-  constructor(public readonly resource: Resource, itemLabel: string) {
-    super(getTitle(resource), vscode.TreeItemCollapsibleState.None);
-    this.description = resource.uri.path;
+export class ResourceTreeItem extends vscode.TreeItem {
+  constructor(
+    public readonly resource: Resource,
+    private readonly dataStore: IDataStore,
+    collapsibleState = vscode.TreeItemCollapsibleState.None
+  ) {
+    super(getTitle(resource), collapsibleState);
+    this.contextValue = 'resource';
+    this.description = vscode.workspace.asRelativePath(resource.uri);
     this.tooltip = undefined;
     if (isPlaceholder(resource)) {
       this.command = {
@@ -248,7 +249,6 @@ class ResourceTreeItem extends vscode.TreeItem {
         arguments: [resource.uri],
       };
     }
-    this.contextValue = itemLabel;
 
     let iconStr: string;
     switch (this.resource.type) {
@@ -264,6 +264,16 @@ class ResourceTreeItem extends vscode.TreeItem {
         break;
     }
     this.iconPath = new vscode.ThemeIcon(iconStr);
+  }
+
+  async resolveTreeItem(): Promise<ResourceTreeItem> {
+    if (this instanceof ResourceTreeItem) {
+      const content = await this.dataStore?.read(this.resource.uri);
+      this.tooltip = content
+        ? getNoteTooltip(content)
+        : getTitle(this.resource);
+    }
+    return this;
   }
 }
 
@@ -282,4 +292,8 @@ export class DirectoryTreeItem extends vscode.TreeItem {
 
   iconPath = new vscode.ThemeIcon('folder');
   contextValue = 'directory';
+
+  async resolveTreeItem(): Promise<GroupedResourceTreeItem> {
+    return this;
+  }
 }


### PR DESCRIPTION
Bringing the backlink in house.
Why?
- it's fully based on the Foam model, so it provides a consistent representation of notes in the workspace
- it provides the same preview functionality for note tree items as the other Foam panels
- it also provides a preview for the full row for each reference, to get better context of the link

In the process we needed to make some changes in the model, specifically:
- all links now have a reference to their position (before just wikilinks, not direct links)
- improved support for a note having more than one link to another

Will leave a couple of comments in the code to highlight some interesting points

![image](https://user-images.githubusercontent.com/457005/109991556-b3864c00-7d0a-11eb-92c5-683e21849182.png)
