### PR TITLE
Make references also links

### DIFF
--- a/packages/foam-vscode/src/features/navigation-provider.spec.ts
+++ b/packages/foam-vscode/src/features/navigation-provider.spec.ts
@@ -55,8 +55,8 @@ describe('Document navigation', () => {
       expect(links.length).toEqual(0);
     });
 
-    it('should not create links for wikilinks (as we use definitions)', async () => {
-      const fileA = await createFile('# File A');
+    it('should create links for wikilinks', async () => {
+      const fileA = await createFile('# File A', ['file-a.md']);
       const fileB = await createFile(`this is a link to [[${fileA.name}]].`);
       const ws = createTestWorkspace()
         .set(parser.parse(fileA.uri, fileA.content))
@@ -67,7 +67,9 @@ describe('Document navigation', () => {
       const provider = new NavigationProvider(ws, graph, parser);
       const links = provider.provideDocumentLinks(doc);
 
-      expect(links.length).toEqual(0);
+      expect(links.length).toEqual(1);
+      expect(links[0].target).toEqual(OPEN_COMMAND.asURI(fileA.uri));
+      expect(links[0].range).toEqual(new vscode.Range(0, 18, 0, 28));
     });
 
     it('should create links for placeholders', async () => {

--- a/packages/foam-vscode/src/features/navigation-provider.ts
+++ b/packages/foam-vscode/src/features/navigation-provider.ts
@@ -42,8 +42,8 @@ const feature: FoamFeature = {
 
 /**
  * Provides navigation and references for Foam links.
- * - We create definintions for existing wikilinks
- * - We create links for placholders
+ * - We create definintions for existing wikilinks but not placeholders
+ * - We create links for both
  * - We create references for both
  *
  * Placeholders are created as links so that when clicking on them a new note will be created.
@@ -130,19 +130,19 @@ export class NavigationProvider
   }
 
   /**
-   * Create links for placholders
+   * Create links for wikilinks and placeholders
    */
   public provideDocumentLinks(
     document: vscode.TextDocument
   ): vscode.DocumentLink[] {
     const resource = this.parser.parse(document.uri, document.getText());
 
-    const targets: { link: ResourceLink; target: URI }[] = resource.links
-      .map(link => ({
+    const targets: { link: ResourceLink; target: URI }[] = resource.links.map(
+      link => ({
         link,
         target: this.workspace.resolveLink(resource, link),
-      }))
-      .filter(link => URI.isPlaceholder(link.target));
+      })
+    );
 
     return targets.map(o => {
       const command = OPEN_COMMAND.asURI(toVsCodeUri(o.target));
@@ -150,7 +150,9 @@ export class NavigationProvider
         toVsCodeRange(o.link.range),
         command
       );
-      documentLink.tooltip = `Create note for '${o.target.path}'`;
+      documentLink.tooltip = URI.isPlaceholder(o.target)
+        ? `Create note for '${o.target.path}'`
+        : `Go to ${URI.toFsPath(o.target)}`;
       return documentLink;
     });
   }

--- a/packages/foam-vscode/src/test/test-utils-vscode.ts
+++ b/packages/foam-vscode/src/test/test-utils-vscode.ts
@@ -53,7 +53,7 @@ export const getUriInWorkspace = (...filepath: string[]) => {
  * @param path relative file path
  * @returns an object containing various information about the file created
  */
-export const createFile = async (content: string, filepath?: string[]) => {
+export const createFile = async (content: string, filepath: string[] = []) => {
   const uri = getUriInWorkspace(...filepath);
   const filenameComponents = path.parse(URI.toFsPath(uri));
   await vscode.workspace.fs.writeFile(


### PR DESCRIPTION
Fix #836 

Make both definitions and links for wikilinks, so that either navigation method can work.