### PR TITLE
bugfix/705: replacing Indexable Types with Map

### DIFF
--- a/packages/foam-core/src/model/graph.ts
+++ b/packages/foam-core/src/model/graph.ts
@@ -202,7 +202,7 @@ export class FoamGraph implements IDisposable {
       target.path,
       this.backlinks.get(target.path)?.filter(connectionsToKeep) ?? []
     );
-    if ((this.backlinks.get(target.path) as Connection[]).length === 0) {
+    if (this.backlinks.get(target.path)?.length === 0) {
       this.backlinks.delete(target.path);
       if (URI.isPlaceholder(target)) {
         delete this.placeholders[uriToPlaceholderId(target)];

--- a/packages/foam-core/src/model/tags.ts
+++ b/packages/foam-core/src/model/tags.ts
@@ -24,9 +24,9 @@ export class FoamTags implements IDisposable {
   ): FoamTags {
     let tags = new FoamTags();
 
-    Object.values(workspace.list()).forEach(resource =>
-      tags.addResourceFromTagIndex(resource)
-    );
+    workspace
+      .list()
+      .forEach(resource => tags.addResourceFromTagIndex(resource));
 
     if (keepMonitoring) {
       tags.disposables.push(

--- a/packages/foam-core/test/workspace.test.ts
+++ b/packages/foam-core/test/workspace.test.ts
@@ -64,6 +64,13 @@ describe('Workspace resources', () => {
     expect(ws.find(uri)).toBeNull();
     expect(() => ws.get(uri)).toThrow();
   });
+
+  it('Should work with a resource named like a JS prototype property', () => {
+    const ws = createTestWorkspace();
+    const noteA = createTestNote({ uri: '/somewhere/constructor.md' });
+    ws.set(noteA);
+    expect(ws.list()).toEqual([noteA]);
+  });
 });
 
 describe('Graph', () => {
@@ -517,6 +524,23 @@ describe('Placeholders', () => {
       target: URI.placeholder('/path/to/page-c.md'),
       link: expect.objectContaining({ type: 'wikilink' }),
     });
+  });
+
+  it('Should work with a placeholder named like a JS prototype property', () => {
+    const ws = createTestWorkspace();
+    const noteA = createTestNote({
+      uri: '/page-a.md',
+      links: [{ slug: 'constructor' }],
+    });
+    ws.set(noteA);
+    const graph = FoamGraph.fromWorkspace(ws);
+
+    expect(
+      graph
+        .getAllNodes()
+        .map(uri => uri.path)
+        .sort()
+    ).toEqual(['/page-a.md', 'constructor']);
   });
 });
 

--- a/packages/foam-vscode/src/features/link-completion.ts
+++ b/packages/foam-vscode/src/features/link-completion.ts
@@ -52,12 +52,14 @@ export class CompletionProvider
       return item;
     });
 
-    const placeholders = Object.values(this.graph.placeholders).map(uri => {
-      return new vscode.CompletionItem(
-        uri.path,
-        vscode.CompletionItemKind.Interface
-      );
-    });
+    const placeholders = Array.from(this.graph.placeholders.values()).map(
+      uri => {
+        return new vscode.CompletionItem(
+          uri.path,
+          vscode.CompletionItemKind.Interface
+        );
+      }
+    );
 
     return new vscode.CompletionList([...resources, ...placeholders]);
   }


### PR DESCRIPTION
Resolve #705

By using an `Indexable Types` like :
```typescript
  public readonly backlinks: { [key: string]: Connection[] } = {};
```
The checks like this don't work if the `key` has the same name as a prototype method
```typescript
this.backlinks[target.path] = this.backlinks[target.path] ?? [];
```
I think the object `this.backlinks` is assign to a function.

One solution is to replace the `Indexable Types` by a `Map`.
After manual checks it work by replacing by a `Map` the two flowing attributes:
  - `public readonly backlinks` of `class FoamGraph`.
  - `private resourcesByName` of `class FoamWorkspace`.
  
I've written a test to catch the bug, but I can't make it work for all the cases.