### PR TITLE
docs: update instructions for Github pages

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ Like the soapy suds it's named after, **Foam** is mostly air.
 
 1. The editing experience of **Foam** is powered by VS Code, enhanced by workspace settings that glue together [[recommended-extensions]] and preferences optimised for writing and navigating information.
 2. To back up, collaborate on and share your content between devices, Foam pairs well with [GitHub](http://github.com/).
-3. To publish your content, you can set it up to publish to [GitHub Pages](https://pages.github.com/) with zero code and zero config, or to any website hosting platform like [Netlify](http://netlify.com/) or [Vercel](https://vercel.com).
+3. To publish your content, you can set it up to publish to [GitHub Pages](https://pages.github.com/), or to any website hosting platform like [Netlify](http://netlify.com/) or [Vercel](https://vercel.com).
 
 > **Fun fact**: This documentation was researched, written and published using **Foam**.
 

--- a/docs/publishing/publish-to-github-pages.md
+++ b/docs/publishing/publish-to-github-pages.md
@@ -1,6 +1,8 @@
 # Github Pages
 
-- The [Foam template](https://github.com/foambubble/foam-template) is **GitHub Pages** ready, all you have to do is [turn it on in your repository settings](https://guides.github.com/features/pages/).
+- In VSCode workspace settings set `"foam.edit.linkReferenceDefinitions": "withoutExtensions"`
+- Execute the “Foam: Run Janitor” command from the command palette.
+- [Turn **GitHub Pages** on in your repository settings](https://guides.github.com/features/pages/).
 - The default GitHub Pages template is called [Primer](https://github.com/pages-themes/primer). See Primer docs for how to customise html layouts and templates.
 - GitHub Pages is built on [Jekyll](https://jekyllrb.com/), so it supports things like permalinks, front matter metadata etc.
 


### PR DESCRIPTION
Because foam template defaults have been changed:
https://github.com/foambubble/foam-template/commit/ec2d44ad86e3df962008361a07ba2501a5943515#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L16