### PR TITLE
[Templates v2] Add `FOAM_TITLE` snippet variable

### DIFF
--- a/docs/features/note-templates.md
+++ b/docs/features/note-templates.md
@@ -14,4 +14,14 @@ To create a note from a template, execute the `Foam: Create New Note From Templa
 
 _Theme: Ayu Light_
 
+### Variables
+
 Templates can use all the variables available in [VS Code Snippets](https://code.visualstudio.com/docs/editor/userdefinedsnippets#_variables).
+
+In addition, you can also use variables provided by Foam:
+
+| Name         | Description                                                                         |
+| ------------ | ----------------------------------------------------------------------------------- |
+| `FOAM_TITLE` | The title of the note. If used, Foam will prompt you to enter a title for the note. |
+
+**Note:** neither the defaulting feature (eg. `${variable:default}`) nor the format feature (eg. `${variable/(.*)/${1:/upcase}/}`) (available to other variables) are available for these Foam-provided variables.

--- a/packages/foam-vscode/src/features/create-from-template.test.ts
+++ b/packages/foam-vscode/src/features/create-from-template.test.ts
@@ -1,0 +1,36 @@
+import { window } from 'vscode';
+import { substituteFoamVariables } from './create-from-template';
+
+describe('substituteFoamVariables', () => {
+  test('Does nothing if no Foam-specific variables are used', async () => {
+    const input = `
+      # \${AnotherVariable} <-- Unrelated to foam
+      # \${AnotherVariable:default_value} <-- Unrelated to foam
+      # \${AnotherVariable:default_value/(.*)/\${1:/upcase}/}} <-- Unrelated to foam
+      # $AnotherVariable} <-- Unrelated to foam
+      # #CURRENT_YEAR-\${CURRENT_MONTH}-$CURRENT_DAY <-- Unrelated to foam
+    `;
+
+    expect(await substituteFoamVariables(input)).toEqual(input);
+  });
+
+  test('Resolves FOAM_TITLE', async () => {
+    const input = `
+      # $FOAM_TITLE <-- The title goes here
+      # \${FOAM_TITLE} <-- and also here
+    `;
+
+    const foam_title = 'My note title';
+
+    jest
+      .spyOn(window, 'showInputBox')
+      .mockImplementationOnce(jest.fn(() => Promise.resolve(foam_title)));
+
+    const expected = `
+      # My note title <-- The title goes here
+      # My note title <-- and also here
+    `;
+
+    expect(await substituteFoamVariables(input)).toEqual(expected);
+  });
+});

--- a/packages/foam-vscode/src/features/janitor.ts
+++ b/packages/foam-vscode/src/features/janitor.ts
@@ -3,7 +3,6 @@ import {
   workspace,
   ExtensionContext,
   commands,
-  Range,
   ProgressLocation,
 } from 'vscode';
 import * as fs from 'fs';

--- a/packages/foam-vscode/src/features/preview-navigation.ts
+++ b/packages/foam-vscode/src/features/preview-navigation.ts
@@ -23,7 +23,7 @@ export const markdownItWithFoamLinks = (
 ) => {
   return md.use(markdownItRegex, {
     name: 'connect-wikilinks',
-    regex: /\[\[([^\[\]]+?)\]\]/,
+    regex: /\[\[([^[\]]+?)\]\]/,
     replace: (wikilink: string) => {
       try {
         const resource = workspace.find(wikilink);

--- a/packages/foam-vscode/src/utils/vsc-utils.ts
+++ b/packages/foam-vscode/src/utils/vsc-utils.ts
@@ -1,4 +1,4 @@
-import { Position, Range, Uri, workspace } from 'vscode';
+import { Position, Range, Uri } from 'vscode';
 import {
   Position as FoamPosition,
   Range as FoamRange,


### PR DESCRIPTION
Following on the discussion in #534, I've taken the first step towards implementation.

This PR adds `FOAM_TITLE` variable.

Fixes #560 

# Naming

I'm fine to name the variable whatever. 🤷 It has the `FOAM_` prefix as a namespace to show that it was provided by Foam.
It uses all caps to match the variable name style that VSCode/TextMate uses.

# Limitations

If you look at the [full syntax](https://code.visualstudio.com/docs/editor/userdefinedsnippets#_grammar) for TextMate variables, you'll see that variables can contain:

* default values (`${FOAM_TITLE:This is my Title}`)
* transfomations (`${FOAM_TITLE/(.*)/{$1:/downcase}/}`)

For simplicity, I have not implemented support for these.
VSCode doesn't expose its [`SnippetParser`](https://github.com/microsoft/vscode/blob/72d14ad2fb6fa9dbf9484b92f927dbf39c9d60d2/src/vs/editor/contrib/snippet/snippetParser.ts) to us, and the re-implementation is a decent amount of work.
In the future, I would love to extend our support so that users can use these features like any other variables in the file.

# Current Implementation

- It looks for variables that start with `FOAM_` using a regex
- It resolves the variables that it knows  how to resolve (currently just `FOAM_TITLE`) and ignores unknown ones
- It swaps instances of the variables in the template with the resolved values
- It sends the substituted template test to `SnippetString` (as it always did) and let VSCode do its thing.

# Alternatives

If we could change the regex to recognize variables with default values and transforms, then instead of replacing the entire variable before sending it to the `SnippetParser`, we could resolve the values, and replace the default value with our resolved value. Something like:

Template contains: `${FOAM_TITLE/(.*)/{$1:/downcase}/}`

We resolve `FOAM_TITLE` to `User Provided New Note Title` and send `${FOAM_TITLE:User Provided New Note Title/(.*)/{$1:/downcase}/}` to the `SnippetParser`.

The `SnippetParser` doesn't recognize `FOAM_TITLE`, so it falls to the default value `User Provided New Note Title` and runs the transform.

# For the next PR

Ref: #561 

Refactor this code to allow for variables to depend on the resolved values of other variables.
ex. the proposed `FOAM_TITLE_SLUG` variable depends on the resolved value of `FOAM_TITLE`. Other things will have to be refactored at the same time though (eg. when we ask the user for the filepath, we should preopulate it with `FOAM_TITLE_SLUG` if we asked them for `FOAM_TITLE`), so I'll leave that for the next PR.