### PR TITLE
doc: describe how to select launch configuration

### DIFF
--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -56,7 +56,7 @@ Tests in `foam-vscode` live alongside the code in `src`.
 
 This guide assumes you read the previous instructions and you're set up to work on Foam.
 
-1. Now we'll use the launch configuration defined at [`.vscode/launch.json`](https://github.com/foambubble/foam/blob/master/.vscode/launch.json) to start a new extension host of VS Code. From the root, or the `foam-vscode` workspace, press f5.
+1. Now we'll use the launch configuration defined at [`.vscode/launch.json`](https://github.com/foambubble/foam/blob/master/.vscode/launch.json) to start a new extension host of VS Code. Open the "Run and Debug" Activity (the icon with the bug on the far left) and select "Run VSCode Extension" in the pop-up menu. Now hit F5 or click the green arrow "play" button to fire up a new copy of VS Code with your extension installed.
 
 2. In the new extension host of VS Code that launched, open a Foam workspace (e.g. your personal one, or a test-specific one created from [foam-template](https://github.com/foambubble/foam-template)). This is strictly not necessary, but the extension won't auto-run unless it's in a workspace with a `.vscode/foam.json` file.
 


### PR DESCRIPTION
It took me a while to figure out why my extension host was quitting on its own soon after I launched it. It's because my launch config defaulted to "Test VSCode Extension". Hope this will save others the time.