### PR TITLE
Ignore directories ending in md

### DIFF
--- a/packages/foam-core/src/bootstrap.ts
+++ b/packages/foam-core/src/bootstrap.ts
@@ -3,6 +3,7 @@ import { FoamConfig, Foam, IDataStore } from './index';
 import { loadPlugins } from './plugins';
 import { isSome } from './utils';
 import { Logger } from './utils/log';
+import { isMarkdownFile } from './utils/uri';
 import { FoamWorkspace } from './model/workspace';
 
 export const bootstrap = async (config: FoamConfig, dataStore: IDataStore) => {
@@ -16,7 +17,7 @@ export const bootstrap = async (config: FoamConfig, dataStore: IDataStore) => {
   await Promise.all(
     files.map(async uri => {
       Logger.info('Found: ' + uri);
-      if (uri.path.endsWith('md')) {
+      if (isMarkdownFile(uri)) {
         const content = await dataStore.read(uri);
         if (isSome(content)) {
           workspace.set(parser.parse(uri, content));

--- a/packages/foam-core/src/utils/uri.ts
+++ b/packages/foam-core/src/utils/uri.ts
@@ -2,6 +2,7 @@ import { posix } from 'path';
 import GithubSlugger from 'github-slugger';
 import { hash } from './core';
 import { URI } from '../common/uri';
+import { statSync } from 'fs';
 
 export const uriToSlug = (noteUri: URI): string => {
   return GithubSlugger.slug(posix.parse(noteUri.path).name);
@@ -95,3 +96,7 @@ export const isSameUri = (a: URI, b: URI) =>
   a.path === b.path && // Note we don't use fsPath for sameness
   a.fragment === b.fragment &&
   a.query === b.query;
+
+export const isMarkdownFile = (uri: URI): boolean => {
+  return uri.path.endsWith('md') && statSync(uri.fsPath).isFile();
+};


### PR DESCRIPTION
Fixes #483 

We now check to ensure that the URI is a file (not a directory, etc.).
~We also now accept more extensions to be used.~