### PR TITLE
Allow for title property missing in frontmatter

### DIFF
--- a/packages/foam-core/src/markdown-provider.ts
+++ b/packages/foam-core/src/markdown-provider.ts
@@ -177,7 +177,7 @@ const titlePlugin: ParserPlugin = {
   },
   onDidFindProperties: (props, note) => {
     // Give precendence to the title from the frontmatter if it exists
-    note.title = props.title.toString() ?? note.title;
+    note.title = props.title?.toString() ?? note.title;
   },
   onDidVisitTree: (tree, note) => {
     if (note.title === '') {


### PR DESCRIPTION
During development of another feature I saw the foam log was overflowing with undefined errors. As I don't have any title properties in Frontmatter `props.title` is undefined. As a result, the toString() leads to problems. This change allows for optional presence for the title property.