### PR TITLE
fix:(#591) 'foam-vscode.open-daily-note' error on Windows

### DIFF
--- a/packages/foam-core/src/model/uri.ts
+++ b/packages/foam-core/src/model/uri.ts
@@ -103,7 +103,11 @@ export abstract class URI {
     // on other systems bwd-slashes are valid
     // filename character, eg /f\oo/ba\r.txt
     if (isWindows) {
-      path = `/${path.replace(/\\/g, _slash)}`;
+      if (path.startsWith(_slash)) {
+        path = `${path.replace(/\\/g, _slash)}`;
+      } else {
+        path = `/${path.replace(/\\/g, _slash)}`;
+      }
     }
 
     // check for authority as used in UNC shares


### PR DESCRIPTION
* when calling URI.file more than two time on windows
* a extra slash('/') at path's beginning may cause some problems
* so add a condition to solve it