### PR TITLE
Create a proposal for the "new note" fallback chain

### DIFF
--- a/docs/proposals/note-creation-filepath-fallback-chain.md
+++ b/docs/proposals/note-creation-filepath-fallback-chain.md
@@ -1,13 +1,15 @@
 # Templates v2 Proposal <!-- omit in TOC -->
 
 - [Introduction](#introduction)
+- [Goals](#goals)
 - [Proposal: "New note" path resolution](#proposal-new-note-path-resolution)
   - [Phase 1: `<workspace>/.foam/templates/new-note.md`](#phase-1-workspacefoamtemplatesnew-notemd)
-  - [Phase 2: `<home_dir>/.foam/templates/new-note.md`](#phase-2-home_dirfoamtemplatesnew-notemd)
-  - [Phase 3: `foam.newNoteDirectory`](#phase-3-foamnewnotedirectory)
+  - [`foam.rootDirectory`](#foamrootdirectory)
+  - [Phase 2: `${foam.rootDirectory ?? <home_dir>}/.foam/templates/new-note.md`](#phase-2-foamrootdirectory--home_dirfoamtemplatesnew-notemd)
+  - [Phase 3: `foam.rootDirectory`](#phase-3-foamrootdirectory)
   - [Phase 4: Use the directory of the active editor](#phase-4-use-the-directory-of-the-active-editor)
   - [Phase 5: Use the workspace root](#phase-5-use-the-workspace-root)
-  - [Phase 6: `<home_dir>`](#phase-6-home_dir)
+  - [Phase 6: `foam.rootDirectory ?? <home_dir>`](#phase-6-foamrootdirectory--home_dir)
 - [Progression of Foam usage maturity](#progression-of-foam-usage-maturity)
 
 ## Introduction
@@ -17,7 +19,13 @@ Currently, each command has its own fallback chain, which leads to inconsistent 
 
 This document will guide the development direction that each note-creating-command will eventually be modified to follow.
 
-Note that throughout this doc, `foam.newNoteDirectory` is used as a placeholder to denote a new Foam setting that we would add, as discussed in [this comment](https://github.com/foambubble/foam/issues/670#issuecomment-860184377).
+Note that throughout this doc, `foam.rootDirectory` is used as a placeholder name to denote a new Foam setting that we would add.
+
+## Goals
+
+* 100% coverage: Define a fallback chain such that Foam should always know where to / have a place to create a note
+* Sensible UX: Simplicity and consistency: it does what the user expects, and covers their needs without undue complexity.
+* Progressive UX: Users start with sensible defaults, then can customize as their usage of Foam gets more sophisticated.
 
 ## Proposal: "New note" path resolution
 
@@ -25,38 +33,37 @@ Note that throughout this doc, `foam.newNoteDirectory` is used as a placeholder 
 
 If `<workspace>/.foam/templates/new-note.md` exists, parse it looking for `filepath`:
 
-* An absolute path in `filepath` in `<workspace>/.foam/templates/new-note.md` should just use that absolute path.
 * A relative path in `filepath` in `<workspace>/.foam/templates/new-note.md` should be relative to the workspace.
+  * **Justification:** Allows users to have customized templates in a given workspace.
+* An absolute path in `filepath` in `<workspace>/.foam/templates/new-note.md` should just use that absolute path.
+  * **Justification:** Allows uses to have their notes for a project inside another repository.
 
-### Phase 2: `<home_dir>/.foam/templates/new-note.md`
+### `foam.rootDirectory`
 
-If `<workspace>/.foam/templates/new-note.md` does not exist (or no `filepath` attribute is defined in it), fall back to `<home_dir>/.foam/templates/new-note.md`
+`foam.rootDirectory` is a new Foam setting that we would add. It would be a directory that will be used for finding all global Foam-related settings.
+For some users, this might be the directory of their "second brain" / Zettelkasten repository.
+If not explicitly set, then Foam would look for the global Foam-related settings in the user's home directory (e.g., `~` on Linux/Mac), as discussed in [this comment](https://github.com/foambubble/foam/issues/670#issuecomment-860184377).
+### Phase 2: `${foam.rootDirectory ?? <home_dir>}/.foam/templates/new-note.md`
 
-* An absolute path in `filepath` in `<home_dir>/.foam/templates/new-note.md` should just use that absolute path.
-* A relative path in `filepath` in `<home_dir>/.foam/templates/new-note.md` should result in:
-  * **Option A**: Relative to the home directory
-    * This behaviour matches `<workspace>/.foam/templates/new-note.md` behaviour
-  * **Option B**: Relative to `foam.newNoteDirectory`
-    * I suspect is what you'd expect if you've already defined `foam.newNoteDirectory`
-  * **Option C**: Both. Relative to `foam.newNoteDirectory`, only when `foam.newNoteDirectory` is defined. Otherwise, relative to `<home_dir>`
-    * Things get a little weird if you didn't have `foam.newNoteDirectory` defined, then later defined it.
-  * **Option D**: Its own fallback chain:
-    * Relative to `foam.newNoteDirectory`, if defined
-    * Relative to workspace, if a workspace is open
-    * Relative to the home directory
-    * **Note:** This is similar to Phases 3, 5, and 6. But it doesn't make sense to include Phase 4 in this chain.
+If `<workspace>/.foam/templates/new-note.md` does not exist (or no `filepath` attribute is defined in it), fall back to `${foam.rootDirectory ?? <home_dir>}/.foam/templates/new-note.md`
 
-### Phase 3: `foam.newNoteDirectory`
+**Justification:** Allows users to define templates that can be used globally.
 
-If `<home_dir>/.foam/templates/new-note.md` does not exist (or no `filepath` attribute is defined in it), fall back to `foam.newNoteDirectory`.
+* An absolute path in `filepath` in `${foam.rootDirectory ?? <home_dir>}/.foam/templates/new-note.md` should just use that absolute path.
+* A relative path in `filepath` in `${foam.rootDirectory ?? <home_dir>}/.foam/templates/new-note.md` should result in:
+  * Relative to the current workspace (~Phase 5)
+    * **Justification:** This allows you to always store notes in a `notes` subdirectory of each project, etc.
+  * then relative to `foam.rootDirectory ?? <home_dir>` (~Phase 6) in the edge case where no workspace is open.
+    * **Justification:** Mostly here just to have a reasonable fallback in this edge case. It's kinda as if your Foam root directory is a default workspace.
 
-`foam.newNoteDirectory` should be a filepath, matching the spec used for `filepath` in the templates:
-  * Consistency: with the behaviour of the existing template commands.
-  * Flexibility: Users could use variables like `$FOAM_TITLE` (and eventually other snippet variables) in the path.
+### Phase 3: `foam.rootDirectory`
 
+If `${foam.rootDirectory ?? <home_dir>}/.foam/templates/new-note.md` does not exist (or no `filepath` attribute is defined in it), fall back to directory defined in `foam.rootDirectory`.
+
+**Justification:** This allows users to define a global directory to hold all Foam-related stuff (e.g., a second brain repository).
 ### Phase 4: Use the directory of the active editor
 
-If `foam.newNoteDirectory` is not defined, then use the directory of the active editor (`dirname(vscode.window.activeTextEditor)`).
+If `foam.rootDirectory` is not defined, then use the directory of the active editor (`dirname(vscode.window.activeTextEditor)`).
 This matches the behaviour of what [Markdown Notes'](https://marketplace.visualstudio.com/items?itemName=kortina.vscode-markdown-notes) `SAME_AS_ACTIVE_NOTE` does.
 
 ### Phase 5: Use the workspace root
@@ -65,14 +72,21 @@ If there is no active note, then use the workspace root (`workspace.workspaceFol
 
 This matches the behaviour of what [Markdown Notes'](https://marketplace.visualstudio.com/items?itemName=kortina.vscode-markdown-notes) `WORKSPACE_ROOT` does.
 
-### Phase 6: `<home_dir>`
+**Justification:** A reasonable fallback in the edge case where there isn't a file open.
 
-In the case where there is also no workspace open, then use `<home_dir>`.
+### Phase 6: `foam.rootDirectory ?? <home_dir>`
+
+In the case where there is also no workspace open, then use `foam.rootDirectory ?? <home_dir>`.
+
+**Justification:** A reasonable fallback in the edge case where there isn't a workspace open. It's as if your Foam root directory is a default workspace.
 
 Markdown Notes doesn't handle this case well, creating the note in the directory where VSCode was started from (???) and then failing to open the note.
 
 ## Progression of Foam usage maturity
 
 * When users first start using Foam, they have set up nothing. They skip to Phase 4.
-* They might then define `foam.newNoteDirectory` which means that they use Phase 3.
-* Then they might get into templates, which allow the fine-grain control of Phases 1 and 2.
+* They then might decide they want to set a global location where they store their notes (e.g., a second brain repository)
+  * They then define `foam.rootDirectory`, which means that they use Phase 3.
+* Then they might get into templates, which allow the fine-grain control of Phases 1 and 2:
+  * At first, they'll probably set them up in `foam.rootDirectory` to control their notes globally (Phase 2)
+  * For finer grain control, they Set up overrides of the global templates on a per-workspace level (Phase 1)

--- a/docs/proposals/note-creation-filepath-fallback-chain.md
+++ b/docs/proposals/note-creation-filepath-fallback-chain.md
@@ -1,0 +1,78 @@
+# Templates v2 Proposal <!-- omit in TOC -->
+
+- [Introduction](#introduction)
+- [Proposal: "New note" path resolution](#proposal-new-note-path-resolution)
+  - [Phase 1: `<workspace>/.foam/templates/new-note.md`](#phase-1-workspacefoamtemplatesnew-notemd)
+  - [Phase 2: `<home_dir>/.foam/templates/new-note.md`](#phase-2-home_dirfoamtemplatesnew-notemd)
+  - [Phase 3: `foam.newNoteDirectory`](#phase-3-foamnewnotedirectory)
+  - [Phase 4: Use the directory of the active editor](#phase-4-use-the-directory-of-the-active-editor)
+  - [Phase 5: Use the workspace root](#phase-5-use-the-workspace-root)
+  - [Phase 6: `<home_dir>`](#phase-6-home_dir)
+- [Progression of Foam usage maturity](#progression-of-foam-usage-maturity)
+
+## Introduction
+
+This document aims to standardize the fallback chain that is used by Foam when determining where to create a new note.
+Currently, each command has its own fallback chain, which leads to inconsistent behaviour in Foam.
+
+This document will guide the development direction that each note-creating-command will eventually be modified to follow.
+
+Note that throughout this doc, `foam.newNoteDirectory` is used as a placeholder to denote a new Foam setting that we would add, as discussed in [this comment](https://github.com/foambubble/foam/issues/670#issuecomment-860184377).
+
+## Proposal: "New note" path resolution
+
+### Phase 1: `<workspace>/.foam/templates/new-note.md`
+
+If `<workspace>/.foam/templates/new-note.md` exists, parse it looking for `filepath`:
+
+* An absolute path in `filepath` in `<workspace>/.foam/templates/new-note.md` should just use that absolute path.
+* A relative path in `filepath` in `<workspace>/.foam/templates/new-note.md` should be relative to the workspace.
+
+### Phase 2: `<home_dir>/.foam/templates/new-note.md`
+
+If `<workspace>/.foam/templates/new-note.md` does not exist (or no `filepath` attribute is defined in it), fall back to `<home_dir>/.foam/templates/new-note.md`
+
+* An absolute path in `filepath` in `<home_dir>/.foam/templates/new-note.md` should just use that absolute path.
+* A relative path in `filepath` in `<home_dir>/.foam/templates/new-note.md` should result in:
+  * **Option A**: Relative to the home directory
+    * This behaviour matches `<workspace>/.foam/templates/new-note.md` behaviour
+  * **Option B**: Relative to `foam.newNoteDirectory`
+    * I suspect is what you'd expect if you've already defined `foam.newNoteDirectory`
+  * **Option C**: Both. Relative to `foam.newNoteDirectory`, only when `foam.newNoteDirectory` is defined. Otherwise, relative to `<home_dir>`
+    * Things get a little weird if you didn't have `foam.newNoteDirectory` defined, then later defined it.
+  * **Option D**: Its own fallback chain:
+    * Relative to `foam.newNoteDirectory`, if defined
+    * Relative to workspace, if a workspace is open
+    * Relative to the home directory
+    * **Note:** This is similar to Phases 3, 5, and 6. But it doesn't make sense to include Phase 4 in this chain.
+
+### Phase 3: `foam.newNoteDirectory`
+
+If `<home_dir>/.foam/templates/new-note.md` does not exist (or no `filepath` attribute is defined in it), fall back to `foam.newNoteDirectory`.
+
+`foam.newNoteDirectory` should be a filepath, matching the spec used for `filepath` in the templates:
+  * Consistency: with the behaviour of the existing template commands.
+  * Flexibility: Users could use variables like `$FOAM_TITLE` (and eventually other snippet variables) in the path.
+
+### Phase 4: Use the directory of the active editor
+
+If `foam.newNoteDirectory` is not defined, then use the directory of the active editor (`dirname(vscode.window.activeTextEditor)`).
+This matches the behaviour of what [Markdown Notes'](https://marketplace.visualstudio.com/items?itemName=kortina.vscode-markdown-notes) `SAME_AS_ACTIVE_NOTE` does.
+
+### Phase 5: Use the workspace root
+
+If there is no active note, then use the workspace root (`workspace.workspaceFolders[0].uri`)
+
+This matches the behaviour of what [Markdown Notes'](https://marketplace.visualstudio.com/items?itemName=kortina.vscode-markdown-notes) `WORKSPACE_ROOT` does.
+
+### Phase 6: `<home_dir>`
+
+In the case where there is also no workspace open, then use `<home_dir>`.
+
+Markdown Notes doesn't handle this case well, creating the note in the directory where VSCode was started from (???) and then failing to open the note.
+
+## Progression of Foam usage maturity
+
+* When users first start using Foam, they have set up nothing. They skip to Phase 4.
+* They might then define `foam.newNoteDirectory` which means that they use Phase 3.
+* Then they might get into templates, which allow the fine-grain control of Phases 1 and 2.


### PR DESCRIPTION
My work on [allowing templates in the user's home directory](https://github.com/foambubble/foam/pull/679), 
* combined with [this question](https://github.com/foambubble/foam/issues/670#issuecomment-860184377) about having a global setting for default note creation, 
* combined with Foam's inadequate handling of the edge case where no workspace is open

Has forced me to consider what the complete new note creation fallback chain ought to be. I realized that I really need to nail it down so that I could enforce consistency between all of Foam's methods of creating notes.

Here's what I've managed to come up with. Feel free to criticize it in any way.

It's probably easiest to view the [rendered version](https://github.com/movermeyer/foam/blob/filepath_fallback_path/docs/proposals/note-creation-filepath-fallback-chain.md) of this document.

Let me know what you think so I can get the commands all switched over to use it.

@riccardoferretti 