### PR TITLE
Only remove link definition token that contain an alias divider

### DIFF
--- a/packages/foam-vscode/src/features/preview-navigation.ts
+++ b/packages/foam-vscode/src/features/preview-navigation.ts
@@ -96,9 +96,13 @@ export const markdownItWithRemoveLinkReferences = (
   md: markdownit,
   workspace: FoamWorkspace
 ) => {
-  // Forget about reference blocks before processing links.
+  // Forget about reference links that contain an alias divider
   md.inline.ruler.before('link', 'clear-references', state => {
-    state.env.references = undefined;
+    Object.keys(state.env.references).map(refKey => {
+      if (refKey.includes(ALIAS_DIVIDER_CHAR)) {
+        delete state.env.references[refKey];
+      }
+    });
     return false;
   });
   return md;

--- a/packages/foam-vscode/src/features/preview-navigation.ts
+++ b/packages/foam-vscode/src/features/preview-navigation.ts
@@ -98,7 +98,7 @@ export const markdownItWithRemoveLinkReferences = (
 ) => {
   // Forget about reference links that contain an alias divider
   md.inline.ruler.before('link', 'clear-references', state => {
-    Object.keys(state.env.references).map(refKey => {
+    Object.keys(state.env.references).forEach(refKey => {
       if (refKey.includes(ALIAS_DIVIDER_CHAR)) {
         delete state.env.references[refKey];
       }


### PR DESCRIPTION
This resolves #696. Where we initially removed the entire reference definition block, we now only remove the one that contain a `|`. So, we allow

`[foo]: /url "title"`

But filter out the following one for the preview:
`[foo|alias]: /url "title"`
