### PR TITLE
Allows wikilinks to be opened in the editor again

### DIFF
--- a/packages/foam-vscode/src/features/preview-navigation.spec.ts
+++ b/packages/foam-vscode/src/features/preview-navigation.spec.ts
@@ -19,7 +19,7 @@ describe('Link generation in preview', () => {
     expect(md.render(`[[note-a]]`)).toEqual(
       `<p><a class='foam-note-link' title='${noteA.title}' href='${URI.toFsPath(
         noteA.uri
-      )}'>note-a</a></p>\n`
+      )}' data-href='${URI.toFsPath(noteA.uri)}'>note-a</a></p>\n`
     );
   });
 

--- a/packages/foam-vscode/src/features/preview-navigation.ts
+++ b/packages/foam-vscode/src/features/preview-navigation.ts
@@ -50,7 +50,9 @@ export const markdownItWithFoamLinks = (
 
         return `<a class='foam-note-link' title='${
           resource.title
-        }' href='${URI.toFsPath(resource.uri)}'>${linkLabel}</a>`;
+        }' href='${URI.toFsPath(resource.uri)}' data-href='${URI.toFsPath(
+          resource.uri
+        )}'>${linkLabel}</a>`;
       } catch (e) {
         Logger.error(
           `Error while creating link for [[${wikilink}]] in Preview panel`,


### PR DESCRIPTION
Solves #648 by adding a data-href attribute to the link. The combination of this attribute and an absolute link will do the trick for correct behaviour. Found the solution in this issue: https://github.com/microsoft/vscode/issues/126402