### PR TITLE
Add FOAM_TITLE_SLUG template variable

### DIFF
--- a/docs/features/note-templates.md
+++ b/docs/features/note-templates.md
@@ -20,8 +20,9 @@ Templates can use all the variables available in [VS Code Snippets](https://code
 
 In addition, you can also use variables provided by Foam:
 
-| Name         | Description                                                                         |
-| ------------ | ----------------------------------------------------------------------------------- |
-| `FOAM_TITLE` | The title of the note. If used, Foam will prompt you to enter a title for the note. |
+| Name              | Description                                                                                                                                                                                                                                                                                                                        |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `FOAM_TITLE`      | The title of the note. If used, Foam will prompt you to enter a title for the note.                                                                                                                                                                                                                                                |
+| `FOAM_TITLE_SLUG` | The "slug-ified" version of `FOAM_TITLE`, suitable for use in a filepath. If used, Foam will prompt you to enter a title for the note. For example, if the value provided to `FOAM_TITLE` was `Living in a dream world`, then `FOAM_TITLE_SLUG` will be `living-in-a-dream-world`. Note that it does not include a file extension. |
 
 **Note:** neither the defaulting feature (eg. `${variable:default}`) nor the format feature (eg. `${variable/(.*)/${1:/upcase}/}`) (available to other variables) are available for these Foam-provided variables.

--- a/packages/foam-vscode/src/features/create-from-template.test.ts
+++ b/packages/foam-vscode/src/features/create-from-template.test.ts
@@ -1,5 +1,8 @@
 import { window } from 'vscode';
-import { substituteFoamVariables } from './create-from-template';
+import {
+  resolveFoamVariables,
+  substituteFoamVariables,
+} from './create-from-template';
 
 describe('substituteFoamVariables', () => {
   test('Does nothing if no Foam-specific variables are used', () => {
@@ -12,27 +15,142 @@ describe('substituteFoamVariables', () => {
     `;
 
     const givenValues = new Map<string, string>();
+    givenValues.set('FOAM_TITLE', 'My note title');
+    givenValues.set('FOAM_TITLE_SLUG', 'my-note-title');
     expect(substituteFoamVariables(input, givenValues)).toEqual(input);
   });
 
-  test('Resolves FOAM_TITLE', () => {
+  test('Correctly substitutes variables that are substrings of one another', () => {
+    // FOAM_TITLE is a substring of FOAM_TITLE_SLUG
+    // If we're not careful with how we substitute the values
+    // we can end up putting the FOAM_TITLE where FOAM_TITLE_SLUG should be.
     const input = `
-      # $FOAM_TITLE <-- The title goes here
-      # \${FOAM_TITLE} <-- and also here
+      # \${FOAM_TITLE}
+      # $FOAM_TITLE
+      # \${FOAM_TITLE_SLUG}
+      # $FOAM_TITLE_SLUG
     `;
 
+    const expected = `
+      # My note title
+      # My note title
+      # my-note-title
+      # my-note-title
+    `;
+
+    const givenValues = new Map<string, string>();
+    givenValues.set('FOAM_TITLE', 'My note title');
+    givenValues.set('FOAM_TITLE_SLUG', 'my-note-title');
+    expect(substituteFoamVariables(input, givenValues)).toEqual(expected);
+  });
+});
+
+describe('resolveFoamVariables', () => {
+  test('Does nothing for unknown Foam-specific variables', async () => {
+    const variables = ['FOAM_FOO'];
+
+    const expected = new Map<string, string>();
+    expected.set('FOAM_FOO', 'FOAM_FOO');
+
+    const givenValues = new Map<string, string>();
+    expect(await resolveFoamVariables(variables, givenValues)).toEqual(
+      expected
+    );
+  });
+
+  test('Resolves FOAM_TITLE', async () => {
     const foam_title = 'My note title';
+    const variables = ['FOAM_TITLE'];
 
     jest
       .spyOn(window, 'showInputBox')
       .mockImplementationOnce(jest.fn(() => Promise.resolve(foam_title)));
 
-    const expected = `
-      # My note title <-- The title goes here
-      # My note title <-- and also here
-    `;
+    const expected = new Map<string, string>();
+    expected.set('FOAM_TITLE', foam_title);
 
     const givenValues = new Map<string, string>();
-    expect(substituteFoamVariables(input, givenValues)).toEqual(expected);
+    expect(await resolveFoamVariables(variables, givenValues)).toEqual(
+      expected
+    );
+  });
+
+  test('Resolves FOAM_TITLE without asking the user when it is provided', async () => {
+    const foam_title = 'My note title';
+    const variables = ['FOAM_TITLE'];
+
+    const expected = new Map<string, string>();
+    expected.set('FOAM_TITLE', foam_title);
+
+    const givenValues = new Map<string, string>();
+    givenValues.set('FOAM_TITLE', foam_title);
+    expect(await resolveFoamVariables(variables, givenValues)).toEqual(
+      expected
+    );
+  });
+
+  test('Resolves FOAM_TITLE and FOAM_TITLE_SLUG, but only prompts the user for the title once', async () => {
+    const foam_title = 'My note title';
+    const variables = ['FOAM_TITLE', 'FOAM_TITLE_SLUG'];
+
+    jest
+      .spyOn(window, 'showInputBox')
+      .mockImplementationOnce(jest.fn(() => Promise.resolve(foam_title)));
+
+    const expected = new Map<string, string>();
+    expected.set('FOAM_TITLE', foam_title);
+    expected.set('FOAM_TITLE_SLUG', 'my-note-title');
+
+    const givenValues = new Map<string, string>();
+    expect(await resolveFoamVariables(variables, givenValues)).toEqual(
+      expected
+    );
+  });
+
+  test('Resolves FOAM_TITLE_SLUG by resolving FOAM_TITLE first when FOAM_TITLE is not used', async () => {
+    const foam_title = 'My note title';
+    const variables = ['FOAM_TITLE_SLUG'];
+
+    jest
+      .spyOn(window, 'showInputBox')
+      .mockImplementationOnce(jest.fn(() => Promise.resolve(foam_title)));
+
+    const expected = new Map<string, string>();
+    expected.set('FOAM_TITLE_SLUG', 'my-note-title');
+
+    const givenValues = new Map<string, string>();
+    expect(await resolveFoamVariables(variables, givenValues)).toEqual(
+      expected
+    );
+  });
+
+  test('Resolves FOAM_TITLE_SLUG when FOAM_TITLE is provided', async () => {
+    const foam_title = 'My note title';
+    const variables = ['FOAM_TITLE_SLUG'];
+
+    const expected = new Map<string, string>();
+    expected.set('FOAM_TITLE_SLUG', 'my-note-title');
+
+    const givenValues = new Map<string, string>();
+    givenValues.set('FOAM_TITLE', foam_title);
+
+    expect(await resolveFoamVariables(variables, givenValues)).toEqual(
+      expected
+    );
+  });
+
+  test('Resolves FOAM_TITLE_SLUG when FOAM_TITLE_SLUG is provided', async () => {
+    const foam_title_slug = 'my-note-title';
+    const variables = ['FOAM_TITLE_SLUG'];
+
+    const expected = new Map<string, string>();
+    expected.set('FOAM_TITLE_SLUG', foam_title_slug);
+
+    const givenValues = new Map<string, string>();
+    givenValues.set('FOAM_TITLE_SLUG', foam_title_slug);
+
+    expect(await resolveFoamVariables(variables, givenValues)).toEqual(
+      expected
+    );
   });
 });

--- a/packages/foam-vscode/src/features/create-from-template.test.ts
+++ b/packages/foam-vscode/src/features/create-from-template.test.ts
@@ -2,7 +2,7 @@ import { window } from 'vscode';
 import { substituteFoamVariables } from './create-from-template';
 
 describe('substituteFoamVariables', () => {
-  test('Does nothing if no Foam-specific variables are used', async () => {
+  test('Does nothing if no Foam-specific variables are used', () => {
     const input = `
       # \${AnotherVariable} <-- Unrelated to foam
       # \${AnotherVariable:default_value} <-- Unrelated to foam
@@ -11,10 +11,11 @@ describe('substituteFoamVariables', () => {
       # #CURRENT_YEAR-\${CURRENT_MONTH}-$CURRENT_DAY <-- Unrelated to foam
     `;
 
-    expect(await substituteFoamVariables(input)).toEqual(input);
+    const givenValues = new Map<string, string>();
+    expect(substituteFoamVariables(input, givenValues)).toEqual(input);
   });
 
-  test('Resolves FOAM_TITLE', async () => {
+  test('Resolves FOAM_TITLE', () => {
     const input = `
       # $FOAM_TITLE <-- The title goes here
       # \${FOAM_TITLE} <-- and also here
@@ -31,6 +32,7 @@ describe('substituteFoamVariables', () => {
       # My note title <-- and also here
     `;
 
-    expect(await substituteFoamVariables(input)).toEqual(expected);
+    const givenValues = new Map<string, string>();
+    expect(substituteFoamVariables(input, givenValues)).toEqual(expected);
   });
 });


### PR DESCRIPTION
Implements #561

I have refactored the code in #549. **This should not be merged until that one is merged, AND this one is rebased.**

The top level command cna pass in known values for each of the variables, which will be useful in a future where clicking a Wikilink provides the value of `FOAM_TITLE`.

Then I added `FOAM_TITLE_SLUG`, which required additional refactoring. This is because it depends on the value of `FOAM_TITLE`, which may or may not be present in the template, and may or may not be already resolved.

# ~Open~ question

**Update: I'm going to leave the existing behaviour for now: we won't ask for the title unless the template needs it.**

Should we always resolve `FOAM_TITLE_SLUG` (regardless of whether the template asks for it)?

**Benefit:** We always have it available to populate the default filepath
**Detriment:** We always ask the user for it when using `Foam: Create New Note From Template` (ie. 1 more step). If they use either `FOAM_TITLE_SLUG` or `FOAM_TITLE`, there won't be any additional steps.