### PR TITLE
Allow custom theming of Foam Links

### DIFF
--- a/docs/recommended-extensions.md
+++ b/docs/recommended-extensions.md
@@ -18,7 +18,7 @@ These extensions are not (yet?) defined in `.vscode/extensions.json`, but have b
 - [Markdown Preview Mermaid Support](https://marketplace.visualstudio.com/items?itemName=bierner.markdown-mermaid)
 - [Mermaid Markdown Syntax Highlighting](https://marketplace.visualstudio.com/items?itemName=bpruitt-goddard.mermaid-markdown-syntax-highlighting)
 - [VSCode PDF Viewing](https://marketplace.visualstudio.com/items?itemName=tomoki1207.pdf)
-- [Git Lens](https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens)
+- [Project Manager](https://marketplace.visualstudio.com/items?itemName=alefragnani.project-manager) (to quickly switch between projects)
 - [Markdown Extended](https://marketplace.visualstudio.com/items?itemName=jebbs.markdown-extended) (with `kbd` option disabled, `kbd` turns wikilinks into non-clickable buttons)
 - [GitDoc](https://marketplace.visualstudio.com/items?itemName=vsls-contrib.gitdoc) (easy version management via git auto commits)
 - [Markdown Footnotes](https://marketplace.visualstudio.com/items?itemName=bierner.markdown-footnotes) (Adds [^footnote] syntax support to VS Code's built-in markdown preview)

--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -355,6 +355,26 @@
         "command": "foam-vscode.open-daily-note",
         "key": "alt+d"
       }
+    ],
+    "colors": [
+      {
+        "id": "foam.link.found",
+        "description": "Color decoration for links.",
+        "defaults": {
+          "dark": "textLink.foreground",
+          "light": "textLink.foreground",
+          "highContrast": "textLink.foreground"
+        }
+      },
+      {
+        "id": "foam.link.placeholder",
+        "description": "Color decoration for placeholder links.",
+        "defaults": {
+          "dark": "editorWarning.foreground",
+          "light": "editorWarning.foreground",
+          "highContrast": "editorWarning.foreground"
+        }
+      }
     ]
   },
   "scripts": {

--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -358,7 +358,7 @@
     ],
     "colors": [
       {
-        "id": "foam.link.found",
+        "id": "foam.link.resource",
         "description": "Color decoration for links.",
         "defaults": {
           "dark": "textLink.foreground",

--- a/packages/foam-vscode/src/features/document-decorator.ts
+++ b/packages/foam-vscode/src/features/document-decorator.ts
@@ -12,14 +12,14 @@ export const CONFIG_KEY = 'decorations.links.enable';
 const linkDecoration = vscode.window.createTextEditorDecorationType({
   rangeBehavior: vscode.DecorationRangeBehavior.ClosedClosed,
   textDecoration: 'none',
-  color: { id: 'textLink.foreground' },
+  color: { id: 'foam.link.found' },
   cursor: 'pointer',
 });
 
 const placeholderDecoration = vscode.window.createTextEditorDecorationType({
   rangeBehavior: vscode.DecorationRangeBehavior.ClosedClosed,
   textDecoration: 'none',
-  color: { id: 'editorWarning.foreground' },
+  color: { id: 'foam.link.placeholder' },
   cursor: 'pointer',
 });
 

--- a/packages/foam-vscode/src/features/document-decorator.ts
+++ b/packages/foam-vscode/src/features/document-decorator.ts
@@ -12,7 +12,7 @@ export const CONFIG_KEY = 'decorations.links.enable';
 const linkDecoration = vscode.window.createTextEditorDecorationType({
   rangeBehavior: vscode.DecorationRangeBehavior.ClosedClosed,
   textDecoration: 'none',
-  color: { id: 'foam.link.found' },
+  color: { id: 'foam.link.resource' },
   cursor: 'pointer',
 });
 


### PR DESCRIPTION
Allow custom theming of Foam Links.

This is just a fix so that while using `workbench.colorCustomizations` the default VSCode link/editor warning colors are not also modified by using:

```json
"workbench.colorCustomizations": {
    "foam.link.found": "#88e8ffcc",
    "foam.link.placeholder": "#ffff9ccc",
},
```

instead of:
```json
"workbench.colorCustomizations": {
    "textLink.foreground": "#88e8ffcc",
    "editorWarning.foreground": "#ffff9ccc",
},
```

### Format
`foam.{{item}}.{{type}}`

This format would allow for easy extensibility in the future.


#### Example
`foam.link.found`
`foam.link.placeholder`

![2021-10-02-23-48-19](https://user-images.githubusercontent.com/596184/135948520-2b6d378c-8dea-4cba-8fd7-589bc130ccd3.png)


### Further Questions / Discussion
I'm unsure if the mouse icon should also be changed. Changing to a mouse `pointer` icon when hovering and not holding `ctrl` generates the feeling that you should be able to click on the link and have something happen.

Currently, this doesn't do anything. You must hold `ctrl` and then `click`. This is a good system to stop accidental link clicking and I fully agree with the `ctrl + click` functionality.

However as I mentioned above, the mouse `pointer` icon gives the user the feeling that clicking should accomplish an action.

This feels like a UX/UI discussion and I have very little knowledge of it. Anyone else that has any other concerns, please let me know.


### Future Actions/Possibilities
I'm also currently looking into creating a [Semantic Highlighting Provider](https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide) for actually being able to use a Theme that also has Foam in mind.

This will be the first time I've tried to do a provider for semantic highlighting but looking through the example and documentation it doesn't seem too difficult to tie into Foam.