### PR TITLE
Replace vscode Uri with foam URI

### DIFF
--- a/packages/foam-vscode/src/features/wikilink-reference-generation.ts
+++ b/packages/foam-vscode/src/features/wikilink-reference-generation.ts
@@ -35,6 +35,7 @@ import {
   LINK_REFERENCE_DEFINITION_FOOTER,
   LINK_REFERENCE_DEFINITION_HEADER,
 } from '../core/janitor';
+import { fromVsCodeUri } from '../utils/vsc-utils';
 
 const feature: FoamFeature = {
   activate: async (context: ExtensionContext, foamPromise: Promise<Foam>) => {
@@ -73,7 +74,7 @@ const feature: FoamFeature = {
 
 function updateDocumentInNoteGraph(foam: Foam, document: TextDocument) {
   foam.workspace.set(
-    foam.services.parser.parse(document.uri, document.getText())
+    foam.services.parser.parse(fromVsCodeUri(document.uri), document.getText())
   );
 }
 
@@ -139,7 +140,7 @@ function generateReferenceList(
     return [];
   }
 
-  const note = foam.get(doc.uri);
+  const note = foam.get(fromVsCodeUri(doc.uri));
 
   // Should never happen as `doc` is usually given by `editor.document`, which
   // binds to an opened note.


### PR DESCRIPTION
Fixes: #813

While debugging above mentioned issue i noticed that in both of below places, an vscode `Uri` is used, while by the function definition a Foam `URI` is required.
1. https://github.com/foambubble/foam/blob/fd9bf8f04fa2cef2e3dc133cf07b3de8ff79084e/packages/foam-vscode/src/features/wikilink-reference-generation.ts#L75
2. https://github.com/foambubble/foam/blob/fd9bf8f04fa2cef2e3dc133cf07b3de8ff79084e/packages/foam-vscode/src/features/wikilink-reference-generation.ts#L141
Typescript doesn't complaint about that, since they have similar interfaces, but the inconsistency that is mentioned [here](https://github.com/microsoft/vscode/issues/116298) leads to the above issue.

In case any additional information, changes needed, please let me know.
