### PR TITLE
Allow inclusion of note when using reference definitions

### DIFF
--- a/packages/foam-vscode/src/features/preview-navigation.ts
+++ b/packages/foam-vscode/src/features/preview-navigation.ts
@@ -144,15 +144,19 @@ export const markdownItWithRemoveLinkReferences = (
   md: markdownit,
   workspace: FoamWorkspace
 ) => {
-  // Forget about reference links that contain an alias divider
   md.inline.ruler.before('link', 'clear-references', state => {
     if (state.env.references) {
       Object.keys(state.env.references).forEach(refKey => {
+        // Forget about reference links that contain an alias divider
+        // Aliased reference links will lead the MarkdownParser to include wrong link references
         if (refKey.includes(ALIAS_DIVIDER_CHAR)) {
           delete state.env.references[refKey];
         }
 
-        // if we try to include this note, we can remove the reference as well
+        // When the reference is present due to an inclusion of that note, we
+        // need to remove that reference. This ensures the MarkdownIt parser
+        // will not replace the wikilink syntax with an <a href> link and as a result
+        // break our inclusion logic.
         if (state.src.toLowerCase().includes(`![[${refKey.toLowerCase()}]]`)) {
           delete state.env.references[refKey];
         }

--- a/packages/foam-vscode/src/features/preview-navigation.ts
+++ b/packages/foam-vscode/src/features/preview-navigation.ts
@@ -151,6 +151,11 @@ export const markdownItWithRemoveLinkReferences = (
         if (refKey.includes(ALIAS_DIVIDER_CHAR)) {
           delete state.env.references[refKey];
         }
+
+        // if we try to include this note, we can remove the reference as well
+        if (state.src.toLowerCase().includes(`![[${refKey.toLowerCase()}]]`)) {
+          delete state.env.references[refKey];
+        }
       });
     }
     return false;


### PR DESCRIPTION
Fixes #794.

The idea is that when we want to include a note that is also referred in the link definition, we can just "remove" that definition. This prevents the tokenisation to distort the inclusion format.