### PR TITLE
Removes escape character of an alias when setting target

### DIFF
--- a/packages/foam-core/src/markdown-provider.ts
+++ b/packages/foam-core/src/markdown-provider.ts
@@ -219,6 +219,7 @@ const wikilinkPlugin: ParserPlugin = {
         target: hasAlias
           ? literalContent
               .substring(2, literalContent.indexOf(ALIAS_DIVIDER_CHAR))
+              .replace(/\\/g, '')
               .trim()
           : text.trim(),
         range: astPositionToFoamRange(node.position!),

--- a/packages/foam-vscode/src/features/document-link-provider.spec.ts
+++ b/packages/foam-vscode/src/features/document-link-provider.spec.ts
@@ -22,10 +22,7 @@ describe('Document links provider', () => {
 
   afterAll(async () => {
     await cleanWorkspace();
-    await updateFoamVsCodeConfig(
-      'edit.linkReferenceDefinitions',
-      'withoutExtensions'
-    );
+    await updateFoamVsCodeConfig('edit.linkReferenceDefinitions', undefined);
   });
 
   beforeEach(async () => {

--- a/packages/foam-vscode/src/features/document-link-provider.spec.ts
+++ b/packages/foam-vscode/src/features/document-link-provider.spec.ts
@@ -10,19 +10,16 @@ import {
 import { LinkProvider } from './document-link-provider';
 import { OPEN_COMMAND } from './utility-commands';
 import { toVsCodeUri } from '../utils/vsc-utils';
-import { updateFoamVsCodeConfig } from '../services/config';
 
 describe('Document links provider', () => {
   const parser = createMarkdownParser([]);
 
   beforeAll(async () => {
     await cleanWorkspace();
-    await updateFoamVsCodeConfig('edit.linkReferenceDefinitions', 'off');
   });
 
   afterAll(async () => {
     await cleanWorkspace();
-    await updateFoamVsCodeConfig('edit.linkReferenceDefinitions', undefined);
   });
 
   beforeEach(async () => {

--- a/packages/foam-vscode/src/features/document-link-provider.spec.ts
+++ b/packages/foam-vscode/src/features/document-link-provider.spec.ts
@@ -10,16 +10,22 @@ import {
 import { LinkProvider } from './document-link-provider';
 import { OPEN_COMMAND } from './utility-commands';
 import { toVsCodeUri } from '../utils/vsc-utils';
+import { updateFoamVsCodeConfig } from '../services/config';
 
 describe('Document links provider', () => {
   const parser = createMarkdownParser([]);
 
   beforeAll(async () => {
     await cleanWorkspace();
+    await updateFoamVsCodeConfig('edit.linkReferenceDefinitions', 'off');
   });
 
   afterAll(async () => {
     await cleanWorkspace();
+    await updateFoamVsCodeConfig(
+      'edit.linkReferenceDefinitions',
+      'withoutExtensions'
+    );
   });
 
   beforeEach(async () => {
@@ -102,10 +108,11 @@ describe('Document links provider', () => {
   });
 
   it('should support wikilinks that have an alias', async () => {
-    const fileB = await createFile('# File B');
+    const fileB = await createFile("# File B that's aliased");
     const fileA = await createFile(
       `this is a link to [[${fileB.name}|alias]].`
     );
+
     const noteA = parser.parse(fileA.uri, fileA.content);
     const noteB = parser.parse(fileB.uri, fileB.content);
     const ws = createTestWorkspace()
@@ -119,5 +126,26 @@ describe('Document links provider', () => {
     expect(links.length).toEqual(1);
     expect(links[0].target).toEqual(OPEN_COMMAND.asURI(noteB.uri));
     expect(links[0].range).toEqual(new vscode.Range(0, 18, 0, 33));
+  });
+
+  it('should support wikilink aliases in tables using escape character', async () => {
+    const fileB = await createFile('# File that has to be aliased');
+    const fileA = await createFile(`
+  | Col A | ColB |
+  | --- | --- |
+  | [[${fileB.name}\\|alias]] | test |
+    `);
+    const noteA = parser.parse(fileA.uri, fileA.content);
+    const noteB = parser.parse(fileB.uri, fileB.content);
+    const ws = createTestWorkspace()
+      .set(noteA)
+      .set(noteB);
+
+    const { doc } = await showInEditor(noteA.uri);
+    const provider = new LinkProvider(ws, parser);
+    const links = provider.provideDocumentLinks(doc);
+
+    expect(links.length).toEqual(1);
+    expect(links[0].target).toEqual(OPEN_COMMAND.asURI(noteB.uri));
   });
 });

--- a/packages/foam-vscode/src/test/support/extended-vscode-environment.js
+++ b/packages/foam-vscode/src/test/support/extended-vscode-environment.js
@@ -13,6 +13,10 @@ class ExtendedVscodeEnvironment extends VscodeEnvironment {
     // And also https://github.com/microsoft/vscode-test/issues/37#issuecomment-700167820
     this.global.RegExp = RegExp;
     this.global.vscode = vscode;
+
+    vscode.workspace
+      .getConfiguration()
+      .update('foam.edit.linkReferenceDefinitions', 'off');
   }
   async teardown() {
     this.global.vscode = initialVscode;


### PR DESCRIPTION
This resolves #695 and additionally also provides better input for the graph rendering. When setting the target, the escape character is now explicitly removed.