### PR TITLE
Add related projects section to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -175,3 +175,4 @@ This project follows the [all-contributors](https://github.com/all-contributors/
 - [Notational velocity](https://notational.net/)
 - [Zim](https://github.com/zim-desktop-wiki/zim-desktop-wiki)
 - [Joplin](https://github.com/laurent22/joplin)
+- [Memo](https://github.com/svsool/vscode-memo)

--- a/readme.md
+++ b/readme.md
@@ -166,3 +166,12 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
+
+## Related projects
+
+- [Roam Research](https://roamresearch.com/)
+- [Dendron](https://github.com/dendronhq/dendron/)
+- [Obsidian](https://obsidian.md/)
+- [Notational velocity](https://notational.net/)
+- [Zim](https://github.com/zim-desktop-wiki/zim-desktop-wiki)
+- [Joplin](https://github.com/laurent22/joplin)


### PR DESCRIPTION
Not sure if you'll want this but could be of service to potential users. Or maybe could be in a separate file with comparisons to foam?