### PR TITLE
Always ask for the note title when creating from template

### DIFF
--- a/packages/foam-vscode/src/features/create-from-template.test.ts
+++ b/packages/foam-vscode/src/features/create-from-template.test.ts
@@ -58,15 +58,15 @@ describe('resolveFoamVariables', () => {
   });
 
   test('Resolves FOAM_TITLE', async () => {
-    const foam_title = 'My note title';
+    const foamTitle = 'My note title';
     const variables = ['FOAM_TITLE'];
 
     jest
       .spyOn(window, 'showInputBox')
-      .mockImplementationOnce(jest.fn(() => Promise.resolve(foam_title)));
+      .mockImplementationOnce(jest.fn(() => Promise.resolve(foamTitle)));
 
     const expected = new Map<string, string>();
-    expected.set('FOAM_TITLE', foam_title);
+    expected.set('FOAM_TITLE', foamTitle);
 
     const givenValues = new Map<string, string>();
     expect(await resolveFoamVariables(variables, givenValues)).toEqual(
@@ -75,14 +75,14 @@ describe('resolveFoamVariables', () => {
   });
 
   test('Resolves FOAM_TITLE without asking the user when it is provided', async () => {
-    const foam_title = 'My note title';
+    const foamTitle = 'My note title';
     const variables = ['FOAM_TITLE'];
 
     const expected = new Map<string, string>();
-    expected.set('FOAM_TITLE', foam_title);
+    expected.set('FOAM_TITLE', foamTitle);
 
     const givenValues = new Map<string, string>();
-    givenValues.set('FOAM_TITLE', foam_title);
+    givenValues.set('FOAM_TITLE', foamTitle);
     expect(await resolveFoamVariables(variables, givenValues)).toEqual(
       expected
     );

--- a/packages/foam-vscode/src/features/create-from-template.test.ts
+++ b/packages/foam-vscode/src/features/create-from-template.test.ts
@@ -120,4 +120,30 @@ describe('resolveFoamTemplateVariables', () => {
 
     expect(await resolveFoamTemplateVariables(input)).toEqual(expected);
   });
+
+  test('Allows extra variables to be provided; only resolves the unique set', async () => {
+    const foamTitle = 'My note title';
+
+    jest
+      .spyOn(window, 'showInputBox')
+      .mockImplementationOnce(jest.fn(() => Promise.resolve(foamTitle)));
+
+    const input = `
+      # $FOAM_TITLE
+    `;
+
+    const expectedOutput = `
+      # My note title
+    `;
+
+    const expectedMap = new Map<string, string>();
+    expectedMap.set('FOAM_TITLE', foamTitle);
+
+    const expectedSnippet = new SnippetString(expectedOutput);
+    const expected = [expectedMap, expectedSnippet];
+
+    expect(
+      await resolveFoamTemplateVariables(input, new Set(['FOAM_TITLE']))
+    ).toEqual(expected);
+  });
 });

--- a/packages/foam-vscode/src/features/create-from-template.ts
+++ b/packages/foam-vscode/src/features/create-from-template.ts
@@ -184,12 +184,16 @@ async function askUserForFilepathConfirmation(
 }
 
 export async function resolveFoamTemplateVariables(
-  templateText: string
+  templateText: string,
+  extraVariablesToResolve: Set<string> = new Set()
 ): Promise<[Map<string, string>, SnippetString]> {
   const givenValues = new Map<string, string>();
-  const variables = findFoamVariables(templateText.toString());
+  const variables = findFoamVariables(templateText.toString()).concat(
+    ...extraVariablesToResolve
+  );
+  const uniqVariables = [...new Set(variables)];
 
-  const resolvedValues = await resolveFoamVariables(variables, givenValues);
+  const resolvedValues = await resolveFoamVariables(uniqVariables, givenValues);
   const subbedText = substituteFoamVariables(
     templateText.toString(),
     resolvedValues
@@ -223,7 +227,8 @@ async function createNoteFromDefaultTemplate(): Promise<void> {
   let resolvedValues, templateSnippet;
   try {
     [resolvedValues, templateSnippet] = await resolveFoamTemplateVariables(
-      templateText
+      templateText,
+      new Set(['FOAM_TITLE'])
     );
   } catch (err) {
     if (err instanceof UserCancelledOperation) {


### PR DESCRIPTION
### What are you trying to accomplish?

In order to create a note from a template you need two things:

1. the filepath
2. the file contents.

In cases where the template doesn't explicitly specify the path using the metadata syntax (i.e. all current templates since the metadata syntax isn't implemented yet), we'll add `$FOAM_TITLE` to the list of variables to resolve, and use it as the filepath.

This will prompt the user for a title as they (reasonably) [expect it to](https://github.com/foambubble/foam/issues/640).

Then in the future when the template metadata block contains an explicit override of the filepath, we will stop adding `$FOAM_TITLE`, and whether or not the user gets prompted will depend on the contents of the `filepath` metadata.

Fixes https://github.com/foambubble/foam/issues/640
Ref: https://github.com/foambubble/foam/issues/640#issuecomment-844826452

### What approach did you choose and why?

I've added `FOAM_TITLE` unconditionally to the list of variables to resolve, resulting in `Foam: Create New Note` always asking for a note's title.

In the future, we'll make this conditional on whether the template provides the filepath to use in its [metadata block](#563 ).

### What should reviewers focus on?

Are there cases you could imagine where someone would not want it to prompt for a title, besides the future scenario where the `filepath` metadata is provided in the template?

I'm writing this very early in the morning with little sleep. I may be forgetting some case???

### What doesn't change with this PR?

**Note:** This PR does not change the behaviour of `Foam: Create New Note From Template`.
In cases where the template does not reference `${FOAM_TITLE}`, the user will still not be prompted to enter a title.
This works, since in `Foam: Create New Note From Template` there is a separate step where they fill in the filepath they desire. If we were to always resolve `${FOAM_TITLE}`, it could make this command take longer than necessary, especially in cases where their desired filepath does not match the desired title:

**Example of where always asking for title in `Foam: Create New Note From Template` would be a worse UX**

1. User runs `Foam: Create New Note From Template`; selects an empty template.
1. User is prompted for a title; enters "On the Origin of Species"
1. Filepath prompt now has `<dir>/On the Origin of Species.md`
1. User deletes the existing filepath prompt and changes it to `<dir>/draft-1.md`

The user never wanted the title to be reflected in the filepath, so there was no need to prompt them.
It's fine to always prompt them in the `Foam: Create New Note` case, since that command is opinionated in order to have the most streamlined command for the most common use case. `Foam: Create New Note From Template` is slower, but less opinionated, and more flexible/powerful.