### PR TITLE
Make daily notes use templates

### DIFF
--- a/docs/features/daily-notes.md
+++ b/docs/features/daily-notes.md
@@ -25,9 +25,9 @@ The above configuration would create a file `journal/note-2020-07-25.mdx`, with 
 
 ## Daily Note Templates
 
-In the future, Foam may provide a functionality for specifying a template for new Daily Notes and other types of documents.
+Daily notes can also make use of [templates](note-templates.md), by defining a special `.foam/templates/daily-note.md` template.
 
-In the meantime, you can use [VS Code Snippets](https://code.visualstudio.com/docs/editor/userdefinedsnippets) for defining your own Daily Note template.
+See [Note Templates](note-templates.md) for details of the features available in templates.
 
 ## Roam-style Automatic Daily Notes
 

--- a/docs/features/note-templates.md
+++ b/docs/features/note-templates.md
@@ -24,10 +24,16 @@ To create a note from a template:
 
 _Theme: Ayu Light_
 
-## Default template
+## Special templates
+### Default template
 
 The `.foam/templates/new-note.md` template is special in that it is the template that will be used by the `Foam: Create New Note` command.
 Customize this template to contain content that you want included every time you create a note.
+
+### Default daily note template
+
+The `.foam/templates/daily-note.md` template is special in that it is the template that will be used when creating daily notes (e.g. by using `Foam: Open Daily Note`).
+Customize this template to contain content that you want included every time you create a daily note.
 
 ## Variables
 
@@ -58,6 +64,8 @@ Foam-specific variables (e.g. `$FOAM_TITLE`) can be used within template metadat
 
 The `filepath` metadata attribute allows you to define a relative or absolute filepath to use when creating a note using the template.
 If the filepath is a relative filepath, it is relative to the current workspace.
+
+**Note:** While you can make use of the `filepath` attribute in [daily note](daily-notes.md) templates (`.foam/templates/daily-note.md`), there is currently no way to have `filepath` vary based on the date. This will be improved in the future. For now, you can customize the location of daily notes using the [`foam.openDailyNote` settings](daily-notes.md).
 
 #### Example of relative `filepath`
 

--- a/packages/foam-vscode/src/dated-notes.test.ts
+++ b/packages/foam-vscode/src/dated-notes.test.ts
@@ -1,4 +1,4 @@
-import { Uri, workspace } from 'vscode';
+import { workspace } from 'vscode';
 import { getDailyNotePath } from './dated-notes';
 import { URI } from 'foam-core';
 import { isWindows } from './utils';
@@ -13,7 +13,7 @@ describe('getDailyNotePath', () => {
   test('Adds the root directory to relative directories', async () => {
     const config = 'journal';
 
-    const expectedPath = Uri.joinPath(
+    const expectedPath = URI.joinPath(
       workspace.workspaceFolders[0].uri,
       config,
       `${isoDate}.md`
@@ -25,7 +25,7 @@ describe('getDailyNotePath', () => {
     const foamConfiguration = workspace.getConfiguration('foam');
 
     expect(URI.toFsPath(getDailyNotePath(foamConfiguration, date))).toEqual(
-      expectedPath.fsPath
+      URI.toFsPath(expectedPath)
     );
   });
 

--- a/packages/foam-vscode/src/features/create-from-template.test.ts
+++ b/packages/foam-vscode/src/features/create-from-template.test.ts
@@ -211,7 +211,7 @@ describe('resolveFoamTemplateVariables', () => {
       .spyOn(window, 'showInputBox')
       .mockImplementationOnce(jest.fn(() => Promise.resolve(foamTitle)));
 
-    const input = '# ${FOAM_TITLE}';
+    const input = `# \${FOAM_TITLE}`;
 
     const expectedOutput = '# My note title\nSelected text';
 


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #565: Allowing daily notes to use templates.

### What approach did you choose and why?

1. I added a new template creation function, `createNoteFromDailyNoteTemplate`:
   * It differs from `createNoteFromDefaultTemplate` in a few ways:
       * It uses `daily-note.md` instead of `new-note.md`
       * It only resolves `FOAM_TITLE` if the template requires it
       * It accepts parameters for the default template text and the desired output location
2. I then changed `createDailyNoteIfNotExists` to call this function.
3. I then refactored `createNoteFromDefaultTemplate` to be able to handle all the differences.
    * This refactor will be re-used as part of the changes needed for https://github.com/foambubble/foam/issues/566

#### Limitation

We make use of the `filepath` template metadata attribute, if it is present in the template. 
However, this is currently pretty useless, since we don't yet have a way to specify the date in the `filepath`.

* If we end up [adding a Foam-specific variable](https://github.com/foambubble/foam/issues/564), then we could use that new variable in `filepath`
* Alternatively, if we solve #692, then we could use the [`CURRENT_YEAR`/`CURRENT_MONTH`/`CURRENT_DATE` VS Code snippet variables](https://code.visualstudio.com/docs/editor/userdefinedsnippets#_variables).

For right now, as long as they don't use `filepath`, we continue to behave as we currently do: determining the filepath from the `foam.openDailyNote.*` settings.

**Claim:** This limitation should not prevent users from enjoying the other benefits of templates in the mean time.

### What should reviewers focus on?
<!--
Outline anything you'd like reviewers to pay extra attention to. List open questions for discussion.
-->

...

### The impact of these changes
<!--
Are there any specific impacts from this change that you'd like to call out?
-->

...

### Testing

To test this change:

1. Create a new `.foam/templates/daily-note.md` template file:

```yaml
# $CURRENT_YEAR-$CURRENT_MONTH-$CURRENT_DATE

## What I plan on doing today
 
* [ ] Contribute to Foam! 🎉 
* [ ] 20 minute cardio workout 💨 

## What I did today

* 

```

2. Run `Foam: Open Daily Note`

The new note should be created at the filepath defined by `foam.openDailyNote.*` settings, using the contents of the `daily-note.md` template.

### Checklist
- [x] I have manually tested this change. 
- [x] This PR is safe to roll back.
