### PR TITLE
Allow for dots in wikilinks

### DIFF
--- a/packages/foam-core/src/model/workspace.ts
+++ b/packages/foam-core/src/model/workspace.ts
@@ -110,7 +110,12 @@ export class FoamWorkspace implements IDisposable {
 
       case 'key':
         const name = pathToResourceName(resourceId as string);
-        const paths = this.resourcesByName[name];
+        let paths = this.resourcesByName[name];
+
+        if (isNone(paths) || paths.length === 0) {
+          paths = this.resourcesByName[resourceId as string];
+        }
+
         if (isNone(paths) || paths.length === 0) {
           return null;
         }
@@ -118,6 +123,7 @@ export class FoamWorkspace implements IDisposable {
         const sortedPaths = paths.length === 1
           ? paths
           : paths.sort((a, b) => a.localeCompare(b));
+
         return this.resources[sortedPaths[0]];
 
       case 'absolute-path':

--- a/packages/foam-core/test/workspace.test.ts
+++ b/packages/foam-core/test/workspace.test.ts
@@ -354,6 +354,20 @@ describe('Wikilinks', () => {
       attachmentABis.uri,
     ]);
   });
+
+  it('Allows for dendron-style wikilinks, including a dot', () => {
+    const noteA = createTestNote({
+      uri: '/path/to/page-a.md',
+      links: [{ slug: 'dendron.style' }],
+    });
+    const noteB1 = createTestNote({ uri: '/path/to/another/dendron.style.md' });
+
+    const ws = createTestWorkspace();
+    ws.set(noteA).set(noteB1);
+    const graph = FoamGraph.fromWorkspace(ws);
+
+    expect(graph.getLinks(noteA.uri).map(l => l.target)).toEqual([noteB1.uri]);
+  });
 });
 
 describe('markdown direct links', () => {


### PR DESCRIPTION
This will allow for dendron-style wikilinks, resolves #672. Due to the correct behaviour, it ensures proper working of the graph and explorer functions as well.