### PR TITLE
Apply entire tag regex to the preview window

### DIFF
--- a/packages/foam-vscode/src/features/preview-navigation.spec.ts
+++ b/packages/foam-vscode/src/features/preview-navigation.spec.ts
@@ -51,6 +51,12 @@ describe('Stylable tag generation in preview', () => {
       `<p>Lorem <span class='foam-tag'>#ipsum</span> dolor <span class='foam-tag'>#sit</span></p>`
     );
   });
+
+  it('transforms a string containing a tag with dash', () => {
+    expect(md.render(`Lorem ipsum dolor #si-t`)).toMatch(
+      `<p>Lorem ipsum dolor <span class='foam-tag'>#si-t</span></p>`
+    );
+  });
 });
 
 describe('Displaying included notes in preview', () => {

--- a/packages/foam-vscode/src/features/preview-navigation.ts
+++ b/packages/foam-vscode/src/features/preview-navigation.ts
@@ -119,7 +119,7 @@ export const markdownItWithFoamTags = (
 ) => {
   return md.use(markdownItRegex, {
     name: 'foam-tags',
-    regex: /(#\w+)/,
+    regex: /(?<=^|\s)(#[0-9]*[\p{L}/_-][\p{L}\p{N}/_-]*)/u,
     replace: (tag: string) => {
       try {
         const resource = workspace.find(tag);


### PR DESCRIPTION
This fixes #773. The change is simply ensuring we take the same parameters we use to extract tags for the display here.