### PR TITLE
Add support for nested tags

### DIFF
--- a/packages/foam-core/src/utils/hashtags.ts
+++ b/packages/foam-core/src/utils/hashtags.ts
@@ -1,6 +1,6 @@
 import { isSome } from './core';
-const HASHTAG_REGEX = /(^|\s)#([0-9]*[\p{L}_-][\p{L}\p{N}_-]*)/gmu;
-const WORD_REGEX = /(^|\s)([0-9]*[\p{L}_-][\p{L}\p{N}_-]*)/gmu;
+const HASHTAG_REGEX = /(^|\s)#([0-9]*[\p{L}\/_-][\p{L}\p{N}\/_-]*)/gmu;
+const WORD_REGEX = /(^|\s)([0-9]*[\p{L}\/_-][\p{L}\p{N}\/_-]*)/gmu;
 
 export const extractHashtags = (text: string): Set<string> => {
   return isSome(text)

--- a/packages/foam-core/src/utils/hashtags.ts
+++ b/packages/foam-core/src/utils/hashtags.ts
@@ -1,6 +1,6 @@
 import { isSome } from './core';
-const HASHTAG_REGEX = /(^|\s)#([0-9]*[\p{L}\/_-][\p{L}\p{N}\/_-]*)/gmu;
-const WORD_REGEX = /(^|\s)([0-9]*[\p{L}\/_-][\p{L}\p{N}\/_-]*)/gmu;
+const HASHTAG_REGEX = /(^|\s)#([0-9]*[\p{L}/_-][\p{L}\p{N}/_-]*)/gmu;
+const WORD_REGEX = /(^|\s)([0-9]*[\p{L}/_-][\p{L}\p{N}/_-]*)/gmu;
 
 export const extractHashtags = (text: string): Set<string> => {
   return isSome(text)

--- a/packages/foam-core/test/markdown-provider.test.ts
+++ b/packages/foam-core/test/markdown-provider.test.ts
@@ -336,6 +336,19 @@ this is some #text that includes #tags we #care-about.
       new Set(['text', 'tags', 'care-about', 'hello', 'world', 'this_is_good'])
     );
   });
+
+  it('can find nested tags as array in yaml', () => {
+    const noteA = createNoteFromMarkdown(
+      '/dir1/page-a.md',
+      `
+---
+tags: [hello, world,  parent/child]
+---
+# this is a heading
+    `
+    );
+    expect(noteA.tags).toEqual(new Set(['hello', 'world', 'parent/child']));
+  });
 });
 
 describe('parser plugins', () => {

--- a/packages/foam-core/test/utils.test.ts
+++ b/packages/foam-core/test/utils.test.ts
@@ -19,6 +19,11 @@ describe('hashtag extraction', () => {
       new Set(['hello-world', 'this_planet'])
     );
   });
+  it('supports nested tags', () => {
+    expect(extractHashtags('#parent/child on #planet')).toEqual(
+      new Set(['parent/child', 'planet'])
+    );
+  });
   it('ignores tags that only have numbers in text', () => {
     expect(
       extractHashtags('this #123 tag should be ignore, but not #123four')

--- a/packages/foam-vscode/src/features/tags-tree-view/index.spec.ts
+++ b/packages/foam-vscode/src/features/tags-tree-view/index.spec.ts
@@ -36,7 +36,7 @@ describe('Tags tree panel', () => {
   });
 
   afterAll(async () => {
-    _foam.workspace.dispose();
+    _foam.dispose();
     await cleanWorkspace();
   });
 
@@ -66,18 +66,15 @@ describe('Tags tree panel', () => {
     provider.refresh();
 
     const parentTreeItems = (await provider.getChildren()) as Tag[];
-    const parentTagItem = parentTreeItems.filter(item => item instanceof Tag);
-    expect(parentTagItem[0].title).toEqual('parent');
-    expect(parentTagItem[0].title).not.toEqual('child');
+    const parentTagItem = parentTreeItems.pop();
+    expect(parentTagItem.title).toEqual('parent');
+    expect(parentTagItem.title).not.toEqual('child');
 
-    const childTreeItems = (await provider.getChildren(
-      parentTagItem[0]
-    )) as Tag[];
+    const childTreeItems = (await provider.getChildren(parentTagItem)) as Tag[];
 
     childTreeItems.map(child => {
       if (child instanceof Tag) {
         expect(child.title).toEqual('child');
-        expect(child.title).not.toEqual('parent');
       }
     });
   });
@@ -101,7 +98,6 @@ describe('Tags tree panel', () => {
     )[0];
 
     expect(parentTagItem.title).toEqual('parent');
-    expect(parentTagItem.title).not.toEqual('child');
 
     const childTreeItems = (await provider.getChildren(parentTagItem)) as Tag[];
 

--- a/packages/foam-vscode/src/features/tags-tree-view/index.spec.ts
+++ b/packages/foam-vscode/src/features/tags-tree-view/index.spec.ts
@@ -1,0 +1,115 @@
+import {
+  cleanWorkspace,
+  closeEditors,
+  createTestNote,
+} from '../../test/test-utils';
+
+import { Tag, TagsProvider } from '.';
+
+import {
+  bootstrap,
+  createConfigFromFolders,
+  Foam,
+  FileDataStore,
+  FoamConfig,
+  MarkdownResourceProvider,
+  Matcher,
+} from 'foam-core';
+
+describe('Tags tree panel', () => {
+  let _foam: Foam;
+  let provider: TagsProvider;
+
+  beforeAll(async () => {
+    await cleanWorkspace();
+
+    const config: FoamConfig = createConfigFromFolders([]);
+    const mdProvider = new MarkdownResourceProvider(
+      new Matcher(
+        config.workspaceFolders,
+        config.includeGlobs,
+        config.ignoreGlobs
+      )
+    );
+    _foam = await bootstrap(config, new FileDataStore(), [mdProvider]);
+    provider = new TagsProvider(_foam, _foam.workspace);
+  });
+
+  afterAll(async () => {
+    _foam.workspace.dispose();
+    await cleanWorkspace();
+  });
+
+  beforeEach(async () => {
+    await closeEditors();
+  });
+
+  it('correctly provides a tag from a set of notes', async () => {
+    const noteA = createTestNote({
+      tags: new Set(['test']),
+      uri: './note-a.md',
+    });
+    _foam.workspace.set(noteA);
+    provider.refresh();
+
+    const treeItems = (await provider.getChildren()) as Tag[];
+
+    treeItems.map(item => expect(item.tag).toContain('test'));
+  });
+
+  it('correctly handles a parent and child tag', async () => {
+    const noteA = createTestNote({
+      tags: new Set(['parent/child']),
+      uri: './note-a.md',
+    });
+    _foam.workspace.set(noteA);
+    provider.refresh();
+
+    const parentTreeItems = (await provider.getChildren()) as Tag[];
+    const parentTagItem = parentTreeItems.filter(item => item instanceof Tag);
+    expect(parentTagItem[0].title).toEqual('parent');
+    expect(parentTagItem[0].title).not.toEqual('child');
+
+    const childTreeItems = (await provider.getChildren(
+      parentTagItem[0]
+    )) as Tag[];
+
+    childTreeItems.map(child => {
+      if (child instanceof Tag) {
+        expect(child.title).toEqual('child');
+        expect(child.title).not.toEqual('parent');
+      }
+    });
+  });
+
+  it('correctly handles a single parent and multiple child tag', async () => {
+    const noteA = createTestNote({
+      tags: new Set(['parent/child']),
+      uri: './note-a.md',
+    });
+    _foam.workspace.set(noteA);
+    const noteB = createTestNote({
+      tags: new Set(['parent/subchild']),
+      uri: './note-b.md',
+    });
+    _foam.workspace.set(noteB);
+    provider.refresh();
+
+    const parentTreeItems = (await provider.getChildren()) as Tag[];
+    const parentTagItem = parentTreeItems.filter(
+      item => item instanceof Tag
+    )[0];
+
+    expect(parentTagItem.title).toEqual('parent');
+    expect(parentTagItem.title).not.toEqual('child');
+
+    const childTreeItems = (await provider.getChildren(parentTagItem)) as Tag[];
+
+    childTreeItems.map(child => {
+      if (child instanceof Tag) {
+        expect(['child', 'subchild']).toContain(child.title);
+        expect(child.title).not.toEqual('parent');
+      }
+    });
+  });
+});

--- a/packages/foam-vscode/src/features/tags-tree-view/index.spec.ts
+++ b/packages/foam-vscode/src/features/tags-tree-view/index.spec.ts
@@ -72,7 +72,7 @@ describe('Tags tree panel', () => {
 
     const childTreeItems = (await provider.getChildren(parentTagItem)) as Tag[];
 
-    childTreeItems.map(child => {
+    childTreeItems.forEach(child => {
       if (child instanceof Tag) {
         expect(child.title).toEqual('child');
       }
@@ -101,7 +101,7 @@ describe('Tags tree panel', () => {
 
     const childTreeItems = (await provider.getChildren(parentTagItem)) as Tag[];
 
-    childTreeItems.map(child => {
+    childTreeItems.forEach(child => {
       if (child instanceof Tag) {
         expect(['child', 'subchild']).toContain(child.title);
         expect(child.title).not.toEqual('parent');

--- a/packages/foam-vscode/src/features/tags-tree-view/index.ts
+++ b/packages/foam-vscode/src/features/tags-tree-view/index.ts
@@ -3,6 +3,7 @@ import { Foam, Resource, URI, FoamWorkspace } from 'foam-core';
 import { FoamFeature } from '../../types';
 import { getNoteTooltip, getContainsTooltip, isSome } from '../../utils';
 
+const TAG_SEPARATOR = '/';
 const feature: FoamFeature = {
   activate: async (
     context: vscode.ExtensionContext,
@@ -62,7 +63,7 @@ export class TagsProvider implements vscode.TreeDataProvider<TagTreeItem> {
   }
 
   getTreeItem(element: TagTreeItem): vscode.TreeItem {
-    if (element.title.indexOf('/') > -1) {
+    if (element.title.indexOf(TAG_SEPARATOR) > -1) {
       return;
     }
     return element;
@@ -71,10 +72,10 @@ export class TagsProvider implements vscode.TreeDataProvider<TagTreeItem> {
   getChildren(element?: Tag): Thenable<TagTreeItem[]> {
     if (element) {
       const tagChilds: TagTreeItem[] = this.tags
-        .filter(tag => tag.tag.indexOf(element.tag + '/') > -1)
+        .filter(tag => tag.tag.indexOf(element.tag + TAG_SEPARATOR) > -1)
         .map(
           ({ tag, notes }) =>
-            new Tag(tag, tag.substring(tag.indexOf('/') + 1), notes)
+            new Tag(tag, tag.substring(tag.indexOf(TAG_SEPARATOR) + 1), notes)
         );
 
       const references: TagTreeItem[] = element.notes
@@ -150,7 +151,7 @@ export class TagSearch extends vscode.TreeItem {
   constructor(public readonly tag: string) {
     super(`Search #${tag}`, vscode.TreeItemCollapsibleState.None);
     const searchString = `#?${tag}`;
-    this.title = tag.replace('/', '-');
+    this.title = tag.replace(TAG_SEPARATOR, '-');
     this.tooltip = `Search ${searchString} in workspace`;
     this.command = {
       command: 'workbench.action.findInFiles',

--- a/packages/foam-vscode/src/features/tags-tree-view/index.ts
+++ b/packages/foam-vscode/src/features/tags-tree-view/index.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { Foam, Resource, URI, FoamWorkspace, Logger } from 'foam-core';
+import { Foam, Resource, URI, FoamWorkspace } from 'foam-core';
 import { FoamFeature } from '../../types';
 import { getNoteTooltip, getContainsTooltip, isSome } from '../../utils';
 

--- a/packages/foam-vscode/src/test/test-utils.ts
+++ b/packages/foam-vscode/src/test/test-utils.ts
@@ -47,6 +47,7 @@ export const createTestNote = (params: {
   title?: string;
   definitions?: NoteLinkDefinition[];
   links?: Array<{ slug: string } | { to: string }>;
+  tags?: Set<string>;
   text?: string;
   root?: URI;
 }): Resource => {
@@ -57,7 +58,7 @@ export const createTestNote = (params: {
     properties: {},
     title: params.title ?? path.parse(strToUri(params.uri).path).base,
     definitions: params.definitions ?? [],
-    tags: new Set(),
+    tags: params.tags ?? new Set(),
     links: params.links
       ? params.links.map((link, index) => {
           const range = Range.create(

--- a/packages/foam-vscode/src/utils/grouped-resources-tree-data-provider.test.ts
+++ b/packages/foam-vscode/src/utils/grouped-resources-tree-data-provider.test.ts
@@ -1,4 +1,4 @@
-import { FoamGraph, FoamWorkspace, URI } from 'foam-core';
+import { FoamWorkspace } from 'foam-core';
 import { OPEN_COMMAND } from '../features/utility-commands';
 import {
   GroupedResoucesConfigGroupBy,


### PR DESCRIPTION
This is an attempt to implement nested tags like described in #614.

My coding skills are a bit rusty, so feel free to have a thorough look at it.

The changes ensure that forward slashes are accepted in tags. The tag tree view explorer is adjusted to display parent/child relations in tags, and respect a logical sorting algorithm that puts childs on top, and references after those.
<img width="348" alt="Screenshot 2021-05-19 at 13 32 07" src="https://user-images.githubusercontent.com/495374/118806706-b0314400-b8a7-11eb-9bf8-48aa5d172cf2.png">

I've also made a minor to change to the call to the search dialog. It now starts as a RegEx search to make the Pound signal optional. This ensures we also find the tags jotted down in the Frontmatter.

<img width="333" alt="Screenshot 2021-05-19 at 13 32 29" src="https://user-images.githubusercontent.com/495374/118806701-af98ad80-b8a7-11eb-90e6-09c38fca54e9.png">

