### PR TITLE
Handle users cancelling "Create New Note" commands

### DIFF
--- a/packages/foam-vscode/CHANGELOG.md
+++ b/packages/foam-vscode/CHANGELOG.md
@@ -8,7 +8,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 - Unknown Foam template variables are now ignored by Foam.
   - e.g. before `$FOAM_FOO` would become `FOAM_FOO`, now it is passed to VSCode which turns it into an empty string
-
+- Cancelling `Foam: Create New Note` and `Foam: Create New Note From Template` actually ends the commands
 ## [0.13.2] - 2021-05-06
 
 Fixes and Improvements:

--- a/packages/foam-vscode/src/features/create-from-template.spec.ts
+++ b/packages/foam-vscode/src/features/create-from-template.spec.ts
@@ -20,6 +20,33 @@ describe('createFromTemplate', () => {
       });
     });
   });
+
+  describe('create-note-from-default-template', () => {
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('can be cancelled while resolving FOAM_TITLE', async () => {
+      const spy = jest
+        .spyOn(window, 'showInputBox')
+        .mockImplementation(jest.fn(() => Promise.resolve(undefined)));
+
+      const fileWriteSpy = jest.spyOn(workspace.fs, 'writeFile');
+
+      await commands.executeCommand(
+        'foam-vscode.create-note-from-default-template'
+      );
+
+      expect(spy).toBeCalledWith({
+        prompt: `Enter a title for the new note`,
+        value: 'Title of my New Note',
+        validateInput: expect.anything(),
+      });
+
+      expect(fileWriteSpy).toHaveBeenCalledTimes(0);
+    });
+  });
+
   describe('create-new-template', () => {
     afterEach(() => {
       jest.clearAllMocks();


### PR DESCRIPTION
As part of the refactoring done in #601, I broke the cancellation flow.

### 2 cases

When resolving `$FOAM_TITLE`, if the user cancels (i.e. hits `Esc` key), then the command should cancel.
Instead it was setting `FOAM_TITLE` to `undefined` and continuing onto the next steps, ultimately producing a new note with `undefined` in it. (The problem is not that the note has `undefined` in it, the problem is that cancelling the command didn't stop the command from continuing) 

![image](https://user-images.githubusercontent.com/1459385/117573542-7e013480-b0a6-11eb-87ff-97c855ac510e.png)

### What should reviewers focus on?

Surely, there has to be a better (built-in?) pattern for a user cancelling an operation while deep in a stack.
Is there some built-in Exception I should be using instead? Some other related pattern?