### PR TITLE
Remove unused argument

### DIFF
--- a/packages/foam-vscode/src/features/create-from-template.ts
+++ b/packages/foam-vscode/src/features/create-from-template.ts
@@ -668,14 +668,12 @@ async function createNoteFromDefaultTemplate(
   }
 }
 
-async function createNoteFromTemplate(
-  templateFilename?: string
-): Promise<void> {
+async function createNoteFromTemplate(): Promise<void> {
   const selectedTemplate = await askUserForTemplate();
   if (selectedTemplate === undefined) {
     return;
   }
-  templateFilename =
+  const templateFilename =
     (selectedTemplate as QuickPickItem).description ||
     (selectedTemplate as QuickPickItem).label;
   const templateUri = URI.joinPath(templatesDir, templateFilename);


### PR DESCRIPTION
`templateFilename` is reassigned before use.