### PR TITLE
fixed bug with Chinese characters in tags (Issue #567)

### DIFF
--- a/packages/foam-core/src/utils/hashtags.ts
+++ b/packages/foam-core/src/utils/hashtags.ts
@@ -1,6 +1,6 @@
 import { isSome } from './core';
-const HASHTAG_REGEX = /(^|[ ])#([\w_-]*[a-zA-Z][\w_-]*\b)/gm;
-const WORD_REGEX = /(^|[ ])([\w_-]*[a-zA-Z][\w_-]*\b)/gm;
+const HASHTAG_REGEX = /(^|\s)#([0-9]*[\p{L}_-][\p{L}\p{N}_-]*)/gmu;
+const WORD_REGEX = /(^|\s)([0-9]*[\p{L}_-][\p{L}\p{N}_-]*)/gmu;
 
 export const extractHashtags = (text: string): Set<string> => {
   return isSome(text)

--- a/packages/foam-core/test/utils.test.ts
+++ b/packages/foam-core/test/utils.test.ts
@@ -95,6 +95,16 @@ describe('hashtag extraction', () => {
       extractHashtags('this #123 tag should be ignore, but not #123four')
     ).toEqual(new Set(['123four']));
   });
+  it('supports unicode letters like Chinese charaters', () => {
+    expect(
+      extractHashtags(`
+        this #tag_with_unicode_letters_汉字, pure Chinese tag like #纯中文标签 and 
+        other mixed tags like #标签1 #123四 should work
+      `)
+    ).toEqual(
+      new Set(['tag_with_unicode_letters_汉字', '纯中文标签', '标签1', '123四'])
+    );
+  });
 
   it('ignores hashes in plain text urls and links', () => {
     expect(


### PR DESCRIPTION
Makes tags support Unicode Letters.

So it possible to create tags with Chinese characters [Issue #567 ](https://github.com/foambubble/foam/issues/567).

Here is my local test pictures after this fix.

![diff_with_change](https://user-images.githubusercontent.com/1583193/113511385-1846f780-9592-11eb-9fbb-c05587292078.png)


