### PR TITLE
Filter out tag references that are part of a nested tag

### DIFF
--- a/packages/foam-vscode/src/features/preview-navigation.ts
+++ b/packages/foam-vscode/src/features/preview-navigation.ts
@@ -2,7 +2,6 @@ import * as vscode from 'vscode';
 import markdownItRegex from 'markdown-it-regex';
 import { Foam, FoamWorkspace, Logger, URI } from 'foam-core';
 import { FoamFeature } from '../types';
-import fp from 'lodash/fp';
 
 const feature: FoamFeature = {
   activate: async (

--- a/packages/foam-vscode/src/features/tags-tree-view/index.spec.ts
+++ b/packages/foam-vscode/src/features/tags-tree-view/index.spec.ts
@@ -4,7 +4,7 @@ import {
   createTestNote,
 } from '../../test/test-utils';
 
-import { Tag, TagReference, TagsProvider } from '.';
+import { Tag, TagsProvider } from '.';
 
 import {
   bootstrap,

--- a/packages/foam-vscode/src/features/tags-tree-view/index.spec.ts
+++ b/packages/foam-vscode/src/features/tags-tree-view/index.spec.ts
@@ -4,7 +4,7 @@ import {
   createTestNote,
 } from '../../test/test-utils';
 
-import { Tag, TagsProvider } from '.';
+import { Tag, TagReference, TagsProvider } from '.';
 
 import {
   bootstrap,
@@ -68,7 +68,6 @@ describe('Tags tree panel', () => {
     const parentTreeItems = (await provider.getChildren()) as Tag[];
     const parentTagItem = parentTreeItems.pop();
     expect(parentTagItem.title).toEqual('parent');
-    expect(parentTagItem.title).not.toEqual('child');
 
     const childTreeItems = (await provider.getChildren(parentTagItem)) as Tag[];
 
@@ -108,6 +107,42 @@ describe('Tags tree panel', () => {
         expect(child.title).not.toEqual('parent');
       }
     });
+    expect(childTreeItems).toHaveLength(3);
+  });
+
+  it('correctly handles a single parent and child tag in the same note', async () => {
+    const noteC = createTestNote({
+      tags: new Set(['main', 'main/subtopic']),
+      title: 'Test note',
+      uri: './note-c.md',
+    });
+
+    _foam.workspace.set(noteC);
+
+    provider.refresh();
+
+    const parentTreeItems = (await provider.getChildren()) as Tag[];
+    const parentTagItem = parentTreeItems.filter(
+      item => item instanceof Tag
+    )[0];
+
+    expect(parentTagItem.title).toEqual('main');
+
+    const childTreeItems = (await provider.getChildren(parentTagItem)) as Tag[];
+
+    childTreeItems
+      .filter(item => item instanceof TagReference)
+      .forEach(item => {
+        expect(item.title).toEqual('Test note');
+      });
+
+    childTreeItems
+      .filter(item => item instanceof Tag)
+      .forEach(item => {
+        expect(['main/subtopic']).toContain(item.tag);
+        expect(item.title).toEqual('subtopic');
+      });
+
     expect(childTreeItems).toHaveLength(3);
   });
 });

--- a/packages/foam-vscode/src/features/tags-tree-view/index.spec.ts
+++ b/packages/foam-vscode/src/features/tags-tree-view/index.spec.ts
@@ -4,7 +4,7 @@ import {
   createTestNote,
 } from '../../test/test-utils';
 
-import { Tag, TagsProvider } from '.';
+import { Tag, TagReference, TagsProvider } from '.';
 
 import {
   bootstrap,
@@ -98,6 +98,7 @@ describe('Tags tree panel', () => {
     )[0];
 
     expect(parentTagItem.title).toEqual('parent');
+    expect(parentTreeItems).toHaveLength(1);
 
     const childTreeItems = (await provider.getChildren(parentTagItem)) as Tag[];
 
@@ -107,5 +108,6 @@ describe('Tags tree panel', () => {
         expect(child.title).not.toEqual('parent');
       }
     });
+    expect(childTreeItems).toHaveLength(3);
   });
 });

--- a/packages/foam-vscode/src/features/tags-tree-view/index.spec.ts
+++ b/packages/foam-vscode/src/features/tags-tree-view/index.spec.ts
@@ -20,19 +20,17 @@ describe('Tags tree panel', () => {
   let _foam: Foam;
   let provider: TagsProvider;
 
+  const config: FoamConfig = createConfigFromFolders([]);
+  const mdProvider = new MarkdownResourceProvider(
+    new Matcher(
+      config.workspaceFolders,
+      config.includeGlobs,
+      config.ignoreGlobs
+    )
+  );
+
   beforeAll(async () => {
     await cleanWorkspace();
-
-    const config: FoamConfig = createConfigFromFolders([]);
-    const mdProvider = new MarkdownResourceProvider(
-      new Matcher(
-        config.workspaceFolders,
-        config.includeGlobs,
-        config.ignoreGlobs
-      )
-    );
-    _foam = await bootstrap(config, new FileDataStore(), [mdProvider]);
-    provider = new TagsProvider(_foam, _foam.workspace);
   });
 
   afterAll(async () => {
@@ -41,7 +39,13 @@ describe('Tags tree panel', () => {
   });
 
   beforeEach(async () => {
+    _foam = await bootstrap(config, new FileDataStore(), [mdProvider]);
+    provider = new TagsProvider(_foam, _foam.workspace);
     await closeEditors();
+  });
+
+  afterEach(() => {
+    _foam.dispose();
   });
 
   it('correctly provides a tag from a set of notes', async () => {

--- a/packages/foam-vscode/src/features/tags-tree-view/index.ts
+++ b/packages/foam-vscode/src/features/tags-tree-view/index.ts
@@ -1,7 +1,12 @@
 import * as vscode from 'vscode';
 import { Foam, Resource, URI, FoamWorkspace } from 'foam-core';
 import { FoamFeature } from '../../types';
-import { getNoteTooltip, getContainsTooltip, isSome } from '../../utils';
+import {
+  getNoteTooltip,
+  getContainsTooltip,
+  isSome,
+  isNone,
+} from '../../utils';
 
 const TAG_SEPARATOR = '/';
 const feature: FoamFeature = {
@@ -85,12 +90,7 @@ export class TagsProvider implements vscode.TreeDataProvider<TagTreeItem> {
         .filter(note =>
           // foreach nested tag item check if the exact tag is present as a tag on the note. If so,
           // it belongs to a nested tag item and should not be displayed as a reference underneath the current element
-          nestedTagItems.reduce(
-            (tagPresentAsNestedTag, nestedTag) => note.tags.has(nestedTag.tag),
-            true
-          )
-            ? note
-            : null
+          isNone(nestedTagItems.find(item => note.tags.has(item.tag)))
         )
         .map(note => new TagReference(element.tag, note))
         .sort((a, b) => a.title.localeCompare(b.title));

--- a/packages/foam-vscode/src/features/tags-tree-view/index.ts
+++ b/packages/foam-vscode/src/features/tags-tree-view/index.ts
@@ -1,12 +1,7 @@
 import * as vscode from 'vscode';
 import { Foam, Resource, URI, FoamWorkspace } from 'foam-core';
 import { FoamFeature } from '../../types';
-import {
-  getNoteTooltip,
-  getContainsTooltip,
-  isSome,
-  isNone,
-} from '../../utils';
+import { getNoteTooltip, getContainsTooltip, isSome } from '../../utils';
 
 const TAG_SEPARATOR = '/';
 const feature: FoamFeature = {

--- a/packages/foam-vscode/src/features/tags-tree-view/index.ts
+++ b/packages/foam-vscode/src/features/tags-tree-view/index.ts
@@ -87,11 +87,7 @@ export class TagsProvider implements vscode.TreeDataProvider<TagTreeItem> {
 
       const references: TagTreeItem[] = element.notes
         .map(({ uri }) => this.foam.workspace.get(uri))
-        .filter(note =>
-          // foreach nested tag item check if the exact tag is present as a tag on the note. If so,
-          // it belongs to a nested tag item and should not be displayed as a reference underneath the current element
-          isNone(nestedTagItems.find(item => note.tags.has(item.tag)))
-        )
+        .filter(note => note.tags.has(element.tag))
         .map(note => new TagReference(element.tag, note))
         .sort((a, b) => a.title.localeCompare(b.title));
 
@@ -104,12 +100,12 @@ export class TagsProvider implements vscode.TreeDataProvider<TagTreeItem> {
     if (!element) {
       const tags: Tag[] = this.tags
         .map(({ tag, notes }) => {
-          const title =
+          const parentTag =
             tag.indexOf(TAG_SEPARATOR) > 0
               ? tag.substring(0, tag.indexOf(TAG_SEPARATOR))
               : tag;
 
-          return new Tag(tag, title, notes);
+          return new Tag(parentTag, parentTag, notes);
         })
         .filter(
           (value, index, array) =>

--- a/packages/foam-vscode/src/features/tags-tree-view/index.ts
+++ b/packages/foam-vscode/src/features/tags-tree-view/index.ts
@@ -82,6 +82,16 @@ export class TagsProvider implements vscode.TreeDataProvider<TagTreeItem> {
 
       const references: TagTreeItem[] = element.notes
         .map(({ uri }) => this.foam.workspace.get(uri))
+        .filter(note =>
+          // foreach nested tag item check if the exact tag is present as a tag on the note. If so,
+          // it belongs to a nested tag item and should not be displayed as a reference underneath the current element
+          nestedTagItems.reduce(
+            (tagPresentAsNestedTag, nestedTag) => note.tags.has(nestedTag.tag),
+            true
+          )
+            ? note
+            : null
+        )
         .map(note => new TagReference(element.tag, note))
         .sort((a, b) => a.title.localeCompare(b.title));
 


### PR DESCRIPTION
While transforming my repo to use nested tags I saw an issue in the tag tree view explorer. Due to the way we nest tags it wrongfully displayed references that are part of a nested tag. 

<img width="321" alt="Screenshot 2021-05-27 at 14 18 23" src="https://user-images.githubusercontent.com/495374/119830255-5c080e80-befc-11eb-8f6f-adab184de11a.png">

The two references displayed here are part of the `change` nested tag. This minor fix ensures proper displaying of references and nested tags, see:

<img width="330" alt="Screenshot 2021-05-27 at 14 46 36" src="https://user-images.githubusercontent.com/495374/119830451-907bca80-befc-11eb-8d0c-5dbc62277849.png">
