### PR TITLE
Remove Markdown Notes from recommended extensions

### DIFF
--- a/docs/.vscode/extensions.json
+++ b/docs/.vscode/extensions.json
@@ -14,9 +14,6 @@
     // Tons of markdown goodies (lists, tables of content, so much more)
     "yzhang.markdown-all-in-one",
 
-    // [[wiki-links]], backlinking etc
-    "kortina.vscode-markdown-notes",
-
     // Graph visualizer
     "tchayen.markdown-links",
 


### PR DESCRIPTION
No longer recommend [Markdown Notes](https://marketplace.visualstudio.com/items?itemName=kortina.vscode-markdown-notes) to users when they are developing Foam.

Ref: https://github.com/foambubble/foam/pull/716#discussion_r671295216

cc @pderaaij 