### PR TITLE
Handle file errors more gracefully in FileDataStore

### DIFF
--- a/packages/foam-core/src/bootstrap.ts
+++ b/packages/foam-core/src/bootstrap.ts
@@ -30,11 +30,11 @@ export const bootstrap = async (config: FoamConfig, dataStore: IDataStore) => {
   const listeners = [
     dataStore.onDidChange(async uri => {
       const content = await dataStore.read(uri);
-      workspace.set(await parser.parse(uri, content));
+      isSome(content) && workspace.set(await parser.parse(uri, content));
     }),
     dataStore.onDidCreate(async uri => {
       const content = await dataStore.read(uri);
-      workspace.set(await parser.parse(uri, content));
+      isSome(content) && workspace.set(await parser.parse(uri, content));
     }),
     dataStore.onDidDelete(uri => {
       workspace.delete(uri);

--- a/packages/foam-core/src/services/datastore.ts
+++ b/packages/foam-core/src/services/datastore.ts
@@ -39,8 +39,10 @@ export interface IDataStore {
 
   /**
    * Read the content of the file from the store
+   *
+   * Returns `null` in case of errors while reading
    */
-  read: (uri: URI) => Promise<string>;
+  read: (uri: URI) => Promise<string | null>;
 
   /**
    * Returns whether the given URI is a match in
@@ -156,7 +158,12 @@ export class FileDataStore implements IDataStore, IDisposable {
   }
 
   async read(uri: URI) {
-    return (await fs.promises.readFile(URI.toFsPath(uri))).toString();
+    try {
+      return (await fs.promises.readFile(URI.toFsPath(uri))).toString();
+    } catch (e) {
+      Logger.error(`onDidCreate: error while reading uri: ${uri.path} - ${e}`);
+      return null;
+    }
   }
 
   dispose() {

--- a/packages/foam-core/src/services/datastore.ts
+++ b/packages/foam-core/src/services/datastore.ts
@@ -161,7 +161,9 @@ export class FileDataStore implements IDataStore, IDisposable {
     try {
       return (await fs.promises.readFile(URI.toFsPath(uri))).toString();
     } catch (e) {
-      Logger.error(`onDidCreate: error while reading uri: ${uri.path} - ${e}`);
+      Logger.error(
+        `FileDataStore: error while reading uri: ${uri.path} - ${e}`
+      );
       return null;
     }
   }

--- a/packages/foam-vscode/src/features/backlinks.ts
+++ b/packages/foam-vscode/src/features/backlinks.ts
@@ -79,7 +79,9 @@ export class BacklinksTreeDataProvider
           )
           .map(async link => {
             const item = new BacklinkTreeItem(resource, link);
-            const lines = (await this.dataStore.read(resource.uri)).split('\n');
+            const lines = (
+              (await this.dataStore.read(resource.uri)) ?? ''
+            ).split('\n');
             if (link.range.start.line < lines.length) {
               const line = lines[link.range.start.line];
               let start = Math.max(0, link.range.start.character - 15);

--- a/packages/foam-vscode/src/features/tags-tree-view/index.ts
+++ b/packages/foam-vscode/src/features/tags-tree-view/index.ts
@@ -1,7 +1,12 @@
 import * as vscode from 'vscode';
 import { Foam, Note, IDataStore, URI } from 'foam-core';
 import { FoamFeature } from '../../types';
-import { getNoteTooltip, getContainsTooltip, isNote } from '../../utils';
+import {
+  getNoteTooltip,
+  getContainsTooltip,
+  isNote,
+  isSome,
+} from '../../utils';
 
 const feature: FoamFeature = {
   activate: async (
@@ -89,7 +94,9 @@ export class TagsProvider implements vscode.TreeDataProvider<TagTreeItem> {
   async resolveTreeItem(item: TagTreeItem): Promise<TagTreeItem> {
     if (item instanceof TagReference) {
       const content = await this.dataStore.read(item.note.uri);
-      item.tooltip = getNoteTooltip(content);
+      if (isSome(content)) {
+        item.tooltip = getNoteTooltip(content);
+      }
     }
     return item;
   }

--- a/packages/foam-vscode/src/utils/grouped-resources-tree-data-provider.ts
+++ b/packages/foam-vscode/src/utils/grouped-resources-tree-data-provider.ts
@@ -6,7 +6,7 @@ import {
   GroupedResourcesConfig,
   GroupedResoucesConfigGroupBy,
 } from '../settings';
-import { getContainsTooltip, getNoteTooltip } from '../utils';
+import { getContainsTooltip, getNoteTooltip, isSome } from '../utils';
 import { OPEN_COMMAND } from '../features/utility-commands';
 import { toVsCodeUri } from './vsc-utils';
 
@@ -262,7 +262,7 @@ export class ResourceTreeItem extends vscode.TreeItem {
   async resolveTreeItem(): Promise<ResourceTreeItem> {
     if (this instanceof ResourceTreeItem) {
       const content = await this.dataStore?.read(this.resource.uri);
-      this.tooltip = content
+      this.tooltip = isSome(content)
         ? getNoteTooltip(content)
         : getTitle(this.resource);
     }


### PR DESCRIPTION
instead of propagating exceptions occurring when reading files, log them and return `null` (to indicate to the client code the error).

This is born to address the file exceptions occurring in CI during integration testing, but in general also allows better handling of this non-critical error.

Example of error from CI:
```   
ENOENT: no such file or directory, open '/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/foam-xVFJeT/iRA4B.md'
```