### PR TITLE
Respect the ignore globs when listing all files

### DIFF
--- a/packages/foam-core/src/markdown-provider.ts
+++ b/packages/foam-core/src/markdown-provider.ts
@@ -59,7 +59,9 @@ export class MarkdownResourceProvider implements ResourceProvider {
 
   async init(workspace: FoamWorkspace) {
     const filesByFolder = await Promise.all(
-      this.matcher.include.map(glob => this.dataStore.list(glob))
+      this.matcher.include.map(glob =>
+        this.dataStore.list(glob, this.matcher.exclude)
+      )
     );
     const files = this.matcher
       .match(filesByFolder.flat())

--- a/packages/foam-core/src/services/datastore.ts
+++ b/packages/foam-core/src/services/datastore.ts
@@ -100,7 +100,7 @@ export interface IDataStore {
    * List the files matching the given glob from the
    * store
    */
-  list: (glob: string) => Promise<URI[]>;
+  list: (glob: string, ignoreGlob?: string | string[]) => Promise<URI[]>;
 
   /**
    * Read the content of the file from the store
@@ -114,8 +114,10 @@ export interface IDataStore {
  * File system based data store
  */
 export class FileDataStore implements IDataStore {
-  async list(glob: string): Promise<URI[]> {
-    const res = await findAllFiles(glob);
+  async list(glob: string, ignoreGlob?: string | string[]): Promise<URI[]> {
+    const res = await findAllFiles(glob, {
+      ignore: ignoreGlob,
+    });
     return res.map(URI.file);
   }
 


### PR DESCRIPTION
This change ensures Foam respects the ignored folders when calling the datastore. It utilises the ignore option of the `glob` module.

Note, to properly ignore my `node_modules` folder in `layouts` I need to configure the ignore glob into: `"**/_layouts/**"`. I do not use `/*` at the end as that will cause it to traverse the entire node_modules folder.