### PR TITLE
Fix implicit insertion of `FOAM_SELECTED_TEXT`

### DIFF
--- a/packages/foam-vscode/src/features/create-from-template.test.ts
+++ b/packages/foam-vscode/src/features/create-from-template.test.ts
@@ -150,21 +150,16 @@ describe('resolveFoamTemplateVariables', () => {
     ).toEqual(expected);
   });
 
-  test('Adds FOAM_SELECTED_TEXT at end of template if it has variable has a value but is not referenced', async () => {
+  test('Appends FOAM_SELECTED_TEXT with a newline to the template if there is selected text but FOAM_SELECTED_TEXT is not referenced and the template ends in a newline', async () => {
     const foamTitle = 'My note title';
 
     jest
       .spyOn(window, 'showInputBox')
       .mockImplementationOnce(jest.fn(() => Promise.resolve(foamTitle)));
 
-    const input = `
-      # \${FOAM_TITLE}
-      # $FOAM_TITLE`;
+    const input = `# \${FOAM_TITLE}\n`;
 
-    const expectedOutput = `
-      # My note title
-      # My note title
-      Selected text`;
+    const expectedOutput = `# My note title\nSelected text\n`;
 
     const expectedMap = new Map<string, string>();
     expectedMap.set('FOAM_TITLE', foamTitle);
@@ -176,13 +171,67 @@ describe('resolveFoamTemplateVariables', () => {
     expect(
       await resolveFoamTemplateVariables(
         input,
-        new Set(['FOAM_TITLE']),
+        new Set(['FOAM_TITLE', 'FOAM_SELECTED_TEXT']),
         givenValues
       )
     ).toEqual(expected);
   });
 
-  test('Does not add FOAM_SELECTED_TEXT at end of template if it has variable not has a value and is not referenced', async () => {
+  test('Appends FOAM_SELECTED_TEXT with a newline to the template if there is selected text but FOAM_SELECTED_TEXT is not referenced and the template ends in multiple newlines', async () => {
+    const foamTitle = 'My note title';
+
+    jest
+      .spyOn(window, 'showInputBox')
+      .mockImplementationOnce(jest.fn(() => Promise.resolve(foamTitle)));
+
+    const input = `# \${FOAM_TITLE}\n\n`;
+
+    const expectedOutput = `# My note title\n\nSelected text\n`;
+
+    const expectedMap = new Map<string, string>();
+    expectedMap.set('FOAM_TITLE', foamTitle);
+    expectedMap.set('FOAM_SELECTED_TEXT', 'Selected text');
+
+    const expected = [expectedMap, expectedOutput];
+    const givenValues = new Map<string, string>();
+    givenValues.set('FOAM_SELECTED_TEXT', 'Selected text');
+    expect(
+      await resolveFoamTemplateVariables(
+        input,
+        new Set(['FOAM_TITLE', 'FOAM_SELECTED_TEXT']),
+        givenValues
+      )
+    ).toEqual(expected);
+  });
+
+  test('Appends FOAM_SELECTED_TEXT without a newline to the template if there is selected text but FOAM_SELECTED_TEXT is not referenced and the template does not end in a newline', async () => {
+    const foamTitle = 'My note title';
+
+    jest
+      .spyOn(window, 'showInputBox')
+      .mockImplementationOnce(jest.fn(() => Promise.resolve(foamTitle)));
+
+    const input = '# ${FOAM_TITLE}';
+
+    const expectedOutput = '# My note title\nSelected text';
+
+    const expectedMap = new Map<string, string>();
+    expectedMap.set('FOAM_TITLE', foamTitle);
+    expectedMap.set('FOAM_SELECTED_TEXT', 'Selected text');
+
+    const expected = [expectedMap, expectedOutput];
+    const givenValues = new Map<string, string>();
+    givenValues.set('FOAM_SELECTED_TEXT', 'Selected text');
+    expect(
+      await resolveFoamTemplateVariables(
+        input,
+        new Set(['FOAM_TITLE', 'FOAM_SELECTED_TEXT']),
+        givenValues
+      )
+    ).toEqual(expected);
+  });
+
+  test('Does not append FOAM_SELECTED_TEXT to a template if there is no selected text and is not referenced', async () => {
     const foamTitle = 'My note title';
 
     jest
@@ -191,10 +240,9 @@ describe('resolveFoamTemplateVariables', () => {
 
     const input = `
       # \${FOAM_TITLE}
-      # $FOAM_TITLE`;
+      `;
 
     const expectedOutput = `
-      # My note title
       # My note title
       `;
 
@@ -204,11 +252,11 @@ describe('resolveFoamTemplateVariables', () => {
 
     const expected = [expectedMap, expectedOutput];
     const givenValues = new Map<string, string>();
-    givenValues.set('FOAM_SELECTED_TEXT', null);
+    givenValues.set('FOAM_SELECTED_TEXT', '');
     expect(
       await resolveFoamTemplateVariables(
         input,
-        new Set(['FOAM_TITLE']),
+        new Set(['FOAM_TITLE', 'FOAM_SELECTED_TEXT']),
         givenValues
       )
     ).toEqual(expected);


### PR DESCRIPTION
### What are you trying to accomplish?

#666 introduced the `FOAM_SELECTED_TEXT` snippet variable.
Crucially, this variable gets implicitly added to the end of templates that don't explicitly reference it, when there is a selection at the time of note creation.

However, the appending is not done correctly.

### What approach did you choose and why?

* I changed the way the value was appended to the template

Existing code: `${templateText}\n      \${FOAM_SELECTED_TEXT}`

First, note that there are spaces inserted at the start of the line. I believe this was a simple oversight.
Next, the addition of the newline should be conditional:

1. Conditional on whether there is any selection to append
    * The existing code inserts a newline regardless of whether there is any selection
    * This was a side-effect of how the code was structured. I've reworked the code to make this addition conditional
2. Conditional on the existence of trailing newline

#### Conditional on trailing newline

It is customary for files to end in a newline. The addition of `FOAM_SELECTED_TEXT` should not change that.
* If the template ends in a newline, then the resulting note should also end in a newline.
* If the template does not end in a newline, then the resulting note should also not end in a newline.

| Template            | Result                                   |
| ------------------- | ---------------------------------------- |
| `# $FOAM_TITLE`     | `# $FOAM_TITLE\n$FOAM_SELECTED_TEXT`     |
| `# $FOAM_TITLE\n`   | `# $FOAM_TITLE\n$FOAM_SELECTED_TEXT\n`   |
| `# $FOAM_TITLE\n\n` | `# $FOAM_TITLE\n\n$FOAM_SELECTED_TEXT\n` |

#### Resolution changes

I also changed the resolution of the `FOAM_SELECTED_TEXT` variable.

It now can be resolved like any other Foam-specific variable, simplifying the resolution logic, and only appending `FOAM_SELECTED_TEXT` if the template doesn't reference it AND there is a value for the selection. 

### What should reviewers focus on?

Convince yourself that the resulting note is what you'd want as a user in all cases.

### Checklist
- [x] I have manually tested this change. 
- [x] This PR is safe to roll back.
