### PR TITLE
fix: (#592) extra autocomplete hints outside wiki-link brackets

### DIFF
--- a/packages/foam-vscode/src/features/link-completion.spec.ts
+++ b/packages/foam-vscode/src/features/link-completion.spec.ts
@@ -76,7 +76,7 @@ describe('Link Completion', () => {
   it('should not return link outside the wiki-link brackets', async () => {
     const { uri } = await createFile('[[file]] then');
     const { doc } = await showInEditor(uri);
-    const provider = new CompletionProvider(ws);
+    const provider = new CompletionProvider(ws, graph);
 
     const links = await provider.provideCompletionItems(
       doc,

--- a/packages/foam-vscode/src/features/link-completion.spec.ts
+++ b/packages/foam-vscode/src/features/link-completion.spec.ts
@@ -61,15 +61,28 @@ describe('Link Completion', () => {
   });
 
   it('should return notes and placeholders', async () => {
-    const { uri } = await createFile('[[');
+    const { uri } = await createFile('[[file]] [[');
     const { doc } = await showInEditor(uri);
     const provider = new CompletionProvider(ws, graph);
 
     const links = await provider.provideCompletionItems(
       doc,
-      new vscode.Position(0, 2)
+      new vscode.Position(0, 11)
     );
 
     expect(links.items.length).toEqual(4);
+  });
+
+  it('should not return link outside the wiki-link brackets', async () => {
+    const { uri } = await createFile('[[file]] then');
+    const { doc } = await showInEditor(uri);
+    const provider = new CompletionProvider(ws);
+
+    const links = await provider.provideCompletionItems(
+      doc,
+      new vscode.Position(0, 12)
+    );
+
+    expect(links).toBeNull();
   });
 });

--- a/packages/foam-vscode/src/features/link-completion.ts
+++ b/packages/foam-vscode/src/features/link-completion.ts
@@ -32,7 +32,7 @@ export class CompletionProvider
       .lineAt(position)
       .text.substr(0, position.character);
 
-    // Requires autocmplete only if cursorPrefix matches `[[` that NOT ended by `]]`.
+    // Requires autocomplete only if cursorPrefix matches `[[` that NOT ended by `]]`.
     // See https://github.com/foambubble/foam/pull/596#issuecomment-825748205 for details.
     // eslint-disable-next-line no-useless-escape
     const requiresAutocomplete = cursorPrefix.match(/\[\[[^\[\]]*(?!.*\]\])/);

--- a/packages/foam-vscode/src/features/link-completion.ts
+++ b/packages/foam-vscode/src/features/link-completion.ts
@@ -32,6 +32,8 @@ export class CompletionProvider
       .lineAt(position)
       .text.substr(0, position.character);
 
+    // Requires autocmplete only if cursorPrefix startting with `[[` and NOT ending with `]]`.
+    // See https://github.com/foambubble/foam/pull/596#issuecomment-825748205 for details.
     // eslint-disable-next-line no-useless-escape
     const requiresAutocomplete = cursorPrefix.match(/\[\[[^\[\]]*(?!.*\]\])/);
 

--- a/packages/foam-vscode/src/features/link-completion.ts
+++ b/packages/foam-vscode/src/features/link-completion.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { Foam, FoamWorkspace, URI, isNote } from 'foam-core';
+import { Foam, FoamWorkspace, URI, FoamGraph } from 'foam-core';
 import { FoamFeature } from '../types';
 import { getNoteTooltip, mdDocSelector } from '../utils';
 import { toVsCodeUri } from '../utils/vsc-utils';
@@ -13,7 +13,7 @@ const feature: FoamFeature = {
     context.subscriptions.push(
       vscode.languages.registerCompletionItemProvider(
         mdDocSelector,
-        new CompletionProvider(foam.workspace),
+        new CompletionProvider(foam.workspace, foam.graph),
         '['
       )
     );
@@ -22,7 +22,7 @@ const feature: FoamFeature = {
 
 export class CompletionProvider
   implements vscode.CompletionItemProvider<vscode.CompletionItem> {
-  constructor(private ws: FoamWorkspace) {}
+  constructor(private ws: FoamWorkspace, private graph: FoamGraph) {}
 
   provideCompletionItems(
     document: vscode.TextDocument,
@@ -41,27 +41,25 @@ export class CompletionProvider
       return null;
     }
 
-    const results = this.ws.list().map(resource => {
-      const uri = resource.uri;
-      if (URI.isPlaceholder(uri)) {
-        return new vscode.CompletionItem(
-          uri.path,
-          vscode.CompletionItemKind.Interface
-        );
-      }
-
+    const resources = this.ws.list().map(resource => {
       const item = new vscode.CompletionItem(
         vscode.workspace.asRelativePath(toVsCodeUri(resource.uri)),
         vscode.CompletionItemKind.File
       );
       item.insertText = URI.getBasename(resource.uri);
-      item.documentation =
-        isNote(resource) && getNoteTooltip(resource.source.text);
+      item.documentation = getNoteTooltip(resource.source.text);
 
       return item;
     });
 
-    return new vscode.CompletionList(results);
+    const placeholders = Object.values(this.graph.placeholders).map(uri => {
+      return new vscode.CompletionItem(
+        uri.path,
+        vscode.CompletionItemKind.Interface
+      );
+    });
+
+    return new vscode.CompletionList([...resources, ...placeholders]);
   }
 }
 

--- a/packages/foam-vscode/src/features/link-completion.ts
+++ b/packages/foam-vscode/src/features/link-completion.ts
@@ -33,7 +33,7 @@ export class CompletionProvider
       .text.substr(0, position.character);
 
     // eslint-disable-next-line no-useless-escape
-    const requiresAutocomplete = cursorPrefix.match(/\[\[[^\]\]]*(?!.*\]\])/);
+    const requiresAutocomplete = cursorPrefix.match(/\[\[[^\[\]]*(?!.*\]\])/);
 
     if (!requiresAutocomplete) {
       return null;

--- a/packages/foam-vscode/src/features/link-completion.ts
+++ b/packages/foam-vscode/src/features/link-completion.ts
@@ -33,7 +33,7 @@ export class CompletionProvider
       .text.substr(0, position.character);
 
     // eslint-disable-next-line no-useless-escape
-    const requiresAutocomplete = cursorPrefix.match(/\[\[([^\[\]]*?)/);
+    const requiresAutocomplete = cursorPrefix.match(/\[\[[^\]\]]*(?!.*\]\])/);
 
     if (!requiresAutocomplete) {
       return null;

--- a/packages/foam-vscode/src/features/link-completion.ts
+++ b/packages/foam-vscode/src/features/link-completion.ts
@@ -32,7 +32,7 @@ export class CompletionProvider
       .lineAt(position)
       .text.substr(0, position.character);
 
-    // Requires autocomplete only if cursorPrefix matches `[[` that NOT ended by `]]`.
+    // Requires autocmplete only if cursorPrefix startting with `[[` and NOT ending with `]]`.
     // See https://github.com/foambubble/foam/pull/596#issuecomment-825748205 for details.
     // eslint-disable-next-line no-useless-escape
     const requiresAutocomplete = cursorPrefix.match(/\[\[[^\[\]]*(?!.*\]\])/);

--- a/packages/foam-vscode/src/features/link-completion.ts
+++ b/packages/foam-vscode/src/features/link-completion.ts
@@ -32,7 +32,7 @@ export class CompletionProvider
       .lineAt(position)
       .text.substr(0, position.character);
 
-    // Requires autocmplete only if cursorPrefix startting with `[[` and NOT ending with `]]`.
+    // Requires autocmplete only if cursorPrefix matches `[[` that NOT ended by `]]`.
     // See https://github.com/foambubble/foam/pull/596#issuecomment-825748205 for details.
     // eslint-disable-next-line no-useless-escape
     const requiresAutocomplete = cursorPrefix.match(/\[\[[^\[\]]*(?!.*\]\])/);


### PR DESCRIPTION
* fix regex expression in `link-completion.ts`.
* edit tests for it.