### PR TITLE
Update recommended extensions based on template

### DIFF
--- a/docs/recommended-extensions.md
+++ b/docs/recommended-extensions.md
@@ -5,9 +5,9 @@ These extensions defined in `.vscode/extensions.json` are automatically installe
 This list is subject to change. Especially the Git ones.
 
 - [Foam for VSCode](https://marketplace.visualstudio.com/items?itemName=foam.foam-vscode) (alpha)
-- [Markdown Notes](https://marketplace.visualstudio.com/items?itemName=kortina.vscode-markdown-notes)
-- [Markdown Links](https://marketplace.visualstudio.com/items?itemName=tchayen.markdown-links)
 - [Markdown All In One](https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one)
+- [Paste Image](https://marketplace.visualstudio.com/items?itemName=mushan.vscode-paste-image)
+- [Spell Right](https://marketplace.visualstudio.com/items?itemName=ban.spellright)
 
 ## Extensions For Additional Features
 


### PR DESCRIPTION
Docs were outdated compared to the extensions on [.vscode/extensions.json](https://github.com/foambubble/foam-template/blob/master/.vscode/extensions.json)

This PR updates the documentation.
