### PR TITLE
WIP: Allow templates to be defined in the user's home directory

### DIFF
--- a/docs/features/note-templates.md
+++ b/docs/features/note-templates.md
@@ -2,7 +2,7 @@
 
 Foam supports note templates. Templates are a way to customize the starting content for your notes (instead of always starting from an empty note).
 
-Note templates are files located in the special `.foam/templates` directory.
+Note templates are files located in the special `.foam/templates` directory. The `.foam/templates` can be within the workspace, or within the user's home directory (e.g. `~/.foam/templates`).
 
 ## Quickstart
 
@@ -26,7 +26,8 @@ _Theme: Ayu Light_
 
 ## Default template
 
-The `.foam/templates/new-note.md` template is special in that it is the template that will be used by the `Foam: Create New Note` command.
+The `.foam/templates/new-note.md` template is special in that it is the template that will be used by the `Foam: Create New Note` command. `Foam: Create New Note` will look for this template in the current workspace, and then in the user's home directory if not found in the current workspace.
+
 Customize this template to contain content that you want included every time you create a note.
 
 ## Variables

--- a/packages/foam-vscode/src/features/create-from-template.ts
+++ b/packages/foam-vscode/src/features/create-from-template.ts
@@ -242,15 +242,15 @@ async function askUserForTemplate() {
 }
 
 async function askUserForFilepathConfirmation(
-  defaultFilepath: Uri,
+  defaultFilepath: string,
   defaultFilename: string
 ) {
   return await window.showInputBox({
     prompt: `Enter the filename for the new note`,
-    value: defaultFilepath.fsPath,
+    value: defaultFilepath,
     valueSelection: [
-      defaultFilepath.fsPath.length - defaultFilename.length,
-      defaultFilepath.fsPath.length - 3,
+      defaultFilepath.length - defaultFilename.length,
+      defaultFilepath.length - 3,
     ],
     validateInput: value =>
       value.trim().length === 0
@@ -356,7 +356,7 @@ async function createNoteFromDefaultTemplate(): Promise<void> {
   let filepath = defaultFilepath;
   if (existsSync(filepath.fsPath)) {
     const newFilepath = await askUserForFilepathConfirmation(
-      defaultFilepath,
+      defaultFilepath.fsPath,
       defaultFilename
     );
 
@@ -410,7 +410,7 @@ async function createNoteFromTemplate(
   const defaultFilename = path.basename(defaultFilepath.path);
 
   const filepath = await askUserForFilepathConfirmation(
-    defaultFilepath,
+    defaultFilepath.fsPath,
     defaultFilename
   );
 

--- a/packages/foam-vscode/src/features/create-from-template.ts
+++ b/packages/foam-vscode/src/features/create-from-template.ts
@@ -245,12 +245,13 @@ async function askUserForFilepathConfirmation(
   defaultFilepath: string,
   defaultFilename: string
 ) {
+  const defaultFilepathNoExtension = defaultFilepath.replace(/\.[^.]+$/, '');
   return await window.showInputBox({
     prompt: `Enter the filename for the new note`,
     value: defaultFilepath,
     valueSelection: [
       defaultFilepath.length - defaultFilename.length,
-      defaultFilepath.length - 3,
+      defaultFilepathNoExtension.length,
     ],
     validateInput: value =>
       value.trim().length === 0
@@ -423,13 +424,14 @@ async function createNoteFromTemplate(
 
 async function createNewTemplate(): Promise<void> {
   const defaultFilename = 'new-template.md';
-  const defaultTemplate = Uri.joinPath(templatesDir, defaultFilename);
+  const defaultFilepath = Uri.joinPath(templatesDir, defaultFilename).fsPath;
+  const defaultFilepathNoExtension = defaultFilepath.replace(/\.[^.]+$/, '');
   const filename = await window.showInputBox({
     prompt: `Enter the filename for the new template`,
-    value: defaultTemplate.fsPath,
+    value: defaultFilepath,
     valueSelection: [
-      defaultTemplate.fsPath.length - defaultFilename.length,
-      defaultTemplate.fsPath.length - 3,
+      defaultFilepath.length - defaultFilename.length,
+      defaultFilepathNoExtension.length,
     ],
     validateInput: value =>
       value.trim().length === 0

--- a/packages/foam-vscode/src/services/config.ts
+++ b/packages/foam-vscode/src/services/config.ts
@@ -6,7 +6,9 @@ import { getIgnoredFilesSetting } from '../settings';
 // not be dependent on vscode but at the moment it's convenient
 // to leverage it
 export const getConfigFromVscode = (): FoamConfig => {
-  const workspaceFolders = workspace.workspaceFolders.map(dir => dir.uri);
+  const workspaceFolders = workspace.workspaceFolders
+    ? workspace.workspaceFolders.map(dir => dir.uri)
+    : [];
   const excludeGlobs = getIgnoredFilesSetting();
 
   return createConfigFromFolders(workspaceFolders, {


### PR DESCRIPTION
### WIP Status

* [ ] Add tests
* [ ] Also manually test to confirm things work on Windows
* [ ] Update the code to match the outcome from [this proposal](https://github.com/foambubble/foam/pull/683)

### What are you trying to accomplish?

As noted in https://github.com/foambubble/foam/issues/670#issuecomment-860092115, you cannot specify "global" templates, even though you should be able to.

### What approach did you choose and why?

I refactored the existing template commands to fallback to using the templates in the user's home directory.

* `Foam: Create New Note`:
    * Looks for `new-note.md` in the current workspace, then the user's home directory if not found in the current workspace.

* `Foam: Create New Note From Template`:
    * Now has a `Show templates from your home directory` option in the quick-pick that appears when the current workspace has templates

![image](https://user-images.githubusercontent.com/1459385/121822546-a19f3800-cc6d-11eb-846f-68e193689dda.png)

* `Foam: Create New Template`:
    * Asks the user where they would like to create the new template

![image](https://user-images.githubusercontent.com/1459385/121822507-6b61b880-cc6d-11eb-91c8-07b78cff6d62.png)
 
### What should reviewers focus on?

There were a bunch of refactoring steps in this PR. I've broken them out by commit.
Reviewing this PR commit by commit might be easier.