### PR TITLE
Revive support for basic link alias

### DIFF
--- a/packages/foam-core/src/markdown-provider.ts
+++ b/packages/foam-core/src/markdown-provider.ts
@@ -14,6 +14,7 @@ import {
   ResourceLink,
   WikiLink,
   ResourceParser,
+  NoteSource,
 } from './model/note';
 import { Position } from './model/position';
 import { Range } from './model/range';
@@ -31,9 +32,11 @@ import { ResourceProvider } from 'model/provider';
 import { IDataStore, FileDataStore, IMatcher } from './services/datastore';
 import { IDisposable } from 'common/lifecycle';
 
+const ALIAS_DIVIDER_CHAR = '|';
+
 export interface ParserPlugin {
   name?: string;
-  visit?: (node: Node, note: Resource) => void;
+  visit?: (node: Node, note: Resource, noteSource: NoteSource) => void;
   onDidInitializeParser?: (parser: unified.Processor) => void;
   onWillParseMarkdown?: (markdown: string) => string;
   onWillVisitTree?: (tree: Node, note: Resource) => void;
@@ -121,7 +124,7 @@ export class MarkdownResourceProvider implements ResourceProvider {
     switch (link.type) {
       case 'wikilink':
         const definitionUri = resource.definitions.find(
-          def => def.label === link.slug
+          def => def.label === link.target
         )?.url;
         if (isSome(definitionUri)) {
           const definedUri = URI.resolve(definitionUri, resource.uri);
@@ -130,8 +133,8 @@ export class MarkdownResourceProvider implements ResourceProvider {
             URI.placeholder(definedUri.path);
         } else {
           targetUri =
-            workspace.find(link.slug, resource.uri)?.uri ??
-            URI.placeholder(link.slug);
+            workspace.find(link.target, resource.uri)?.uri ??
+            URI.placeholder(link.target);
         }
         break;
 
@@ -197,12 +200,28 @@ const titlePlugin: ParserPlugin = {
 
 const wikilinkPlugin: ParserPlugin = {
   name: 'wikilink',
-  visit: (node, note) => {
+  visit: (node, note, noteSource) => {
     if (node.type === 'wikiLink') {
+      const text = node.value as string;
+      const alias = node.data?.alias as string;
+      const literalContent = noteSource.text.substring(
+        node.position!.start.offset!,
+        node.position!.end.offset!
+      );
+
+      const hasAlias =
+        literalContent !== text && literalContent.includes(ALIAS_DIVIDER_CHAR);
       note.links.push({
         type: 'wikilink',
-        slug: node.value as string,
-        target: node.value as string,
+        rawText: literalContent,
+        label: hasAlias
+          ? alias.trim()
+          : literalContent.substring(2, literalContent.length - 2),
+        target: hasAlias
+          ? literalContent
+              .substring(2, literalContent.indexOf(ALIAS_DIVIDER_CHAR))
+              .trim()
+          : text.trim(),
         range: astPositionToFoamRange(node.position!),
       });
     }
@@ -259,7 +278,7 @@ export function createMarkdownParser(
   const parser = unified()
     .use(markdownParse, { gfm: true })
     .use(frontmatterPlugin, ['yaml'])
-    .use(wikiLinkPlugin);
+    .use(wikiLinkPlugin, { aliasDivider: ALIAS_DIVIDER_CHAR });
 
   const plugins = [
     titlePlugin,
@@ -307,6 +326,13 @@ export function createMarkdownParser(
         },
       };
 
+      var noteSource: NoteSource = {
+        text: markdown,
+        contentStart: astPointToFoamPosition(tree.position!.start),
+        end: astPointToFoamPosition(tree.position!.end),
+        eol: eol,
+      };
+
       plugins.forEach(plugin => {
         try {
           plugin.onWillVisitTree?.(tree, note);
@@ -342,7 +368,7 @@ export function createMarkdownParser(
 
         for (let i = 0, len = plugins.length; i < len; i++) {
           try {
-            plugins[i].visit?.(node, note);
+            plugins[i].visit?.(node, note, noteSource);
           } catch (e) {
             handleError(plugins[i], 'visit', uri, e);
           }
@@ -431,7 +457,14 @@ export function createMarkdownReferences(
         : dropExtension(relativePath);
 
       // [wiki-link-text]: path/to/file.md "Page title"
-      return { label: link.slug, url: pathToNote, title: target.title };
+      return {
+        label:
+          link.rawText.indexOf('[[') > -1
+            ? link.rawText.substring(2, link.rawText.length - 2)
+            : link.rawText || link.label,
+        url: pathToNote,
+        title: target.title,
+      };
     })
     .filter(isSome)
     .sort();

--- a/packages/foam-core/src/model/note.ts
+++ b/packages/foam-core/src/model/note.ts
@@ -11,8 +11,9 @@ export interface NoteSource {
 
 export interface WikiLink {
   type: 'wikilink';
-  slug: string;
   target: string;
+  label: string;
+  rawText: string;
   range: Range;
 }
 

--- a/packages/foam-core/test/core.test.ts
+++ b/packages/foam-core/test/core.test.ts
@@ -67,10 +67,10 @@ export const createTestNote = (params: {
           return 'slug' in link
             ? {
                 type: 'wikilink',
-                slug: link.slug,
                 target: link.slug,
+                label: link.slug,
                 range: range,
-                text: 'link text',
+                rawText: 'link text',
               }
             : {
                 type: 'link',

--- a/packages/foam-core/test/markdown-provider.test.ts
+++ b/packages/foam-core/test/markdown-provider.test.ts
@@ -3,7 +3,7 @@ import {
   createMarkdownReferences,
   ParserPlugin,
 } from '../src/markdown-provider';
-import { DirectLink } from '../src/model/note';
+import { DirectLink, WikiLink } from '../src/model/note';
 import { Logger } from '../src/utils/log';
 import { uriToSlug } from '../src/utils/slug';
 import { URI } from '../src/model/uri';
@@ -129,6 +129,24 @@ this is a [link to intro](#introduction)
       noteD.uri,
       noteE.uri,
     ]);
+  });
+
+  it('Parses backlinks with an alias', () => {
+    const note = createNoteFromMarkdown(
+      '/path/to/page-a.md',
+      'this is [[link|link alias]]. A link with spaces [[other link | spaced]]'
+    );
+    expect(note.links.length).toEqual(2);
+    let link = note.links[0] as WikiLink;
+    expect(link.type).toEqual('wikilink');
+    expect(link.rawText).toEqual('[[link|link alias]]');
+    expect(link.label).toEqual('link alias');
+    expect(link.target).toEqual('link');
+    link = note.links[1] as WikiLink;
+    expect(link.type).toEqual('wikilink');
+    expect(link.rawText).toEqual('[[other link | spaced]]');
+    expect(link.label).toEqual('spaced');
+    expect(link.target).toEqual('other link');
   });
 });
 
@@ -335,19 +353,6 @@ this is some #text that includes #tags we #care-about.
     expect(noteA.tags).toEqual(
       new Set(['text', 'tags', 'care-about', 'hello', 'world', 'this_is_good'])
     );
-  });
-
-  it('can find nested tags as array in yaml', () => {
-    const noteA = createNoteFromMarkdown(
-      '/dir1/page-a.md',
-      `
----
-tags: [hello, world,  parent/child]
----
-# this is a heading
-    `
-    );
-    expect(noteA.tags).toEqual(new Set(['hello', 'world', 'parent/child']));
   });
 });
 

--- a/packages/foam-core/test/workspace.test.ts
+++ b/packages/foam-core/test/workspace.test.ts
@@ -232,7 +232,7 @@ describe('Wikilinks', () => {
     expect(graph.getAllConnections()[0]).toEqual({
       source: noteA.uri,
       target: noteB.uri,
-      link: expect.objectContaining({ type: 'wikilink', slug: 'page-b' }),
+      link: expect.objectContaining({ type: 'wikilink', label: 'page-b' }),
     });
   });
 

--- a/packages/foam-vscode/src/features/backlinks.ts
+++ b/packages/foam-vscode/src/features/backlinks.ts
@@ -125,10 +125,7 @@ export class BacklinkTreeItem extends vscode.TreeItem {
     public readonly resource: Resource,
     public readonly link: ResourceLink
   ) {
-    super(
-      link.type === 'wikilink' ? link.slug : link.label,
-      vscode.TreeItemCollapsibleState.None
-    );
+    super(link.label, vscode.TreeItemCollapsibleState.None);
     this.label = `${link.range.start.line}: ${this.label}`;
     this.command = {
       command: 'vscode.open',

--- a/packages/foam-vscode/src/features/document-link-provider.spec.ts
+++ b/packages/foam-vscode/src/features/document-link-provider.spec.ts
@@ -100,4 +100,24 @@ describe('Document links provider', () => {
     );
     expect(links[0].range).toEqual(new vscode.Range(0, 18, 0, 35));
   });
+
+  it('should support wikilinks that have an alias', async () => {
+    const fileB = await createFile('# File B');
+    const fileA = await createFile(
+      `this is a link to [[${fileB.name}|alias]].`
+    );
+    const noteA = parser.parse(fileA.uri, fileA.content);
+    const noteB = parser.parse(fileB.uri, fileB.content);
+    const ws = createTestWorkspace()
+      .set(noteA)
+      .set(noteB);
+
+    const { doc } = await showInEditor(noteA.uri);
+    const provider = new LinkProvider(ws, parser);
+    const links = provider.provideDocumentLinks(doc);
+
+    expect(links.length).toEqual(1);
+    expect(links[0].target).toEqual(OPEN_COMMAND.asURI(noteB.uri));
+    expect(links[0].range).toEqual(new vscode.Range(0, 18, 0, 33));
+  });
 });

--- a/packages/foam-vscode/src/features/preview-navigation.ts
+++ b/packages/foam-vscode/src/features/preview-navigation.ts
@@ -1,7 +1,10 @@
-import * as vscode from 'vscode';
-import markdownItRegex from 'markdown-it-regex';
 import { Foam, FoamWorkspace, Logger, URI } from 'foam-core';
+import markdownItRegex from 'markdown-it-regex';
+import * as vscode from 'vscode';
 import { FoamFeature } from '../types';
+import { isNone } from '../utils';
+
+const ALIAS_DIVIDER_CHAR = '|';
 
 const feature: FoamFeature = {
   activate: async (
@@ -11,11 +14,13 @@ const feature: FoamFeature = {
     const foam = await foamPromise;
 
     return {
-      extendMarkdownIt: (md: markdownit) =>
-        [markdownItWithFoamTags, markdownItWithFoamLinks].reduce(
-          (acc, extension) => extension(acc, foam.workspace),
-          md
-        ),
+      extendMarkdownIt: (md: markdownit) => {
+        return [
+          markdownItWithFoamTags,
+          markdownItWithFoamLinks,
+          markdownItWithRemoveLinkReferences,
+        ].reduce((acc, extension) => extension(acc, foam.workspace), md);
+      },
     };
   },
 };
@@ -29,13 +34,23 @@ export const markdownItWithFoamLinks = (
     regex: /\[\[([^[\]]+?)\]\]/,
     replace: (wikilink: string) => {
       try {
-        const resource = workspace.find(wikilink);
-        if (resource == null) {
-          return getPlaceholderLink(wikilink);
+        const linkHasAlias = wikilink.includes(ALIAS_DIVIDER_CHAR);
+        const resourceLink = linkHasAlias
+          ? wikilink.substring(0, wikilink.indexOf('|'))
+          : wikilink;
+
+        const resource = workspace.find(resourceLink);
+        if (isNone(resource)) {
+          return getPlaceholderLink(resourceLink);
         }
+
+        const linkLabel = linkHasAlias
+          ? wikilink.substr(wikilink.indexOf('|') + 1)
+          : wikilink;
+
         return `<a class='foam-note-link' title='${
           resource.title
-        }' href='${URI.toFsPath(resource.uri)}'>${wikilink}</a>`;
+        }' href='${URI.toFsPath(resource.uri)}'>${linkLabel}</a>`;
       } catch (e) {
         Logger.error(
           `Error while creating link for [[${wikilink}]] in Preview panel`,
@@ -60,7 +75,7 @@ export const markdownItWithFoamTags = (
     replace: (tag: string) => {
       try {
         const resource = workspace.find(tag);
-        if (resource == null) {
+        if (isNone(resource)) {
           return getFoamTag(tag);
         }
       } catch (e) {
@@ -76,5 +91,70 @@ export const markdownItWithFoamTags = (
 
 const getFoamTag = (content: string) =>
   `<span class='foam-tag'>${content}</span>`;
+
+export const markdownItWithRemoveLinkReferences = (
+  md: markdownit,
+  workspace: FoamWorkspace
+) => {
+  // Add a custom rule to execute after the defult link rule to strip away the text
+  // before the alias of the WikiLink.
+
+  // As state is on block level the token array con have multiple links. We need to process
+  // them all. As such we are iterating to find all instances of link_open and find the next
+  // link_close token. We then determine the content between the tokens and if it has an alias.
+  // If it has an alias we iterate over all tokens in between to strip them to the desired content.
+  md.inline.ruler.after('link', 'replace-alias', state => {
+    if (state.tokens.filter(t => t.type === 'link_open').length > 0) {
+      let iteratorInLinkBlock = false;
+      let linkBlockContainsAlias = false;
+      state.tokens.forEach((token, currentTokenIndex) => {
+        if (!iteratorInLinkBlock && token.type !== 'link_open') {
+          return;
+        }
+
+        iteratorInLinkBlock = true;
+        if (iteratorInLinkBlock && token.type === 'link_close') {
+          iteratorInLinkBlock = false;
+          linkBlockContainsAlias = false;
+          return;
+        }
+
+        if (token.type === 'link_open') {
+          const nextLinkClosePosition = state.tokens
+            .slice(currentTokenIndex + 1)
+            .findIndex(t => t.type === 'link_close');
+
+          const linkContent = state.tokens
+            .slice(
+              currentTokenIndex + 1,
+              nextLinkClosePosition + currentTokenIndex + 1
+            )
+            .reduce((linkContent, token) => {
+              return linkContent + token.content;
+            }, '');
+
+          if (linkContent.includes(ALIAS_DIVIDER_CHAR)) {
+            linkBlockContainsAlias = true;
+          }
+        }
+
+        if (linkBlockContainsAlias) {
+          if (token.content.includes(ALIAS_DIVIDER_CHAR)) {
+            const dividerPosition = token.content.indexOf(ALIAS_DIVIDER_CHAR);
+            token.content = token.content.substr(
+              dividerPosition + 1,
+              token.content.length - dividerPosition - 1
+            );
+          } else {
+            token.content = '';
+          }
+        }
+      });
+    } else {
+      return false;
+    }
+  });
+  return md;
+};
 
 export default feature;

--- a/packages/foam-vscode/src/test/test-utils.ts
+++ b/packages/foam-vscode/src/test/test-utils.ts
@@ -70,10 +70,10 @@ export const createTestNote = (params: {
           return 'slug' in link
             ? {
                 type: 'wikilink',
-                slug: link.slug,
                 target: link.slug,
+                label: link.slug,
                 range: range,
-                text: 'link text',
+                rawText: 'link text',
               }
             : {
                 type: 'link',
@@ -139,7 +139,7 @@ export const createNote = (r: Resource) => {
 
   some content and ${r.links
     .map(l =>
-      l.type === 'wikilink' ? `[[${l.slug}]]` : `[${l.label}](${l.target})`
+      l.type === 'wikilink' ? `[[${l.label}]]` : `[${l.label}](${l.target})`
     )
     .join(' some content between links.\n')}
   last line.


### PR DESCRIPTION
## What are you trying to accomplish?
Implementing support of piped links to handle basic aliases of links. 

<img width="1145" alt="Screenshot 2021-05-25 at 20 51 07" src="https://user-images.githubusercontent.com/495374/119552560-f4867d80-bd9a-11eb-964e-e4d42f5381cd.png">


## What approach did you choose and why?
I've revived the implementation as in #223. It resembles the same functionality, but in the refactored code and with additional tests.

## Next steps

- There is an issues with piped links displayed as a table in Github Pages. This PR will not solve that problem. We should look into that specific issue.
