### PR TITLE
Handle different capitalizations of wikilinks and files

### DIFF
--- a/packages/foam-core/src/model/workspace.ts
+++ b/packages/foam-core/src/model/workspace.ts
@@ -26,7 +26,8 @@ const pathToResourceId = (pathValue: string) => {
 };
 const uriToResourceId = (uri: URI) => pathToResourceId(uri.path);
 
-const pathToResourceName = (pathValue: string) => path.parse(pathValue).name;
+const pathToResourceName = (pathValue: string) =>
+  path.parse(pathValue).name.toLowerCase();
 export const uriToResourceName = (uri: URI) => pathToResourceName(uri.path);
 
 export class FoamWorkspace implements IDisposable {

--- a/packages/foam-core/test/workspace.test.ts
+++ b/packages/foam-core/test/workspace.test.ts
@@ -368,6 +368,37 @@ describe('Wikilinks', () => {
 
     expect(graph.getLinks(noteA.uri).map(l => l.target)).toEqual([noteB1.uri]);
   });
+
+  it('Handles capatalization of files and wiki links correctly', () => {
+    const noteA = createTestNote({
+      uri: '/path/to/page-a.md',
+      links: [
+        // uppercased filename, lowercased slug
+        { slug: 'page-b' },
+        // lowercased filename, camelcased wikilink
+        { slug: 'Page-C' },
+        // lowercased filename, lowercased wikilink
+        { slug: 'page-d' },
+      ],
+    });
+    const ws = createTestWorkspace()
+      .set(noteA)
+      .set(createTestNote({ uri: '/somewhere/PAGE-B.md' }))
+      .set(createTestNote({ uri: '/path/another/page-c.md' }))
+      .set(createTestNote({ uri: '/path/another/page-d.md' }));
+    const graph = FoamGraph.fromWorkspace(ws);
+
+    expect(
+      graph
+        .getLinks(noteA.uri)
+        .map(link => link.target.path)
+        .sort()
+    ).toEqual([
+      '/path/another/page-c.md',
+      '/path/another/page-d.md',
+      '/somewhere/PAGE-B.md',
+    ]);
+  });
 });
 
 describe('markdown direct links', () => {


### PR DESCRIPTION
This should fix #641. The essence of the fix is to make sure we register and lookup resources by name in lowercase. This will ensure the key is always the same.

A risk I see is that there might be an issue with backward compatibility. If I now have a wikilink `[[Page]]` and `[[page]]` in different folders, this will clash now. What do we want to do here?

Given the spirit of wikilinks I would say that the situation of above is incorrect anyway. But, we might want to do something here? Add a warning box if the situation occurs, perhaps? Looking for thoughts here.