### PR TITLE
Tags improvements

### DIFF
--- a/packages/foam-core/src/index.ts
+++ b/packages/foam-core/src/index.ts
@@ -3,6 +3,7 @@ import {
   ResourceLink,
   NoteLinkDefinition,
   ResourceParser,
+  Tag,
 } from './model/note';
 import { FoamConfig } from './config';
 import {
@@ -54,6 +55,7 @@ export {
   Resource,
   ResourceLink,
   URI,
+  Tag,
   FoamWorkspace,
   FoamGraph,
   FoamTags,

--- a/packages/foam-core/src/markdown-provider.ts
+++ b/packages/foam-core/src/markdown-provider.ts
@@ -40,7 +40,7 @@ export interface ParserPlugin {
   onWillParseMarkdown?: (markdown: string) => string;
   onWillVisitTree?: (tree: Node, note: Resource) => void;
   onDidVisitTree?: (tree: Node, note: Resource) => void;
-  onDidFindProperties?: (properties: any, note: Resource) => void;
+  onDidFindProperties?: (properties: any, note: Resource, node: Node) => void;
 }
 
 export class MarkdownResourceProvider implements ResourceProvider {
@@ -171,16 +171,32 @@ const getTextFromChildren = (root: Node): string => {
 
 const tagsPlugin: ParserPlugin = {
   name: 'tags',
-  onDidFindProperties: (props, note) => {
-    const yamlTags = extractTagsFromProp(props.tags);
-    yamlTags.forEach(tag => note.tags.add(tag));
+  onDidFindProperties: (props, note, node) => {
+    if (isSome(props.tags)) {
+      const yamlTags = extractTagsFromProp(props.tags);
+      yamlTags.forEach(t => {
+        note.tags.push({
+          label: t,
+          range: astPositionToFoamRange(node.position!),
+        });
+      });
+    }
   },
   visit: (node, note) => {
     if (node.type === 'text') {
       const tags = extractHashtags((node as any).value);
-      if (tags.size > 0) {
-        tags.forEach(tag => note.tags.add(tag));
-      }
+      tags.forEach(tag => {
+        let start = astPointToFoamPosition(node.position!.start);
+        start.character = start.character + tag.offset;
+        const end: Position = {
+          line: start.line,
+          character: start.character + tag.label.length + 1,
+        };
+        note.tags.push({
+          label: tag.label,
+          range: Range.createFromPosition(start, end),
+        });
+      });
     }
   },
 };
@@ -322,7 +338,7 @@ export function createMarkdownParser(
         type: 'note',
         properties: {},
         title: '',
-        tags: new Set(),
+        tags: [],
         links: [],
         definitions: [],
         source: {
@@ -356,7 +372,7 @@ export function createMarkdownParser(
 
             for (let i = 0, len = plugins.length; i < len; i++) {
               try {
-                plugins[i].onDidFindProperties?.(yamlProperties, note);
+                plugins[i].onDidFindProperties?.(yamlProperties, note, node);
               } catch (e) {
                 handleError(plugins[i], 'onDidFindProperties', uri, e);
               }

--- a/packages/foam-core/src/markdown-provider.ts
+++ b/packages/foam-core/src/markdown-provider.ts
@@ -171,12 +171,17 @@ const getTextFromChildren = (root: Node): string => {
 
 const tagsPlugin: ParserPlugin = {
   name: 'tags',
-  onWillVisitTree: (tree, note) => {
-    note.tags = extractHashtags(note.source.text);
-  },
   onDidFindProperties: (props, note) => {
     const yamlTags = extractTagsFromProp(props.tags);
     yamlTags.forEach(tag => note.tags.add(tag));
+  },
+  visit: (node, note) => {
+    if (node.type === 'text') {
+      const tags = extractHashtags((node as any).value);
+      if (tags.size > 0) {
+        tags.forEach(tag => note.tags.add(tag));
+      }
+    }
   },
 };
 

--- a/packages/foam-core/src/model/note.ts
+++ b/packages/foam-core/src/model/note.ts
@@ -33,13 +33,18 @@ export interface NoteLinkDefinition {
   range?: Range;
 }
 
+export interface Tag {
+  label: string;
+  range: Range;
+}
+
 export interface Resource {
   uri: URI;
   type: string;
   title: string;
   properties: any;
   // sections: NoteSection[]
-  tags: Set<string>;
+  tags: Tag[];
   links: ResourceLink[];
 
   // TODO to remove

--- a/packages/foam-core/src/utils/hashtags.ts
+++ b/packages/foam-core/src/utils/hashtags.ts
@@ -1,16 +1,21 @@
 import { isSome } from './core';
-const HASHTAG_REGEX = /(^|\s)#([0-9]*[\p{L}/_-][\p{L}\p{N}/_-]*)/gmu;
-const WORD_REGEX = /(^|\s)([0-9]*[\p{L}/_-][\p{L}\p{N}/_-]*)/gmu;
+const HASHTAG_REGEX = /(?<=^|\s)#([0-9]*[\p{L}/_-][\p{L}\p{N}/_-]*)/gmu;
+const WORD_REGEX = /(?<=^|\s)([0-9]*[\p{L}/_-][\p{L}\p{N}/_-]*)/gmu;
 
-export const extractHashtags = (text: string): Set<string> => {
+export const extractHashtags = (
+  text: string
+): Array<{ label: string; offset: number }> => {
   return isSome(text)
-    ? new Set(Array.from(text.matchAll(HASHTAG_REGEX), m => m[2].trim()))
-    : new Set();
+    ? Array.from(text.matchAll(HASHTAG_REGEX)).map(m => ({
+        label: m[1],
+        offset: m.index!,
+      }))
+    : [];
 };
 
-export const extractTagsFromProp = (prop: string | string[]): Set<string> => {
+export const extractTagsFromProp = (prop: string | string[]): string[] => {
   const text = Array.isArray(prop) ? prop.join(' ') : prop;
   return isSome(text)
-    ? new Set(Array.from(text.matchAll(WORD_REGEX)).map(m => m[2].trim()))
-    : new Set();
+    ? Array.from(text.matchAll(WORD_REGEX)).map(m => m[1])
+    : [];
 };

--- a/packages/foam-core/test/core.test.ts
+++ b/packages/foam-core/test/core.test.ts
@@ -56,7 +56,11 @@ export const createTestNote = (params: {
     properties: {},
     title: params.title ?? path.parse(strToUri(params.uri).path).base,
     definitions: params.definitions ?? [],
-    tags: new Set(params.tags) ?? new Set(),
+    tags:
+      params.tags?.map(t => ({
+        label: t,
+        range: Range.create(0, 0, 0, 0),
+      })) ?? [],
     links: params.links
       ? params.links.map((link, index) => {
           const range = Range.create(

--- a/packages/foam-core/test/markdown-provider.test.ts
+++ b/packages/foam-core/test/markdown-provider.test.ts
@@ -148,6 +148,42 @@ this is a [link to intro](#introduction)
     expect(link.label).toEqual('spaced');
     expect(link.target).toEqual('other link');
   });
+
+  it('Skips wikilinks in codeblocks', () => {
+    const noteA = createNoteFromMarkdown(
+      '/dir1/page-a.md',
+      `
+this is some text with our [[first-wikilink]].
+
+\`\`\`
+this is inside a [[codeblock]]
+\`\`\`
+
+this is some text with our [[second-wikilink]].
+    `
+    );
+    expect(noteA.links.map(l => l.label)).toEqual([
+      'first-wikilink',
+      'second-wikilink',
+    ]);
+  });
+
+  it('Skips wikilinks in inlined codeblocks', () => {
+    const noteA = createNoteFromMarkdown(
+      '/dir1/page-a.md',
+      `
+this is some text with our [[first-wikilink]].
+
+this is \`inside a [[codeblock]]\`
+
+this is some text with our [[second-wikilink]].
+    `
+    );
+    expect(noteA.links.map(l => l.label)).toEqual([
+      'first-wikilink',
+      'second-wikilink',
+    ]);
+  });
 });
 
 describe('Note Title', () => {
@@ -316,13 +352,39 @@ describe('tags plugin', () => {
     const noteA = createNoteFromMarkdown(
       '/dir1/page-a.md',
       `
-# this is a heading
+# this is a #heading
 this is some #text that includes #tags we #care-about.
+    `
+    );
+    expect(noteA.tags).toEqual(
+      new Set(['heading', 'text', 'tags', 'care-about'])
+    );
+  });
+
+  it('will skip tags in codeblocks', () => {
+    const noteA = createNoteFromMarkdown(
+      '/dir1/page-a.md',
+      `
+this is some #text that includes #tags we #care-about.
+
+\`\`\`
+this is a #codeblock
+\`\`\`
     `
     );
     expect(noteA.tags).toEqual(new Set(['text', 'tags', 'care-about']));
   });
 
+  it('will skip tags in inlined codeblocks', () => {
+    const noteA = createNoteFromMarkdown(
+      '/dir1/page-a.md',
+      `
+this is some #text that includes #tags we #care-about.
+this is a \`inlined #codeblock\`
+    `
+    );
+    expect(noteA.tags).toEqual(new Set(['text', 'tags', 'care-about']));
+  });
   it('can find tags as text in yaml', () => {
     const noteA = createNoteFromMarkdown(
       '/dir1/page-a.md',

--- a/packages/foam-core/test/markdown-provider.test.ts
+++ b/packages/foam-core/test/markdown-provider.test.ts
@@ -9,6 +9,7 @@ import { uriToSlug } from '../src/utils/slug';
 import { URI } from '../src/model/uri';
 import { FoamGraph } from '../src/model/graph';
 import { createTestWorkspace } from './core.test';
+import { Range } from '../src/model/range';
 
 Logger.setLevel('error');
 
@@ -353,12 +354,16 @@ describe('tags plugin', () => {
       '/dir1/page-a.md',
       `
 # this is a #heading
-this is some #text that includes #tags we #care-about.
+#this is some #text that includes #tags we #care-about.
     `
     );
-    expect(noteA.tags).toEqual(
-      new Set(['heading', 'text', 'tags', 'care-about'])
-    );
+    expect(noteA.tags).toEqual([
+      { label: 'heading', range: Range.create(1, 12, 1, 20) },
+      { label: 'this', range: Range.create(2, 0, 2, 5) },
+      { label: 'text', range: Range.create(2, 14, 2, 19) },
+      { label: 'tags', range: Range.create(2, 34, 2, 39) },
+      { label: 'care-about', range: Range.create(2, 43, 2, 54) },
+    ]);
   });
 
   it('will skip tags in codeblocks', () => {
@@ -372,7 +377,11 @@ this is a #codeblock
 \`\`\`
     `
     );
-    expect(noteA.tags).toEqual(new Set(['text', 'tags', 'care-about']));
+    expect(noteA.tags.map(t => t.label)).toEqual([
+      'text',
+      'tags',
+      'care-about',
+    ]);
   });
 
   it('will skip tags in inlined codeblocks', () => {
@@ -383,7 +392,11 @@ this is some #text that includes #tags we #care-about.
 this is a \`inlined #codeblock\`
     `
     );
-    expect(noteA.tags).toEqual(new Set(['text', 'tags', 'care-about']));
+    expect(noteA.tags.map(t => t.label)).toEqual([
+      'text',
+      'tags',
+      'care-about',
+    ]);
   });
   it('can find tags as text in yaml', () => {
     const noteA = createNoteFromMarkdown(
@@ -396,9 +409,14 @@ tags: hello, world  this_is_good
 this is some #text that includes #tags we #care-about.
     `
     );
-    expect(noteA.tags).toEqual(
-      new Set(['text', 'tags', 'care-about', 'hello', 'world', 'this_is_good'])
-    );
+    expect(noteA.tags.map(t => t.label)).toEqual([
+      'hello',
+      'world',
+      'this_is_good',
+      'text',
+      'tags',
+      'care-about',
+    ]);
   });
 
   it('can find tags as array in yaml', () => {
@@ -412,9 +430,34 @@ tags: [hello, world,  this_is_good]
 this is some #text that includes #tags we #care-about.
     `
     );
-    expect(noteA.tags).toEqual(
-      new Set(['text', 'tags', 'care-about', 'hello', 'world', 'this_is_good'])
+    expect(noteA.tags.map(t => t.label)).toEqual([
+      'hello',
+      'world',
+      'this_is_good',
+      'text',
+      'tags',
+      'care-about',
+    ]);
+  });
+
+  it('provides rough range for tags in yaml', () => {
+    // For now it's enough to just get the YAML block range
+    // in the future we might want to be more specific
+
+    const noteA = createNoteFromMarkdown(
+      '/dir1/page-a.md',
+      `
+---
+tags: [hello, world, this_is_good]
+---
+# this is a heading
+this is some text
+    `
     );
+    expect(noteA.tags[0]).toEqual({
+      label: 'hello',
+      range: Range.create(1, 0, 3, 3),
+    });
   });
 });
 

--- a/packages/foam-core/test/tags.test.ts
+++ b/packages/foam-core/test/tags.test.ts
@@ -26,9 +26,9 @@ describe('FoamTags', () => {
 
     expect(tags.tags).toEqual(
       new Map([
-        ['primary', [{ uri: pageA.uri }, { uri: pageB.uri }]],
-        ['secondary', [{ uri: pageA.uri }]],
-        ['third', [{ uri: pageB.uri }]],
+        ['primary', [pageA.uri, pageB.uri]],
+        ['secondary', [pageA.uri]],
+        ['third', [pageB.uri]],
       ])
     );
   });
@@ -51,7 +51,7 @@ describe('FoamTags', () => {
     ws.set(taglessPage);
 
     const tags = FoamTags.fromWorkspace(ws);
-    expect(tags.tags).toEqual(new Map([['primary', [{ uri: page.uri }]]]));
+    expect(tags.tags).toEqual(new Map([['primary', [page.uri]]]));
 
     const newPage = createTestNote({
       uri: '/page-b.md',
@@ -61,9 +61,7 @@ describe('FoamTags', () => {
 
     tags.updateResourceWithinTagIndex(taglessPage, newPage);
 
-    expect(tags.tags).toEqual(
-      new Map([['primary', [{ uri: page.uri }, { uri: newPage.uri }]]])
-    );
+    expect(tags.tags).toEqual(new Map([['primary', [page.uri, newPage.uri]]]));
   });
 
   it('Replaces the tag when a note is updated with an altered tag', () => {
@@ -79,7 +77,7 @@ describe('FoamTags', () => {
     ws.set(page);
 
     const tags = FoamTags.fromWorkspace(ws);
-    expect(tags.tags).toEqual(new Map([['primary', [{ uri: page.uri }]]]));
+    expect(tags.tags).toEqual(new Map([['primary', [page.uri]]]));
 
     const pageEdited = createTestNote({
       uri: '/page-a.md',
@@ -90,7 +88,7 @@ describe('FoamTags', () => {
 
     tags.updateResourceWithinTagIndex(page, pageEdited);
 
-    expect(tags.tags).toEqual(new Map([['new', [{ uri: page.uri }]]]));
+    expect(tags.tags).toEqual(new Map([['new', [page.uri]]]));
   });
 
   it('Updates the metadata of a tag when the note is moved', () => {
@@ -105,7 +103,7 @@ describe('FoamTags', () => {
     ws.set(page);
 
     const tags = FoamTags.fromWorkspace(ws);
-    expect(tags.tags).toEqual(new Map([['primary', [{ uri: page.uri }]]]));
+    expect(tags.tags).toEqual(new Map([['primary', [page.uri]]]));
 
     const pageEdited = createTestNote({
       uri: '/new-place/page-a.md',
@@ -116,9 +114,7 @@ describe('FoamTags', () => {
 
     tags.updateResourceWithinTagIndex(page, pageEdited);
 
-    expect(tags.tags).toEqual(
-      new Map([['primary', [{ uri: pageEdited.uri }]]])
-    );
+    expect(tags.tags).toEqual(new Map([['primary', [pageEdited.uri]]]));
   });
 
   it('Updates the metadata of a tag when a note is delete', () => {
@@ -133,7 +129,7 @@ describe('FoamTags', () => {
     ws.set(page);
 
     const tags = FoamTags.fromWorkspace(ws);
-    expect(tags.tags).toEqual(new Map([['primary', [{ uri: page.uri }]]]));
+    expect(tags.tags).toEqual(new Map([['primary', [page.uri]]]));
 
     tags.removeResourceFromTagIndex(page);
 

--- a/packages/foam-core/test/utils.test.ts
+++ b/packages/foam-core/test/utils.test.ts
@@ -4,40 +4,55 @@ import { Logger } from '../src/utils/log';
 Logger.setLevel('error');
 
 describe('hashtag extraction', () => {
+  it('returns empty list if no tags are present', () => {
+    expect(extractHashtags('hello world')).toEqual([]);
+  });
   it('works with simple strings', () => {
-    expect(extractHashtags('hello #world on #this planet')).toEqual(
-      new Set(['world', 'this'])
-    );
+    expect(
+      extractHashtags('hello #world on #this planet').map(t => t.label)
+    ).toEqual(['world', 'this']);
+  });
+  it('detects the offset of the tag', () => {
+    expect(extractHashtags('#hello')).toEqual([{ label: 'hello', offset: 0 }]);
+    expect(extractHashtags(' #hello')).toEqual([{ label: 'hello', offset: 1 }]);
+    expect(extractHashtags('to #hello')).toEqual([
+      { label: 'hello', offset: 3 },
+    ]);
   });
   it('works with tags at beginning or end of text', () => {
-    expect(extractHashtags('#hello world on this #planet')).toEqual(
-      new Set(['hello', 'planet'])
-    );
+    expect(
+      extractHashtags('#hello world on this #planet').map(t => t.label)
+    ).toEqual(['hello', 'planet']);
   });
   it('supports _ and -', () => {
-    expect(extractHashtags('#hello-world on #this_planet')).toEqual(
-      new Set(['hello-world', 'this_planet'])
-    );
+    expect(
+      extractHashtags('#hello-world on #this_planet').map(t => t.label)
+    ).toEqual(['hello-world', 'this_planet']);
   });
   it('supports nested tags', () => {
-    expect(extractHashtags('#parent/child on #planet')).toEqual(
-      new Set(['parent/child', 'planet'])
-    );
+    expect(
+      extractHashtags('#parent/child on #planet').map(t => t.label)
+    ).toEqual(['parent/child', 'planet']);
   });
   it('ignores tags that only have numbers in text', () => {
     expect(
-      extractHashtags('this #123 tag should be ignore, but not #123four')
-    ).toEqual(new Set(['123four']));
+      extractHashtags('this #123 tag should be ignore, but not #123four').map(
+        t => t.label
+      )
+    ).toEqual(['123four']);
   });
   it('supports unicode letters like Chinese charaters', () => {
     expect(
       extractHashtags(`
         this #tag_with_unicode_letters_汉字, pure Chinese tag like #纯中文标签 and 
         other mixed tags like #标签1 #123四 should work
-      `)
-    ).toEqual(
-      new Set(['tag_with_unicode_letters_汉字', '纯中文标签', '标签1', '123四'])
-    );
+      `).map(t => t.label)
+    ).toEqual([
+      'tag_with_unicode_letters_汉字',
+      '纯中文标签',
+      '标签1',
+      '123四',
+    ]);
   });
 
   it('ignores hashes in plain text urls and links', () => {
@@ -47,8 +62,8 @@ describe('hashtag extraction', () => {
         https://site.com/home/#section3a
         [link](https://site.com/#section4) with [link2](https://site.com/home#section5) #control
         hello world
-      `)
-    ).toEqual(new Set(['control']));
+      `).map(t => t.label)
+    ).toEqual(['control']);
   });
 
   it('ignores hashes in links to sections', () => {
@@ -57,6 +72,6 @@ describe('hashtag extraction', () => {
       this is a wikilink to [[#section1]] in the file and a [[link#section2]] in another
       this is a [link](#section3) to a section
       `)
-    ).toEqual(new Set());
+    ).toEqual([]);
   });
 });

--- a/packages/foam-vscode/src/features/create-from-template.ts
+++ b/packages/foam-vscode/src/features/create-from-template.ts
@@ -43,7 +43,7 @@ interface FoamSelectionContent {
 
 const knownFoamVariables = new Set(['FOAM_TITLE', 'FOAM_SELECTED_TEXT']);
 
-const wikilinkDefaultTemplateText = `# $\{1:\$FOAM_TITLE}\n\n$0`;
+const wikilinkDefaultTemplateText = `# $\{1:$FOAM_TITLE}\n\n$0`;
 const defaultTemplateDefaultText: string = `---
 foam_template:
   name: New Note

--- a/packages/foam-vscode/src/features/tag-completion.spec.ts
+++ b/packages/foam-vscode/src/features/tag-completion.spec.ts
@@ -16,14 +16,14 @@ describe('Tag Completion', () => {
     createTestNote({
       root,
       uri: 'file-name.md',
-      tags: new Set(['primary']),
+      tags: ['primary'],
     })
   )
     .set(
       createTestNote({
         root,
         uri: 'File name with spaces.md',
-        tags: new Set(['secondary']),
+        tags: ['secondary'],
       })
     )
     .set(
@@ -31,7 +31,7 @@ describe('Tag Completion', () => {
         root,
         uri: 'path/to/file.md',
         links: [{ slug: 'placeholder text' }],
-        tags: new Set(['primary', 'third']),
+        tags: ['primary', 'third'],
       })
     );
   const foamTags = FoamTags.fromWorkspace(ws);

--- a/packages/foam-vscode/src/features/tags-tree-view/index.spec.ts
+++ b/packages/foam-vscode/src/features/tags-tree-view/index.spec.ts
@@ -4,7 +4,7 @@ import {
   createTestNote,
 } from '../../test/test-utils';
 
-import { Tag, TagReference, TagsProvider } from '.';
+import { TagItem, TagReference, TagsProvider } from '.';
 
 import {
   bootstrap,
@@ -50,33 +50,35 @@ describe('Tags tree panel', () => {
 
   it('correctly provides a tag from a set of notes', async () => {
     const noteA = createTestNote({
-      tags: new Set(['test']),
+      tags: ['test'],
       uri: './note-a.md',
     });
     _foam.workspace.set(noteA);
     provider.refresh();
 
-    const treeItems = (await provider.getChildren()) as Tag[];
+    const treeItems = (await provider.getChildren()) as TagItem[];
 
     treeItems.map(item => expect(item.tag).toContain('test'));
   });
 
   it('correctly handles a parent and child tag', async () => {
     const noteA = createTestNote({
-      tags: new Set(['parent/child']),
+      tags: ['parent/child'],
       uri: './note-a.md',
     });
     _foam.workspace.set(noteA);
     provider.refresh();
 
-    const parentTreeItems = (await provider.getChildren()) as Tag[];
+    const parentTreeItems = (await provider.getChildren()) as TagItem[];
     const parentTagItem = parentTreeItems.pop();
     expect(parentTagItem.title).toEqual('parent');
 
-    const childTreeItems = (await provider.getChildren(parentTagItem)) as Tag[];
+    const childTreeItems = (await provider.getChildren(
+      parentTagItem
+    )) as TagItem[];
 
     childTreeItems.forEach(child => {
-      if (child instanceof Tag) {
+      if (child instanceof TagItem) {
         expect(child.title).toEqual('child');
       }
     });
@@ -84,29 +86,31 @@ describe('Tags tree panel', () => {
 
   it('correctly handles a single parent and multiple child tag', async () => {
     const noteA = createTestNote({
-      tags: new Set(['parent/child']),
+      tags: ['parent/child'],
       uri: './note-a.md',
     });
     _foam.workspace.set(noteA);
     const noteB = createTestNote({
-      tags: new Set(['parent/subchild']),
+      tags: ['parent/subchild'],
       uri: './note-b.md',
     });
     _foam.workspace.set(noteB);
     provider.refresh();
 
-    const parentTreeItems = (await provider.getChildren()) as Tag[];
+    const parentTreeItems = (await provider.getChildren()) as TagItem[];
     const parentTagItem = parentTreeItems.filter(
-      item => item instanceof Tag
+      item => item instanceof TagItem
     )[0];
 
     expect(parentTagItem.title).toEqual('parent');
     expect(parentTreeItems).toHaveLength(1);
 
-    const childTreeItems = (await provider.getChildren(parentTagItem)) as Tag[];
+    const childTreeItems = (await provider.getChildren(
+      parentTagItem
+    )) as TagItem[];
 
     childTreeItems.forEach(child => {
-      if (child instanceof Tag) {
+      if (child instanceof TagItem) {
         expect(['child', 'subchild']).toContain(child.title);
         expect(child.title).not.toEqual('parent');
       }
@@ -116,7 +120,7 @@ describe('Tags tree panel', () => {
 
   it('correctly handles a single parent and child tag in the same note', async () => {
     const noteC = createTestNote({
-      tags: new Set(['main', 'main/subtopic']),
+      tags: ['main', 'main/subtopic'],
       title: 'Test note',
       uri: './note-c.md',
     });
@@ -125,14 +129,16 @@ describe('Tags tree panel', () => {
 
     provider.refresh();
 
-    const parentTreeItems = (await provider.getChildren()) as Tag[];
+    const parentTreeItems = (await provider.getChildren()) as TagItem[];
     const parentTagItem = parentTreeItems.filter(
-      item => item instanceof Tag
+      item => item instanceof TagItem
     )[0];
 
     expect(parentTagItem.title).toEqual('main');
 
-    const childTreeItems = (await provider.getChildren(parentTagItem)) as Tag[];
+    const childTreeItems = (await provider.getChildren(
+      parentTagItem
+    )) as TagItem[];
 
     childTreeItems
       .filter(item => item instanceof TagReference)
@@ -141,7 +147,7 @@ describe('Tags tree panel', () => {
       });
 
     childTreeItems
-      .filter(item => item instanceof Tag)
+      .filter(item => item instanceof TagItem)
       .forEach(item => {
         expect(['main/subtopic']).toContain(item.tag);
         expect(item.title).toEqual('subtopic');

--- a/packages/foam-vscode/src/test/test-utils.ts
+++ b/packages/foam-vscode/src/test/test-utils.ts
@@ -47,7 +47,7 @@ export const createTestNote = (params: {
   title?: string;
   definitions?: NoteLinkDefinition[];
   links?: Array<{ slug: string } | { to: string }>;
-  tags?: Set<string>;
+  tags?: string[];
   text?: string;
   root?: URI;
 }): Resource => {
@@ -58,7 +58,11 @@ export const createTestNote = (params: {
     properties: {},
     title: params.title ?? path.parse(strToUri(params.uri).path).base,
     definitions: params.definitions ?? [],
-    tags: params.tags ?? new Set(),
+    tags:
+      params.tags?.map(t => ({
+        label: t,
+        range: Range.create(0, 0, 0, 0),
+      })) ?? [],
     links: params.links
       ? params.links.map((link, index) => {
           const range = Range.create(


### PR DESCRIPTION
The main goal of this PR is to align the `tags` property with the rest of the `Resource`/`Wikilink` model.

Currently no change has been made to the features (PR is focused on the refactoring itself), but this allows the tag explorer to function more like the backlinks explorer (for future PR).

This also fixes #682 because of the change in how tags are extracted from the note.

cc @pderaaij I have touched some of your code around tags as part of the refactoring.