### PR TITLE
Ignore unknown Foam variables

### DIFF
--- a/packages/foam-vscode/CHANGELOG.md
+++ b/packages/foam-vscode/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the "foam-vscode" extension will be documented in this fi
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## Unreleased
+
+- Unknown Foam template variables are now ignored by Foam.
+  - e.g. before `$FOAM_FOO` would become `FOAM_FOO`, now it is passed to VSCode which turns it into an empty string
+
 ## [0.13.2] - 2021-05-06
 
 Fixes and Improvements:

--- a/packages/foam-vscode/src/features/create-from-template.test.ts
+++ b/packages/foam-vscode/src/features/create-from-template.test.ts
@@ -1,6 +1,7 @@
-import { window } from 'vscode';
+import { SnippetString, window } from 'vscode';
 import {
   resolveFoamVariables,
+  resolveFoamTemplateVariables,
   substituteFoamVariables,
 } from './create-from-template';
 
@@ -11,7 +12,7 @@ describe('substituteFoamVariables', () => {
       # \${AnotherVariable:default_value} <-- Unrelated to foam
       # \${AnotherVariable:default_value/(.*)/\${1:/upcase}/}} <-- Unrelated to foam
       # $AnotherVariable} <-- Unrelated to foam
-      # #CURRENT_YEAR-\${CURRENT_MONTH}-$CURRENT_DAY <-- Unrelated to foam
+      # $CURRENT_YEAR-\${CURRENT_MONTH}-$CURRENT_DAY <-- Unrelated to foam
     `;
 
     const givenValues = new Map<string, string>();
@@ -85,5 +86,38 @@ describe('resolveFoamVariables', () => {
     expect(await resolveFoamVariables(variables, givenValues)).toEqual(
       expected
     );
+  });
+});
+
+describe('resolveFoamTemplateVariables', () => {
+  test('Does nothing for template without Foam-specific variables', async () => {
+    const input = `
+      # \${AnotherVariable} <-- Unrelated to foam
+      # \${AnotherVariable:default_value} <-- Unrelated to foam
+      # \${AnotherVariable:default_value/(.*)/\${1:/upcase}/}} <-- Unrelated to foam
+      # $AnotherVariable} <-- Unrelated to foam
+      # $CURRENT_YEAR-\${CURRENT_MONTH}-$CURRENT_DAY <-- Unrelated to foam
+    `;
+
+    const expectedMap = new Map<string, string>();
+    const expectedSnippet = new SnippetString(input);
+    const expected = [expectedMap, expectedSnippet];
+
+    expect(await resolveFoamTemplateVariables(input)).toEqual(expected);
+  });
+
+  test('Does nothing for unknown Foam-specific variables', async () => {
+    const input = `
+      # $FOAM_FOO
+      # \${FOAM_FOO}
+      # \${FOAM_FOO:default_value}
+      # \${FOAM_FOO:default_value/(.*)/\${1:/upcase}/}}
+    `;
+
+    const expectedMap = new Map<string, string>();
+    const expectedSnippet = new SnippetString(input);
+    const expected = [expectedMap, expectedSnippet];
+
+    expect(await resolveFoamTemplateVariables(input)).toEqual(expected);
   });
 });

--- a/packages/foam-vscode/src/features/create-from-template.ts
+++ b/packages/foam-vscode/src/features/create-from-template.ts
@@ -18,6 +18,8 @@ const templatesDir = Uri.joinPath(
   'templates'
 );
 
+const knownFoamVariables = new Set(['FOAM_TITLE']);
+
 const defaultTemplateDefaultText: string = '# ${FOAM_TITLE}'; // eslint-disable-line no-template-curly-in-string
 const defaultTemplateUri = Uri.joinPath(templatesDir, 'new-note.md');
 
@@ -64,7 +66,8 @@ function findFoamVariables(templateText: string): string[] {
     output.push(matches[1] || matches[2]);
   }
   const uniqVariables = [...new Set(output)];
-  return uniqVariables;
+  const knownVariables = uniqVariables.filter(x => knownFoamVariables.has(x));
+  return knownVariables;
 }
 
 function resolveFoamTitle() {
@@ -167,7 +170,7 @@ async function askUserForFilepathConfirmation(
   });
 }
 
-async function resolveFoamTemplateVariables(
+export async function resolveFoamTemplateVariables(
   templateText: string
 ): Promise<[Map<string, string>, SnippetString]> {
   const givenValues = new Map<string, string>();


### PR DESCRIPTION
When testing #601, I changed my mind on how we should be handling unknown Foam variables.

Generally, if you don't know what something is, you shouldn't mess with it.

Previously it would replace `$FOAM_FOO` with `FOAM_FOO` before passing it VSCode.
Now it just leaves the unknown variables alone and passes them to VSCode unmodified.
