### PR TITLE
Template variable refactor

### DIFF
--- a/packages/foam-vscode/src/features/create-from-template.test.ts
+++ b/packages/foam-vscode/src/features/create-from-template.test.ts
@@ -2,7 +2,7 @@ import { window } from 'vscode';
 import { substituteFoamVariables } from './create-from-template';
 
 describe('substituteFoamVariables', () => {
-  test('Does nothing if no Foam-specific variables are used', async () => {
+  test('Does nothing if no Foam-specific variables are used', () => {
     const input = `
       # \${AnotherVariable} <-- Unrelated to foam
       # \${AnotherVariable:default_value} <-- Unrelated to foam
@@ -11,10 +11,11 @@ describe('substituteFoamVariables', () => {
       # #CURRENT_YEAR-\${CURRENT_MONTH}-$CURRENT_DAY <-- Unrelated to foam
     `;
 
-    expect(await substituteFoamVariables(input)).toEqual(input);
+    const givenValues = new Map<string, string>();
+    expect(substituteFoamVariables(input, givenValues)).toEqual(input);
   });
 
-  test('Resolves FOAM_TITLE', async () => {
+  test('Resolves FOAM_TITLE', () => {
     const input = `
       # $FOAM_TITLE <-- The title goes here
       # \${FOAM_TITLE} <-- and also here
@@ -31,6 +32,7 @@ describe('substituteFoamVariables', () => {
       # My note title <-- and also here
     `;
 
-    expect(await substituteFoamVariables(input)).toEqual(expected);
+    const givenValues = new Map<string, string>();
+    expect(substituteFoamVariables(input, givenValues)).toEqual(expected);
   });
 });

--- a/packages/foam-vscode/src/features/create-from-template.test.ts
+++ b/packages/foam-vscode/src/features/create-from-template.test.ts
@@ -1,5 +1,8 @@
 import { window } from 'vscode';
-import { substituteFoamVariables } from './create-from-template';
+import {
+  resolveFoamVariables,
+  substituteFoamVariables,
+} from './create-from-template';
 
 describe('substituteFoamVariables', () => {
   test('Does nothing if no Foam-specific variables are used', () => {
@@ -12,27 +15,75 @@ describe('substituteFoamVariables', () => {
     `;
 
     const givenValues = new Map<string, string>();
+    givenValues.set('FOAM_TITLE', 'My note title');
     expect(substituteFoamVariables(input, givenValues)).toEqual(input);
   });
 
-  test('Resolves FOAM_TITLE', () => {
+  test('Correctly substitutes variables that are substrings of one another', () => {
+    // FOAM_TITLE is a substring of FOAM_TITLE_NON_EXISTENT_VARIABLE
+    // If we're not careful with how we substitute the values
+    // we can end up putting the FOAM_TITLE in place FOAM_TITLE_NON_EXISTENT_VARIABLE should be.
     const input = `
-      # $FOAM_TITLE <-- The title goes here
-      # \${FOAM_TITLE} <-- and also here
+      # \${FOAM_TITLE}
+      # $FOAM_TITLE
+      # \${FOAM_TITLE_NON_EXISTENT_VARIABLE}
+      # $FOAM_TITLE_NON_EXISTENT_VARIABLE
     `;
 
+    const expected = `
+      # My note title
+      # My note title
+      # \${FOAM_TITLE_NON_EXISTENT_VARIABLE}
+      # $FOAM_TITLE_NON_EXISTENT_VARIABLE
+    `;
+
+    const givenValues = new Map<string, string>();
+    givenValues.set('FOAM_TITLE', 'My note title');
+    expect(substituteFoamVariables(input, givenValues)).toEqual(expected);
+  });
+});
+
+describe('resolveFoamVariables', () => {
+  test('Does nothing for unknown Foam-specific variables', async () => {
+    const variables = ['FOAM_FOO'];
+
+    const expected = new Map<string, string>();
+    expected.set('FOAM_FOO', 'FOAM_FOO');
+
+    const givenValues = new Map<string, string>();
+    expect(await resolveFoamVariables(variables, givenValues)).toEqual(
+      expected
+    );
+  });
+
+  test('Resolves FOAM_TITLE', async () => {
     const foam_title = 'My note title';
+    const variables = ['FOAM_TITLE'];
 
     jest
       .spyOn(window, 'showInputBox')
       .mockImplementationOnce(jest.fn(() => Promise.resolve(foam_title)));
 
-    const expected = `
-      # My note title <-- The title goes here
-      # My note title <-- and also here
-    `;
+    const expected = new Map<string, string>();
+    expected.set('FOAM_TITLE', foam_title);
 
     const givenValues = new Map<string, string>();
-    expect(substituteFoamVariables(input, givenValues)).toEqual(expected);
+    expect(await resolveFoamVariables(variables, givenValues)).toEqual(
+      expected
+    );
+  });
+
+  test('Resolves FOAM_TITLE without asking the user when it is provided', async () => {
+    const foam_title = 'My note title';
+    const variables = ['FOAM_TITLE'];
+
+    const expected = new Map<string, string>();
+    expected.set('FOAM_TITLE', foam_title);
+
+    const givenValues = new Map<string, string>();
+    givenValues.set('FOAM_TITLE', foam_title);
+    expect(await resolveFoamVariables(variables, givenValues)).toEqual(
+      expected
+    );
   });
 });

--- a/packages/foam-vscode/src/features/create-from-template.ts
+++ b/packages/foam-vscode/src/features/create-from-template.ts
@@ -127,7 +127,7 @@ async function createNoteFromTemplate(): Promise<void> {
   const subbedText = await substituteFoamVariables(templateText.toString());
   const snippet = new SnippetString(subbedText);
 
-  const defaultFileName = 'new-note.md';
+  const defaultFileName = 'New Note.md';
   const defaultDir = Uri.joinPath(currentDir, defaultFileName);
   const filename = await window.showInputBox({
     prompt: `Enter the filename for the new note`,

--- a/packages/foam-vscode/src/features/create-from-template.ts
+++ b/packages/foam-vscode/src/features/create-from-template.ts
@@ -164,7 +164,8 @@ async function createNoteFromTemplate(): Promise<void> {
   );
   const snippet = new SnippetString(subbedText);
 
-  const defaultFileName = 'New Note.md';
+  const defaultSlug = resolvedValues.get('FOAM_TITLE') || 'New Note';
+  const defaultFileName = `${defaultSlug}.md`;
   const defaultDir = Uri.joinPath(currentDir, defaultFileName);
   const filename = await window.showInputBox({
     prompt: `Enter the filename for the new note`,

--- a/packages/foam-vscode/src/features/create-from-template.ts
+++ b/packages/foam-vscode/src/features/create-from-template.ts
@@ -72,7 +72,10 @@ function getFoamTitle() {
   });
 }
 
-function resolveFoamVariable(variable: string) {
+function resolveFoamVariable(
+  variable: string,
+  givenValues: Map<string, string>
+) {
   if (variable === 'FOAM_TITLE') {
     return getFoamTitle();
   } else {
@@ -80,25 +83,32 @@ function resolveFoamVariable(variable: string) {
   }
 }
 
-function resolveFoamVariables(variables: string[]) {
+async function resolveFoamVariables(
+  variables: string[],
+  givenValues: Map<string, string>
+) {
   const promises = variables.map(async variable =>
-    Promise.resolve([variable, await resolveFoamVariable(variable)])
+    Promise.resolve([
+      variable,
+      await resolveFoamVariable(variable, givenValues),
+    ])
   );
-  return Promise.all(promises);
-}
 
-export async function substituteFoamVariables(templateText: string) {
-  const variables = findFoamVariables(templateText);
-  const results = await resolveFoamVariables(variables);
-
+  const results = await Promise.all(promises);
   const valueByName = new Map<string, string>();
   results.forEach(result => {
     valueByName.set(result[0], result[1]);
   });
+  return valueByName;
+}
 
-  variables.forEach(variable => {
+export function substituteFoamVariables(
+  templateText: string,
+  givenValues: Map<string, string>
+) {
+  givenValues.forEach((value, variable) => {
     const regex = new RegExp(`\\\${${variable}}|\\$${variable}`, 'g');
-    templateText = templateText.replace(regex, valueByName.get(variable));
+    templateText = templateText.replace(regex, value);
   });
 
   return templateText;
@@ -124,7 +134,14 @@ async function createNoteFromTemplate(): Promise<void> {
   const templateText = await workspace.fs.readFile(
     Uri.joinPath(templatesDir, selectedTemplate)
   );
-  const subbedText = await substituteFoamVariables(templateText.toString());
+
+  const givenValues = new Map<string, string>();
+  const variables = findFoamVariables(templateText.toString());
+  const results = await resolveFoamVariables(variables, givenValues);
+  const subbedText = await substituteFoamVariables(
+    templateText.toString(),
+    results
+  );
   const snippet = new SnippetString(subbedText);
 
   const defaultFileName = 'New Note.md';


### PR DESCRIPTION
Taking the good bits from the abandoned [`FOAM_TITLE_SLUG`](https://github.com/foambubble/foam/pull/569) work.

I'll be using this as the basis of my work on #562.

Ref: https://github.com/foambubble/foam/pull/569#discussion_r615299054

### User impact

The only user-facing changes are related to the default filename used in the filepath confirmation step of `Foam: Create New Note From Template`:

* The default filename is changed from `new-note.md` (Markdown Notes format) to `New Note.md` (Obsidian format)
*  If available, it will use `FOAM_TITLE` as the default filename

cc @riccardoferretti 