### PR TITLE
Consolidate use of Foam URI

### DIFF
--- a/packages/foam-vscode/src/core/model/uri.test.ts
+++ b/packages/foam-vscode/src/core/model/uri.test.ts
@@ -30,8 +30,8 @@ describe('Foam URI', () => {
       const lowerCase = URI.parse('file:///c:/this/is/a/Path');
       expect(upperCase.path).toEqual('/C:/this/is/a/Path');
       expect(lowerCase.path).toEqual('/C:/this/is/a/Path');
-      expect(URI.toFsPath(upperCase)).toEqual('C:/this/is/a/Path');
-      expect(URI.toFsPath(lowerCase)).toEqual('C:/this/is/a/Path');
+      expect(URI.toFsPath(upperCase)).toEqual('C:\\this\\is\\a\\Path');
+      expect(URI.toFsPath(lowerCase)).toEqual('C:\\this\\is\\a\\Path');
     });
 
     it('consistently parses file paths', () => {

--- a/packages/foam-vscode/src/core/model/uri.test.ts
+++ b/packages/foam-vscode/src/core/model/uri.test.ts
@@ -4,7 +4,7 @@ import { URI } from './uri';
 
 Logger.setLevel('error');
 
-describe('Foam URIs', () => {
+describe('Foam URI', () => {
   describe('URI parsing', () => {
     const base = URI.file('/path/to/file.md');
     test.each([
@@ -24,20 +24,45 @@ describe('Foam URIs', () => {
       expect(result.query).toEqual(exp.query);
       expect(result.fragment).toEqual(exp.fragment);
     });
-  });
-  it('supports various cases', () => {
-    expect(uriToSlug(URI.file('/this/is/a/path.md'))).toEqual('path');
-    expect(uriToSlug(URI.file('../a/relative/path.md'))).toEqual('path');
-    expect(uriToSlug(URI.file('another/relative/path.md'))).toEqual('path');
-    expect(uriToSlug(URI.file('no-directory.markdown'))).toEqual(
-      'no-directory'
-    );
-    expect(uriToSlug(URI.file('many.dots.name.markdown'))).toEqual(
-      'manydotsname'
-    );
+
+    it('normalizes the Windows drive letter to upper case', () => {
+      const upperCase = URI.parse('file:///C:/this/is/a/Path');
+      const lowerCase = URI.parse('file:///c:/this/is/a/Path');
+      expect(upperCase.path).toEqual('/C:/this/is/a/Path');
+      expect(lowerCase.path).toEqual('/C:/this/is/a/Path');
+      expect(URI.toFsPath(upperCase)).toEqual('C:/this/is/a/Path');
+      expect(URI.toFsPath(lowerCase)).toEqual('C:/this/is/a/Path');
+    });
+
+    it('consistently parses file paths', () => {
+      const win1 = URI.file('c:\\this\\is\\a\\path');
+      const win2 = URI.parse('c:\\this\\is\\a\\path');
+      expect(win1).toEqual(win2);
+
+      const unix1 = URI.file('/this/is/a/path');
+      const unix2 = URI.parse('/this/is/a/path');
+      expect(unix1).toEqual(unix2);
+    });
+
+    it('correctly parses file paths', () => {
+      const winUri = URI.file('c:\\this\\is\\a\\path');
+      const unixUri = URI.file('/this/is/a/path');
+      expect(winUri).toEqual(
+        URI.create({
+          scheme: 'file',
+          path: '/C:/this/is/a/path',
+        })
+      );
+      expect(unixUri).toEqual(
+        URI.create({
+          scheme: 'file',
+          path: '/this/is/a/path',
+        })
+      );
+    });
   });
 
-  it('computes a relative uri using a slug', () => {
+  it('supports computing relative paths', () => {
     expect(
       URI.computeRelativeURI(URI.file('/my/file.md'), '../hello.md')
     ).toEqual(URI.file('/hello.md'));
@@ -47,5 +72,17 @@ describe('Foam URIs', () => {
     expect(
       URI.computeRelativeURI(URI.file('/my/file.markdown'), '../hello')
     ).toEqual(URI.file('/hello.markdown'));
+  });
+
+  it('can be slugified', () => {
+    expect(uriToSlug(URI.file('/this/is/a/path.md'))).toEqual('path');
+    expect(uriToSlug(URI.file('../a/relative/path.md'))).toEqual('path');
+    expect(uriToSlug(URI.file('another/relative/path.md'))).toEqual('path');
+    expect(uriToSlug(URI.file('no-directory.markdown'))).toEqual(
+      'no-directory'
+    );
+    expect(uriToSlug(URI.file('many.dots.name.markdown'))).toEqual(
+      'manydotsname'
+    );
   });
 });

--- a/packages/foam-vscode/src/dated-notes.spec.ts
+++ b/packages/foam-vscode/src/dated-notes.spec.ts
@@ -45,7 +45,7 @@ describe('getDailyNotePath', () => {
 
   test('Uses absolute directories without modification', async () => {
     const config = isWindows
-      ? 'c:\\absolute_path\\journal'
+      ? 'C:\\absolute_path\\journal'
       : '/absolute_path/journal';
     const expectedPath = isWindows
       ? `${config}\\${isoDate}.md`

--- a/packages/foam-vscode/src/dated-notes.spec.ts
+++ b/packages/foam-vscode/src/dated-notes.spec.ts
@@ -8,6 +8,7 @@ import {
   createFile,
   showInEditor,
 } from './test/test-utils-vscode';
+import { fromVsCodeUri } from './utils/vsc-utils';
 
 describe('getDailyNotePath', () => {
   const date = new Date('2021-02-07T00:00:00Z');
@@ -20,7 +21,7 @@ describe('getDailyNotePath', () => {
     const config = 'journal';
 
     const expectedPath = URI.joinPath(
-      workspace.workspaceFolders[0].uri,
+      fromVsCodeUri(workspace.workspaceFolders[0].uri),
       config,
       `${isoDate}.md`
     );

--- a/packages/foam-vscode/src/dated-notes.ts
+++ b/packages/foam-vscode/src/dated-notes.ts
@@ -4,6 +4,7 @@ import { isAbsolute } from 'path';
 import { focusNote, pathExists } from './utils';
 import { URI } from './core/model/uri';
 import { createNoteFromDailyNoteTemplate } from './features/create-from-template';
+import { fromVsCodeUri } from './utils/vsc-utils';
 
 /**
  * Open the daily note file.
@@ -52,7 +53,7 @@ export function getDailyNotePath(
     return URI.joinPath(URI.file(dailyNoteDirectory), dailyNoteFilename);
   } else {
     return URI.joinPath(
-      workspace.workspaceFolders[0].uri,
+      fromVsCodeUri(workspace.workspaceFolders[0].uri),
       dailyNoteDirectory,
       dailyNoteFilename
     );

--- a/packages/foam-vscode/src/extension.ts
+++ b/packages/foam-vscode/src/extension.ts
@@ -8,6 +8,7 @@ import { Logger } from './core/utils/log';
 import { features } from './features';
 import { getConfigFromVscode } from './services/config';
 import { VsCodeOutputLogger, exposeLogger } from './services/logging';
+import { fromVsCodeUri } from './utils/vsc-utils';
 
 function createMarkdownProvider(config: FoamConfig): MarkdownResourceProvider {
   const matcher = new Matcher(
@@ -18,9 +19,9 @@ function createMarkdownProvider(config: FoamConfig): MarkdownResourceProvider {
   const provider = new MarkdownResourceProvider(matcher, triggers => {
     const watcher = workspace.createFileSystemWatcher('**/*');
     return [
-      watcher.onDidChange(triggers.onDidChange),
-      watcher.onDidCreate(triggers.onDidCreate),
-      watcher.onDidDelete(triggers.onDidDelete),
+      watcher.onDidChange(uri => triggers.onDidChange(fromVsCodeUri(uri))),
+      watcher.onDidCreate(uri => triggers.onDidCreate(fromVsCodeUri(uri))),
+      watcher.onDidDelete(uri => triggers.onDidDelete(fromVsCodeUri(uri))),
       watcher,
     ];
   });

--- a/packages/foam-vscode/src/features/backlinks.spec.ts
+++ b/packages/foam-vscode/src/features/backlinks.spec.ts
@@ -8,7 +8,7 @@ import {
 import { BacklinksTreeDataProvider, BacklinkTreeItem } from './backlinks';
 import { ResourceTreeItem } from '../utils/grouped-resources-tree-data-provider';
 import { OPEN_COMMAND } from './utility-commands';
-import { toVsCodeUri } from '../utils/vsc-utils';
+import { fromVsCodeUri, toVsCodeUri } from '../utils/vsc-utils';
 import { FoamGraph } from '../core/model/graph';
 import { URI } from '../core/model/uri';
 
@@ -25,7 +25,7 @@ describe('Backlinks panel', () => {
     await cleanWorkspace();
   });
 
-  const rootUri = workspace.workspaceFolders[0].uri;
+  const rootUri = fromVsCodeUri(workspace.workspaceFolders[0].uri);
   const ws = createTestWorkspace();
 
   const noteA = createTestNote({

--- a/packages/foam-vscode/src/features/backlinks.ts
+++ b/packages/foam-vscode/src/features/backlinks.ts
@@ -10,6 +10,7 @@ import { FoamWorkspace } from '../core/model/workspace';
 import { FoamGraph } from '../core/model/graph';
 import { Resource, ResourceLink } from '../core/model/note';
 import { Range } from '../core/model/range';
+import { fromVsCodeUri } from '../utils/vsc-utils';
 
 const feature: FoamFeature = {
   activate: async (
@@ -21,7 +22,9 @@ const feature: FoamFeature = {
     const provider = new BacklinksTreeDataProvider(foam.workspace, foam.graph);
 
     vscode.window.onDidChangeActiveTextEditor(async () => {
-      provider.target = vscode.window.activeTextEditor?.document.uri;
+      provider.target = vscode.window.activeTextEditor
+        ? fromVsCodeUri(vscode.window.activeTextEditor?.document.uri)
+        : undefined;
       await provider.refresh();
     });
 

--- a/packages/foam-vscode/src/features/create-from-template-variables.spec.ts
+++ b/packages/foam-vscode/src/features/create-from-template-variables.spec.ts
@@ -343,7 +343,7 @@ describe('resolveFoamTemplateVariables', () => {
 describe('determineDefaultFilepath', () => {
   test('Absolute filepath metadata is unchanged', () => {
     const absolutePath = isWindows
-      ? 'c:\\absolute_path\\journal\\My Note Title.md'
+      ? 'C:\\absolute_path\\journal\\My Note Title.md'
       : '/absolute_path/journal/My Note Title.md';
 
     const resolvedValues = new Map<string, string>();

--- a/packages/foam-vscode/src/features/create-from-template-variables.spec.ts
+++ b/packages/foam-vscode/src/features/create-from-template-variables.spec.ts
@@ -129,7 +129,7 @@ describe('resolveFoamVariables', () => {
   });
 
   test('Resolves FOAM_DATE_* properties with given date', async () => {
-    const targetDate = new Date(2021, 8, 12, 1, 2, 3);
+    const targetDate = new Date(2021, 9, 12, 1, 2, 3);
     const variables = [
       'FOAM_DATE_YEAR',
       'FOAM_DATE_YEAR_SHORT',
@@ -148,12 +148,12 @@ describe('resolveFoamVariables', () => {
     const expected = new Map<string, string>();
     expected.set('FOAM_DATE_YEAR', '2021');
     expected.set('FOAM_DATE_YEAR_SHORT', '21');
-    expected.set('FOAM_DATE_MONTH', '09');
-    expected.set('FOAM_DATE_MONTH_NAME', 'September');
-    expected.set('FOAM_DATE_MONTH_NAME_SHORT', 'Sep');
+    expected.set('FOAM_DATE_MONTH', '10');
+    expected.set('FOAM_DATE_MONTH_NAME', 'October');
+    expected.set('FOAM_DATE_MONTH_NAME_SHORT', 'Oct');
     expected.set('FOAM_DATE_DATE', '12');
-    expected.set('FOAM_DATE_DAY_NAME', 'Sunday');
-    expected.set('FOAM_DATE_DAY_NAME_SHORT', 'Sun');
+    expected.set('FOAM_DATE_DAY_NAME', 'Tuesday');
+    expected.set('FOAM_DATE_DAY_NAME_SHORT', 'Tue');
     expected.set('FOAM_DATE_HOUR', '01');
     expected.set('FOAM_DATE_MINUTE', '02');
     expected.set('FOAM_DATE_SECOND', '03');

--- a/packages/foam-vscode/src/features/create-from-template-variables.spec.ts
+++ b/packages/foam-vscode/src/features/create-from-template-variables.spec.ts
@@ -8,6 +8,7 @@ import {
 import path from 'path';
 import { isWindows } from '../utils';
 import { URI } from '../core/model/uri';
+import { fromVsCodeUri } from '../utils/vsc-utils';
 
 describe('substituteFoamVariables', () => {
   test('Does nothing if no Foam-specific variables are used', () => {
@@ -373,7 +374,7 @@ describe('determineDefaultFilepath', () => {
     );
 
     const expectedPath = path.join(
-      workspace.workspaceFolders[0].uri.fsPath,
+      URI.toFsPath(fromVsCodeUri(workspace.workspaceFolders[0].uri)),
       relativePath
     );
 

--- a/packages/foam-vscode/src/features/create-from-template.ts
+++ b/packages/foam-vscode/src/features/create-from-template.ts
@@ -17,11 +17,11 @@ import {
 } from 'vscode';
 import { FoamFeature } from '../types';
 import { focusNote } from '../utils';
-import { toVsCodeUri } from '../utils/vsc-utils';
+import { fromVsCodeUri, toVsCodeUri } from '../utils/vsc-utils';
 import { extractFoamTemplateFrontmatterMetadata } from '../utils/template-frontmatter-parser';
 
 const templatesDir = URI.joinPath(
-  workspace.workspaceFolders[0].uri,
+  fromVsCodeUri(workspace.workspaceFolders[0].uri),
   '.foam',
   'templates'
 );
@@ -101,7 +101,9 @@ async function templateMetadata(
 }
 
 async function getTemplates(): Promise<URI[]> {
-  const templates = await workspace.findFiles('.foam/templates/**.md', null);
+  const templates = await workspace
+    .findFiles('.foam/templates/**.md', null)
+    .then(v => v.map(uri => fromVsCodeUri(uri)));
   return templates;
 }
 
@@ -477,7 +479,7 @@ function currentDirectoryFilepath(filename: string) {
   const currentDir =
     activeFile !== undefined
       ? URI.parse(path.dirname(activeFile))
-      : workspace.workspaceFolders[0].uri;
+      : fromVsCodeUri(workspace.workspaceFolders[0].uri);
 
   return URI.joinPath(currentDir, filename);
 }
@@ -518,7 +520,7 @@ async function replaceSelectionWithWikiLink(
 function resolveFilepathAttribute(filepath) {
   return isAbsolute(filepath)
     ? URI.file(filepath)
-    : URI.joinPath(workspace.workspaceFolders[0].uri, filepath);
+    : URI.joinPath(fromVsCodeUri(workspace.workspaceFolders[0].uri), filepath);
 }
 
 export function determineDefaultFilepath(

--- a/packages/foam-vscode/src/features/dataviz.ts
+++ b/packages/foam-vscode/src/features/dataviz.ts
@@ -7,6 +7,7 @@ import { getGraphStyle, getTitleMaxLength } from '../settings';
 import { isSome } from '../utils';
 import { Foam } from '../core/model/foam';
 import { Logger } from '../core/utils/log';
+import { fromVsCodeUri } from '../utils/vsc-utils';
 
 const feature: FoamFeature = {
   activate: (context: vscode.ExtensionContext, foamPromise: Promise<Foam>) => {
@@ -46,7 +47,7 @@ const feature: FoamFeature = {
 
         vscode.window.onDidChangeActiveTextEditor(e => {
           if (e?.document?.uri?.scheme === 'file') {
-            const note = foam.workspace.get(e.document.uri);
+            const note = foam.workspace.get(fromVsCodeUri(e.document.uri));
             if (isSome(note)) {
               panel.webview.postMessage({
                 type: 'didSelectNote',
@@ -143,7 +144,7 @@ async function createGraphPanel(foam: Foam, context: vscode.ExtensionContext) {
 
         case 'webviewDidSelectNode':
           const noteUri = vscode.Uri.parse(message.payload);
-          const selectedNote = foam.workspace.get(noteUri);
+          const selectedNote = foam.workspace.get(fromVsCodeUri(noteUri));
 
           if (isSome(selectedNote)) {
             const doc = await vscode.workspace.openTextDocument(

--- a/packages/foam-vscode/src/features/document-decorator.ts
+++ b/packages/foam-vscode/src/features/document-decorator.ts
@@ -9,6 +9,7 @@ import {
 import { ResourceParser } from '../core/model/note';
 import { FoamWorkspace } from '../core/model/workspace';
 import { Foam } from '../core/model/foam';
+import { fromVsCodeUri } from '../utils/vsc-utils';
 
 export const CONFIG_KEY = 'decorations.links.enable';
 
@@ -34,7 +35,10 @@ const updateDecorations = (
   if (!editor || !areDecorationsEnabled()) {
     return;
   }
-  const note = parser.parse(editor.document.uri, editor.document.getText());
+  const note = parser.parse(
+    fromVsCodeUri(editor.document.uri),
+    editor.document.getText()
+  );
   let linkRanges = [];
   let placeholderRanges = [];
   note.links.forEach(link => {

--- a/packages/foam-vscode/src/features/document-link-provider.spec.ts
+++ b/packages/foam-vscode/src/features/document-link-provider.spec.ts
@@ -32,7 +32,7 @@ describe('Document links provider', () => {
     const { uri, content } = await createFile('');
     const ws = new FoamWorkspace().set(parser.parse(uri, content));
 
-    const doc = await vscode.workspace.openTextDocument(uri);
+    const doc = await vscode.workspace.openTextDocument(toVsCodeUri(uri));
     const provider = new LinkProvider(ws, parser);
     const links = provider.provideDocumentLinks(doc);
 
@@ -45,7 +45,7 @@ describe('Document links provider', () => {
     );
     const ws = new FoamWorkspace().set(parser.parse(uri, content));
 
-    const doc = await vscode.workspace.openTextDocument(uri);
+    const doc = await vscode.workspace.openTextDocument(toVsCodeUri(uri));
     const provider = new LinkProvider(ws, parser);
     const links = provider.provideDocumentLinks(doc);
 
@@ -98,7 +98,7 @@ describe('Document links provider', () => {
 
     expect(links.length).toEqual(1);
     expect(links[0].target).toEqual(
-      OPEN_COMMAND.asURI(toVsCodeUri(URI.placeholder('a placeholder')))
+      OPEN_COMMAND.asURI(URI.placeholder('a placeholder'))
     );
     expect(links[0].range).toEqual(new vscode.Range(0, 18, 0, 35));
   });

--- a/packages/foam-vscode/src/features/document-link-provider.ts
+++ b/packages/foam-vscode/src/features/document-link-provider.ts
@@ -3,7 +3,7 @@ import { URI } from '../core/model/uri';
 import { FoamFeature } from '../types';
 import { mdDocSelector } from '../utils';
 import { OPEN_COMMAND } from './utility-commands';
-import { toVsCodeRange, toVsCodeUri } from '../utils/vsc-utils';
+import { fromVsCodeUri, toVsCodeRange, toVsCodeUri } from '../utils/vsc-utils';
 import { getFoamVsCodeConfig } from '../services/config';
 import { Foam } from '../core/model/foam';
 import { FoamWorkspace } from '../core/model/workspace';
@@ -38,11 +38,14 @@ export class LinkProvider implements vscode.DocumentLinkProvider {
   public provideDocumentLinks(
     document: vscode.TextDocument
   ): vscode.DocumentLink[] {
-    const resource = this.parser.parse(document.uri, document.getText());
+    const resource = this.parser.parse(
+      fromVsCodeUri(document.uri),
+      document.getText()
+    );
 
     return resource.links.map(link => {
       const target = this.workspace.resolveLink(resource, link);
-      const command = OPEN_COMMAND.asURI(toVsCodeUri(target));
+      const command = OPEN_COMMAND.asURI(target);
       const documentLink = new vscode.DocumentLink(
         toVsCodeRange(link.range),
         command

--- a/packages/foam-vscode/src/features/hover-provider.spec.ts
+++ b/packages/foam-vscode/src/features/hover-provider.spec.ts
@@ -13,6 +13,7 @@ import {
   createFile,
   showInEditor,
 } from '../test/test-utils-vscode';
+import { toVsCodeUri } from '../utils/vsc-utils';
 import { HoverProvider } from './hover-provider';
 
 // We can't use createTestWorkspace from /packages/foam-vscode/src/test/test-utils.ts
@@ -60,7 +61,7 @@ describe('Hover provider', () => {
       const graph = FoamGraph.fromWorkspace(ws);
       const provider = new HoverProvider(hoverEnabled, ws, graph, parser);
 
-      const doc = await vscode.workspace.openTextDocument(uri);
+      const doc = await vscode.workspace.openTextDocument(toVsCodeUri(uri));
       const pos = new vscode.Position(0, 0);
       const result = await provider.provideHover(doc, pos, noCancelToken);
 
@@ -78,7 +79,7 @@ describe('Hover provider', () => {
 
       const provider = new HoverProvider(hoverEnabled, ws, graph, parser);
 
-      const doc = await vscode.workspace.openTextDocument(uri);
+      const doc = await vscode.workspace.openTextDocument(toVsCodeUri(uri));
       const pos = new vscode.Position(0, 0);
       const result = await provider.provideHover(doc, pos, noCancelToken);
 

--- a/packages/foam-vscode/src/features/hover-provider.ts
+++ b/packages/foam-vscode/src/features/hover-provider.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { URI } from '../core/model/uri';
 import { FoamFeature } from '../types';
 import { getNoteTooltip, mdDocSelector, isSome } from '../utils';
-import { toVsCodeRange } from '../utils/vsc-utils';
+import { fromVsCodeUri, toVsCodeRange } from '../utils/vsc-utils';
 import {
   ConfigurationMonitor,
   monitorFoamVsCodeConfig,
@@ -59,7 +59,10 @@ export class HoverProvider implements vscode.HoverProvider {
       return;
     }
 
-    const startResource = this.parser.parse(document.uri, document.getText());
+    const startResource = this.parser.parse(
+      fromVsCodeUri(document.uri),
+      document.getText()
+    );
 
     const targetLink: ResourceLink | undefined = startResource.links.find(
       link =>
@@ -75,7 +78,7 @@ export class HoverProvider implements vscode.HoverProvider {
     const targetUri = this.workspace.resolveLink(startResource, targetLink);
     const refs = this.graph
       .getBacklinks(targetUri)
-      .filter(link => !URI.isEqual(link.source, document.uri));
+      .filter(link => !URI.isEqual(link.source, fromVsCodeUri(document.uri)));
 
     const links = refs.slice(0, 10).map(link => {
       const command = OPEN_COMMAND.asURI(link.source);

--- a/packages/foam-vscode/src/features/link-completion.spec.ts
+++ b/packages/foam-vscode/src/features/link-completion.spec.ts
@@ -8,10 +8,11 @@ import {
   createFile,
   showInEditor,
 } from '../test/test-utils-vscode';
+import { fromVsCodeUri } from '../utils/vsc-utils';
 import { CompletionProvider } from './link-completion';
 
 describe('Link Completion', () => {
-  const root = vscode.workspace.workspaceFolders[0].uri;
+  const root = fromVsCodeUri(vscode.workspace.workspaceFolders[0].uri);
   const ws = new FoamWorkspace();
   ws.set(
     createTestNote({

--- a/packages/foam-vscode/src/features/orphans.ts
+++ b/packages/foam-vscode/src/features/orphans.ts
@@ -9,6 +9,7 @@ import {
   ResourceTreeItem,
   UriTreeItem,
 } from '../utils/grouped-resources-tree-data-provider';
+import { fromVsCodeUri } from '../utils/vsc-utils';
 
 const feature: FoamFeature = {
   activate: async (
@@ -17,8 +18,8 @@ const feature: FoamFeature = {
   ) => {
     const foam = await foamPromise;
 
-    const workspacesURIs = vscode.workspace.workspaceFolders.map(
-      dir => dir.uri
+    const workspacesURIs = vscode.workspace.workspaceFolders.map(dir =>
+      fromVsCodeUri(dir.uri)
     );
 
     const provider = new GroupedResourcesTreeDataProvider(

--- a/packages/foam-vscode/src/features/placeholders.ts
+++ b/packages/foam-vscode/src/features/placeholders.ts
@@ -9,6 +9,7 @@ import {
   ResourceTreeItem,
   UriTreeItem,
 } from '../utils/grouped-resources-tree-data-provider';
+import { fromVsCodeUri } from '../utils/vsc-utils';
 
 const feature: FoamFeature = {
   activate: async (
@@ -16,8 +17,8 @@ const feature: FoamFeature = {
     foamPromise: Promise<Foam>
   ) => {
     const foam = await foamPromise;
-    const workspacesURIs = vscode.workspace.workspaceFolders.map(
-      dir => dir.uri
+    const workspacesURIs = vscode.workspace.workspaceFolders.map(dir =>
+      fromVsCodeUri(dir.uri)
     );
     const provider = new GroupedResourcesTreeDataProvider(
       'placeholders',

--- a/packages/foam-vscode/src/features/tag-completion.spec.ts
+++ b/packages/foam-vscode/src/features/tag-completion.spec.ts
@@ -8,10 +8,11 @@ import {
   createFile,
   showInEditor,
 } from '../test/test-utils-vscode';
+import { fromVsCodeUri } from '../utils/vsc-utils';
 import { TagCompletionProvider } from './tag-completion';
 
 describe('Tag Completion', () => {
-  const root = vscode.workspace.workspaceFolders[0].uri;
+  const root = fromVsCodeUri(vscode.workspace.workspaceFolders[0].uri);
   const ws = new FoamWorkspace();
   ws.set(
     createTestNote({

--- a/packages/foam-vscode/src/features/utility-commands.ts
+++ b/packages/foam-vscode/src/features/utility-commands.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { FoamFeature } from '../types';
 import { URI } from '../core/model/uri';
-import { toVsCodeUri } from '../utils/vsc-utils';
+import { fromVsCodeUri, toVsCodeUri } from '../utils/vsc-utils';
 import { createNoteForPlaceholderWikilink } from './create-from-template';
 
 export const OPEN_COMMAND = {
@@ -19,18 +19,18 @@ export const OPEN_COMMAND = {
 
         const basedir =
           vscode.workspace.workspaceFolders.length > 0
-            ? vscode.workspace.workspaceFolders[0].uri
-            : vscode.window.activeTextEditor?.document.uri
-            ? URI.getDir(vscode.window.activeTextEditor!.document.uri)
+            ? fromVsCodeUri(vscode.workspace.workspaceFolders[0].uri)
+            : fromVsCodeUri(vscode.window.activeTextEditor?.document.uri)
+            ? URI.getDir(
+                fromVsCodeUri(vscode.window.activeTextEditor!.document.uri)
+              )
             : undefined;
 
         if (basedir === undefined) {
           return;
         }
 
-        const target = toVsCodeUri(
-          URI.createResourceUriFromPlaceholder(basedir, uri)
-        );
+        const target = URI.createResourceUriFromPlaceholder(basedir, uri);
 
         await createNoteForPlaceholderWikilink(title, target);
         return;

--- a/packages/foam-vscode/src/services/config.ts
+++ b/packages/foam-vscode/src/services/config.ts
@@ -1,12 +1,15 @@
 import { Disposable, workspace } from 'vscode';
 import { createConfigFromFolders, FoamConfig } from '../core/config';
 import { getIgnoredFilesSetting } from '../settings';
+import { fromVsCodeUri } from '../utils/vsc-utils';
 
 // TODO this is still to be improved - foam config should
 // not be dependent on vscode but at the moment it's convenient
 // to leverage it
 export const getConfigFromVscode = (): FoamConfig => {
-  const workspaceFolders = workspace.workspaceFolders.map(dir => dir.uri);
+  const workspaceFolders = workspace.workspaceFolders.map(dir =>
+    fromVsCodeUri(dir.uri)
+  );
   const excludeGlobs = getIgnoredFilesSetting();
 
   return createConfigFromFolders(workspaceFolders, {

--- a/packages/foam-vscode/src/test/test-utils-vscode.ts
+++ b/packages/foam-vscode/src/test/test-utils-vscode.ts
@@ -4,7 +4,7 @@
 import * as vscode from 'vscode';
 import path from 'path';
 import { TextEncoder } from 'util';
-import { toVsCodeUri } from '../utils/vsc-utils';
+import { fromVsCodeUri, toVsCodeUri } from '../utils/vsc-utils';
 import { Logger } from '../core/utils/log';
 import { URI } from '../core/model/uri';
 import { Resource } from '../core/model/note';
@@ -36,11 +36,14 @@ export const closeEditors = async () => {
  * @returns an object containing various information about the file created
  */
 export const createFile = async (content: string, filepath?: string[]) => {
-  const rootUri = vscode.workspace.workspaceFolders[0].uri;
+  const rootUri = fromVsCodeUri(vscode.workspace.workspaceFolders[0].uri);
   filepath = filepath ?? [randomString() + '.md'];
-  const uri = vscode.Uri.joinPath(rootUri, ...filepath);
-  const filenameComponents = path.parse(uri.fsPath);
-  await vscode.workspace.fs.writeFile(uri, new TextEncoder().encode(content));
+  const uri = URI.joinPath(rootUri, ...filepath);
+  const filenameComponents = path.parse(URI.toFsPath(uri));
+  await vscode.workspace.fs.writeFile(
+    toVsCodeUri(uri),
+    new TextEncoder().encode(content)
+  );
   return { uri, content, ...filenameComponents };
 };
 

--- a/packages/foam-vscode/src/utils/vsc-utils.spec.ts
+++ b/packages/foam-vscode/src/utils/vsc-utils.spec.ts
@@ -1,60 +1,25 @@
-import os from 'os';
-import { workspace, Uri } from 'vscode';
-import { URI } from '../core/model/uri';
+import { Uri } from 'vscode';
 import { fromVsCodeUri, toVsCodeUri } from './vsc-utils';
 
-describe('uri conversion', () => {
-  it('uses drive letter casing in windows #488 #507', () => {
-    if (os.platform() === 'win32') {
-      const uri = workspace.workspaceFolders[0].uri;
-      const isDriveUppercase =
-        uri.fsPath.charCodeAt(0) >= 'A'.charCodeAt(0) &&
-        uri.fsPath.charCodeAt(0) <= 'Z'.charCodeAt(0);
-      const [drive, path] = uri.fsPath.split(':');
-      const posixPath = path.replace(/\\/g, '/');
+describe('URI conversion', () => {
+  it('converts between Foam and VS Code URI', () => {
+    const vsUnixUri = Uri.file('/this/is/a/path');
+    const fUnixUri = fromVsCodeUri(vsUnixUri);
+    expect(toVsCodeUri(fUnixUri)).toEqual(expect.objectContaining(fUnixUri));
 
-      const withUppercase = `/${drive.toUpperCase()}:${posixPath}`;
-      const withLowercase = `/${drive.toLowerCase()}:${posixPath}`;
-      const expected = isDriveUppercase ? withUppercase : withLowercase;
-
-      expect(fromVsCodeUri(Uri.file(withUppercase)).path).toEqual(expected);
-      expect(fromVsCodeUri(Uri.file(withLowercase)).path).toEqual(expected);
-    }
-  });
-
-  it('correctly parses file paths', () => {
-    const test = workspace.workspaceFolders[0].uri;
-    const uri = URI.file(test.fsPath);
-    expect(uri).toEqual(
-      URI.create({
-        scheme: 'file',
-        path: test.path,
-      })
+    const vsWinUpperDriveUri = Uri.file('C:\\this\\is\\a\\path');
+    const fWinUpperUri = fromVsCodeUri(vsWinUpperDriveUri);
+    expect(toVsCodeUri(fWinUpperUri)).toEqual(
+      expect.objectContaining(fWinUpperUri)
     );
-  });
 
-  it('creates a proper string representation for file uris', () => {
-    const test = workspace.workspaceFolders[0].uri;
-    const uri = URI.file(test.fsPath);
-    expect(URI.toString(uri)).toEqual(test.toString());
-  });
-
-  it('is consistent when converting from VS Code to Foam URI', () => {
-    const vsUri = workspace.workspaceFolders[0].uri;
-    const fUri = fromVsCodeUri(vsUri);
-    expect(toVsCodeUri(fUri)).toEqual(expect.objectContaining(fUri));
-  });
-
-  it('is consistent when converting from Foam to VS Code URI', () => {
-    const test = workspace.workspaceFolders[0].uri;
-    const uri = URI.file(test.fsPath);
-    const fUri = toVsCodeUri(uri);
-    expect(fUri).toEqual(
+    const vsWinLowerUri = Uri.file('c:\\this\\is\\a\\path');
+    const fWinLowerUri = fromVsCodeUri(vsWinLowerUri);
+    expect(toVsCodeUri(fWinLowerUri)).toEqual(
       expect.objectContaining({
-        scheme: 'file',
-        path: test.path,
+        ...fWinLowerUri,
+        path: fWinUpperUri.path, // path is normalized to upper case
       })
     );
-    expect(fromVsCodeUri(fUri)).toEqual(uri);
   });
 });


### PR DESCRIPTION
With this PR all URIs that Foam will work with in its internals will be Foam URI, as opposed to also VS Code Uri.

A few related issues: #813 #814 #816 
VS Code related issues: https://github.com/microsoft/vscode/issues/43959 https://github.com/microsoft/vscode/issues/116298 https://github.com/microsoft/vscode/issues/42159 https://github.com/microsoft/vscode/issues/70004 https://github.com/microsoft/vscode/issues/67523 https://github.com/microsoft/vscode/issues/12448

### The problem

Basically VS Code is not consistent in the way they handle the casing of the drive letter for Windows, and this is causing issues in Foam.

Originally we wanted Foam `URI`, and VS Code `Uri` to be interchangeable (or at least for Foam to be able to consume VS Code `Uri`), but these internal inconsistencies (with no plan to be fixed) have made working in Windows especially error prone.

### The solution

With this PR:
- VS Code `Uri`s are always converted to Foam `URI` before being used by our API
- Foam `URI` always normalizes Windows paths (uppercase drive letter, following the VS Code recommendation, see https://github.com/microsoft/vscode/issues/43959)
- Updated tests

### Considerations

- I actually don't mind what the code looks like, and the increased clarity and consistency are well worth the work
- 

## Challenges

There are still some challenges with this approach.

Originally we wanted `URI => Uri => URI` and `Uri => URI => Uri` to be idempotent, obviously that won't be the case moving forward (but as we will always use `URI` internally, we only have to worry about this on the edges - whereas the current approach makes everything brittle)

Going the route of formally splitting `foam.URI` and `vscode.Uri` has an implementation challenge because for this to make sense typescript has to enforce it, but typescript uses duck typing and I haven't found a clean way to force the conversion. The only options I can think of atm are: renaming one of the fields, adding extra ones, or artificially being more restrictive on the types of existing ones.
Related to this point: microsoft/TypeScript#42698 which means we could use classes in the future once that issue is resolved.

This PR of course would require thorough testing in Windows.

## What reviewers should focus on

- considerations and challenges from the PR
- at a code level, whether the approach makes sense
- test coverage / edge cases
- if you have a windows machine, please play with this 🙏 