### PR TITLE
[TRIVIAL] Add a placeholder for the template file quick pick menu

### DIFF
--- a/packages/foam-vscode/src/features/create-from-template.ts
+++ b/packages/foam-vscode/src/features/create-from-template.ts
@@ -62,7 +62,9 @@ async function createNoteFromTemplate(): Promise<void> {
     activeFile !== undefined
       ? URI.parse(path.dirname(activeFile))
       : workspace.workspaceFolders[0].uri;
-  const selectedTemplate = await window.showQuickPick(templates);
+  const selectedTemplate = await window.showQuickPick(templates, {
+    placeHolder: 'Select a template to use.',
+  });
   if (selectedTemplate === undefined) {
     return;
   }


### PR DESCRIPTION
Slightly nicer UX when using `Create New Note From Template`.

The first step of  `Create New Note From Template` is selecting a template file to use.

**Before:**

<img width="626" alt="image" src="https://user-images.githubusercontent.com/1459385/112762948-64150200-8fd0-11eb-9850-6d2aaee7cb92.png">

**After:**

<img width="708" alt="image" src="https://user-images.githubusercontent.com/1459385/112762904-3a5bdb00-8fd0-11eb-9998-ff88c00875cc.png">
