### PR TITLE
Migrate create-from-template to use Foam's `URI` instead of VSCode's `Uri`

### DIFF
--- a/packages/foam-core/src/model/uri.ts
+++ b/packages/foam-core/src/model/uri.ts
@@ -1,4 +1,7 @@
-// Some code in this file coming from https://github.com/microsoft/vscode/
+// `URI` is mostly compatible with VSCode's `Uri`.
+// Having a Foam-specific URI object allows for easier maintenance of the API.
+// See https://github.com/foambubble/foam/pull/537 for more context.
+// Some code in this file comes from https://github.com/microsoft/vscode/main/src/vs/base/common/uri.ts
 // See LICENSE for details
 
 import * as paths from 'path';

--- a/packages/foam-vscode/src/features/create-from-template.spec.ts
+++ b/packages/foam-vscode/src/features/create-from-template.spec.ts
@@ -1,5 +1,7 @@
+import { URI } from 'foam-core';
 import path from 'path';
-import { commands, Uri, window, workspace } from 'vscode';
+import { toVsCodeUri } from '../utils/vsc-utils';
+import { commands, window, workspace } from 'vscode';
 describe('createFromTemplate', () => {
   describe('create-note-from-template', () => {
     afterEach(() => {
@@ -65,7 +67,7 @@ describe('createFromTemplate', () => {
 
       await commands.executeCommand('foam-vscode.create-new-template');
 
-      const file = await workspace.fs.readFile(Uri.file(template));
+      const file = await workspace.fs.readFile(toVsCodeUri(URI.file(template)));
       expect(window.showInputBox).toHaveBeenCalled();
       expect(file).toBeDefined();
     });
@@ -85,7 +87,9 @@ describe('createFromTemplate', () => {
       await commands.executeCommand('foam-vscode.create-new-template');
 
       expect(window.showInputBox).toHaveBeenCalled();
-      await expect(workspace.fs.readFile(Uri.file(template))).rejects.toThrow();
+      await expect(
+        workspace.fs.readFile(toVsCodeUri(URI.file(template)))
+      ).rejects.toThrow();
     });
   });
 });

--- a/packages/foam-vscode/src/features/create-from-template.ts
+++ b/packages/foam-vscode/src/features/create-from-template.ts
@@ -266,13 +266,11 @@ async function askUserForFilepathConfirmation(
   defaultFilepath: URI,
   defaultFilename: string
 ) {
+  const fsPath = URI.toFsPath(defaultFilepath);
   return await window.showInputBox({
     prompt: `Enter the filename for the new note`,
-    value: URI.toFsPath(defaultFilepath),
-    valueSelection: [
-      URI.toFsPath(defaultFilepath).length - defaultFilename.length,
-      URI.toFsPath(defaultFilepath).length - 3,
-    ],
+    value: fsPath,
+    valueSelection: [fsPath.length - defaultFilename.length, fsPath.length - 3],
     validateInput: value =>
       value.trim().length === 0
         ? 'Please enter a value'
@@ -544,13 +542,11 @@ async function createNoteFromTemplate(
 async function createNewTemplate(): Promise<void> {
   const defaultFilename = 'new-template.md';
   const defaultTemplate = URI.joinPath(templatesDir, defaultFilename);
+  const fsPath = URI.toFsPath(defaultTemplate);
   const filename = await window.showInputBox({
     prompt: `Enter the filename for the new template`,
-    value: URI.toFsPath(defaultTemplate),
-    valueSelection: [
-      URI.toFsPath(defaultTemplate).length - defaultFilename.length,
-      URI.toFsPath(defaultTemplate).length - 3,
-    ],
+    value: fsPath,
+    valueSelection: [fsPath.length - defaultFilename.length, fsPath.length - 3],
     validateInput: value =>
       value.trim().length === 0
         ? 'Please enter a value'

--- a/packages/foam-vscode/src/features/create-from-template.ts
+++ b/packages/foam-vscode/src/features/create-from-template.ts
@@ -10,7 +10,6 @@ import {
   Selection,
   SnippetString,
   TextDocument,
-  Uri,
   ViewColumn,
   window,
   workspace,
@@ -18,9 +17,10 @@ import {
 } from 'vscode';
 import { FoamFeature } from '../types';
 import { focusNote } from '../utils';
+import { toVsCodeUri } from '../utils/vsc-utils';
 import { extractFoamTemplateFrontmatterMetadata } from '../utils/template-frontmatter-parser';
 
-const templatesDir = Uri.joinPath(
+const templatesDir = URI.joinPath(
   workspace.workspaceFolders[0].uri,
   '.foam',
   'templates'
@@ -52,7 +52,7 @@ foam_template:
 
 \${FOAM_SELECTED_TEXT}
 `;
-const defaultTemplateUri = Uri.joinPath(templatesDir, 'new-note.md');
+const defaultTemplateUri = URI.joinPath(templatesDir, 'new-note.md');
 
 const templateContent = `# \${1:$TM_FILENAME_BASE}
 
@@ -74,16 +74,16 @@ For a full list of features see [the VS Code snippets page](https://code.visuals
 `;
 
 async function templateMetadata(
-  templateUri: Uri
+  templateUri: URI
 ): Promise<Map<string, string>> {
   const contents = await workspace.fs
-    .readFile(templateUri)
+    .readFile(toVsCodeUri(templateUri))
     .then(bytes => bytes.toString());
   const [templateMetadata] = extractFoamTemplateFrontmatterMetadata(contents);
   return templateMetadata;
 }
 
-async function getTemplates(): Promise<Uri[]> {
+async function getTemplates(): Promise<URI[]> {
   const templates = await workspace.findFiles('.foam/templates/**.md', null);
   return templates;
 }
@@ -263,15 +263,15 @@ async function askUserForTemplate() {
 }
 
 async function askUserForFilepathConfirmation(
-  defaultFilepath: Uri,
+  defaultFilepath: URI,
   defaultFilename: string
 ) {
   return await window.showInputBox({
     prompt: `Enter the filename for the new note`,
-    value: defaultFilepath.fsPath,
+    value: URI.toFsPath(defaultFilepath),
     valueSelection: [
-      defaultFilepath.fsPath.length - defaultFilename.length,
-      defaultFilepath.fsPath.length - 3,
+      URI.toFsPath(defaultFilepath).length - defaultFilename.length,
+      URI.toFsPath(defaultFilepath).length - 3,
     ],
     validateInput: value =>
       value.trim().length === 0
@@ -324,10 +324,13 @@ export async function resolveFoamTemplateVariables(
 
 async function writeTemplate(
   templateSnippet: SnippetString,
-  filepath: Uri,
+  filepath: URI,
   viewColumn: ViewColumn = ViewColumn.Active
 ) {
-  await workspace.fs.writeFile(filepath, new TextEncoder().encode(''));
+  await workspace.fs.writeFile(
+    toVsCodeUri(filepath),
+    new TextEncoder().encode('')
+  );
   await focusNote(filepath, true, viewColumn);
   await window.activeTextEditor.insertSnippet(templateSnippet);
 }
@@ -336,10 +339,10 @@ function currentDirectoryFilepath(filename: string) {
   const activeFile = window.activeTextEditor?.document?.uri.path;
   const currentDir =
     activeFile !== undefined
-      ? Uri.parse(path.dirname(activeFile))
+      ? URI.parse(path.dirname(activeFile))
       : workspace.workspaceFolders[0].uri;
 
-  return Uri.joinPath(currentDir, filename);
+  return URI.joinPath(currentDir, filename);
 }
 
 function findSelectionContent(): FoamSelectionContent | undefined {
@@ -379,13 +382,13 @@ export function determineDefaultFilepath(
   resolvedValues: Map<string, string>,
   templateMetadata: Map<string, string>
 ) {
-  let defaultFilepath: Uri;
+  let defaultFilepath: URI;
   if (templateMetadata.get('filepath')) {
     const filepathFromMetadata = templateMetadata.get('filepath');
     if (isAbsolute(filepathFromMetadata)) {
-      defaultFilepath = Uri.file(filepathFromMetadata);
+      defaultFilepath = URI.file(filepathFromMetadata);
     } else {
-      defaultFilepath = Uri.joinPath(
+      defaultFilepath = URI.joinPath(
         workspace.workspaceFolders[0].uri,
         filepathFromMetadata
       );
@@ -399,8 +402,10 @@ export function determineDefaultFilepath(
 
 async function createNoteFromDefaultTemplate(): Promise<void> {
   const templateUri = defaultTemplateUri;
-  const templateText = existsSync(templateUri.fsPath)
-    ? await workspace.fs.readFile(templateUri).then(bytes => bytes.toString())
+  const templateText = existsSync(URI.toFsPath(templateUri))
+    ? await workspace.fs
+        .readFile(toVsCodeUri(templateUri))
+        .then(bytes => bytes.toString())
     : defaultTemplateDefaultText;
 
   const selectedContent = findSelectionContent();
@@ -437,7 +442,7 @@ async function createNoteFromDefaultTemplate(): Promise<void> {
   const defaultFilename = path.basename(defaultFilepath.path);
 
   let filepath = defaultFilepath;
-  if (existsSync(filepath.fsPath)) {
+  if (existsSync(URI.toFsPath(filepath))) {
     const newFilepath = await askUserForFilepathConfirmation(
       defaultFilepath,
       defaultFilename
@@ -446,7 +451,7 @@ async function createNoteFromDefaultTemplate(): Promise<void> {
     if (newFilepath === undefined) {
       return;
     }
-    filepath = Uri.file(newFilepath);
+    filepath = URI.file(newFilepath);
   }
 
   await writeTemplate(
@@ -474,9 +479,9 @@ async function createNoteFromTemplate(
   templateFilename =
     (selectedTemplate as QuickPickItem).description ||
     (selectedTemplate as QuickPickItem).label;
-  const templateUri = Uri.joinPath(templatesDir, templateFilename);
+  const templateUri = URI.joinPath(templatesDir, templateFilename);
   const templateText = await workspace.fs
-    .readFile(templateUri)
+    .readFile(toVsCodeUri(templateUri))
     .then(bytes => bytes.toString());
 
   const selectedContent = findSelectionContent();
@@ -519,7 +524,7 @@ async function createNoteFromTemplate(
   if (filepath === undefined) {
     return;
   }
-  const filepathURI = Uri.file(filepath);
+  const filepathURI = URI.file(filepath);
 
   await writeTemplate(
     templateSnippet,
@@ -538,13 +543,13 @@ async function createNoteFromTemplate(
 
 async function createNewTemplate(): Promise<void> {
   const defaultFilename = 'new-template.md';
-  const defaultTemplate = Uri.joinPath(templatesDir, defaultFilename);
+  const defaultTemplate = URI.joinPath(templatesDir, defaultFilename);
   const filename = await window.showInputBox({
     prompt: `Enter the filename for the new template`,
-    value: defaultTemplate.fsPath,
+    value: URI.toFsPath(defaultTemplate),
     valueSelection: [
-      defaultTemplate.fsPath.length - defaultFilename.length,
-      defaultTemplate.fsPath.length - 3,
+      URI.toFsPath(defaultTemplate).length - defaultFilename.length,
+      URI.toFsPath(defaultTemplate).length - 3,
     ],
     validateInput: value =>
       value.trim().length === 0
@@ -557,9 +562,9 @@ async function createNewTemplate(): Promise<void> {
     return;
   }
 
-  const filenameURI = Uri.file(filename);
+  const filenameURI = URI.file(filename);
   await workspace.fs.writeFile(
-    filenameURI,
+    toVsCodeUri(filenameURI),
     new TextEncoder().encode(templateContent)
   );
   await focusNote(filenameURI, false);


### PR DESCRIPTION
### What are you trying to accomplish?

Foam uses its own `URI` object, which is similar to VSCode's `Uri` object.
See https://github.com/foambubble/foam/pull/537 for the reasoning.

This PR changes `create-from-template` to use Foam's `URI` instead of VSCode's `Uri`.

### What approach did you choose and why?

1. Basic rename `Uri` -> `URI`
2. Corrected all the compiler failures
    * `.fsPath` -> `URI.toFsPath`
    * Use `toVsCodeUri` when calling VSCode APIs that care. 

### What should reviewers focus on?
<!--
Outline anything you'd like reviewers to pay extra attention to. List open questions for discussion.
-->

...

### The impact of these changes

No impact on functionality. It will make my changes in https://github.com/foambubble/foam/pull/700 a bit cleaner.

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

### Checklist
- [x] I have manually tested this change. 
- [x] This PR is safe to roll back.
