### PR TITLE
Add support for wikilinks disambiguation 

### DIFF
--- a/docs/proposals/wikilinks-in-foam.md
+++ b/docs/proposals/wikilinks-in-foam.md
@@ -1,0 +1,97 @@
+# Wikilinks in Foam
+
+Foam supports standard wikilinks in the format `[[wikilink]]`.
+
+Wikilinks can refer to any note or attachment in the repo: `[[note.md]]`, `[[doc.pdf]]`, `[[image.jpg]]`.
+
+The usual wikilink syntax without extension refers to notes: `[[wikilink]]` and `[[wikilink.md]]` are equivalent.
+
+The goal of wikilinks is to uniquily identify a file in a repo, no matter in which directory it lives.
+
+Sometimes in a repo you can have files with the same name in different directories.
+Foam allows you to identify those files using the minimum effort needed to disambiguate them.
+
+This is achieved by adding as many directories above the file needed to uniquely identify the link, e.g. `[[house/todo]]`.
+
+See below for more details.
+
+## Goals for wikilinks in Foam
+
+Wikilinks in Foam are meant to satisfy the following:
+- make it easy for users to identify a resource
+- make it interoperable with other similar note taking systems (Obsidian, Dendron, ...)
+- be easy to get started with, but satisfy growing needs
+
+## Types of wikilinks supported in Foam
+
+Foam supports two types of keys inside a wikilink: a **path** reference and an **identifier** reference:
+
+- `[[./file]]` and `[[../to/another/file]]` are **path** links to a resource, relative _from the source_
+- `[[/path/to/file]]` is a **path** link to a resource, relative _from the repo root_
+- `[[file]]` is an **identifier** of a resource (based on the filename)
+- `[[path/to/file]]` is an **identifier** of a resource (based on the path), the same is true for `[[to/file]]`
+
+It's important to note that sometimes identifier keys can't uniquely locale a resource.
+
+A more concrete example will help:
+
+```
+/
+  projects/
+    house/
+      todo.md
+    buy-car/
+      todo.md
+      cars.md
+  work/
+    todo.md
+    notes.md
+```
+
+In the above repo:
+
+- `[[cars]]` is a unique identifier of a resource - it can be used anywhere in the repo
+- `[[todo]]` is an non-unique identifier as it can refer to multiple resources
+- `[[house/todo]]` is a unique identifier of a resource - it can be used anywhere in the repo
+- `[[projects/house/todo]]` is a unique identifier of a resource - it can be used anywhere in the repo
+- `[[/projects/house/todo]]` is a path reference to a resource
+- `[[./todo]]` is a path reference to a resource (e.g. from `/projects/buy-car/cars.md`)
+
+Basically we could say as a rule:
+
+- if the link starts with `/` or `.` we consider it a **path** reference, in the first case from the repo root, otherwise from the source note
+- if a link doesn't start with `/` or `.` it is an **identifier**
+  - generally speaking we use the shortest identifier available to identify a resource, **but all are valid**
+    - `[[projects/buy-car/cars]]`, `[[buy-car/cars]]`, `[[cars]]` are all unique identifier to the same resource, and are all valid in a document
+    - the same can be said for `[[projects/house/todo]]` and `[[house/todo]]` - but not for `[[todo]]`, because it can refer to more than one resource
+
+## Compatibility with other apps
+
+Foam's identifiers are a super set of Obsidian's: all Obsidian links are supported by Foam, but Foam multi-part identifier (scenario 6) is only supported by Foam.
+
+To improve compatibility this option should either be behind a configuration key, or it should be easily updated e.g. via the janitor.
+
+| Scenario                    | Obsidian                        | Foam                            |
+| --------------------------- | ------------------------------- | ------------------------------- |
+| 1 `[[notes]]`               | ✔ unique identifier in repo     | ✔ unique identifier in repo     |
+| 2 `[[/work/notes]]`         | ✔ valid path from repo root     | ✔ valid path from repo root     |
+| 3 `[[work/notes]]`          | ✔ valid path from repo root     | ✔ valid identifier in repo      |
+| 4 `[[project/house/todo]]`  | ✔ valid path from repo root     | ✔ valid unique identifier       |
+| 5 `[[/project/house/todo]]` | ✔ valid path from repo root     | ✔ valid path from repo root     |
+| 6 `[[house/todo]]`          | ✘ incorrect path from repo root | ✔ valid unique identifier       |
+| 7 `[[todo]]`                | ✘ ambiguous identifier          | ✘ ambiguous identifier          |
+| 8 `[[/house/todo]]`         | ✘ incorrect path from repo root | ✘ incorrect path from repo root |
+
+## Non-unique identifiers
+
+We can't prevent non-unique identifiers from occurring in Foam (first and foremost because a file could be edited with another editor) but we can flag them. 
+
+Therefore Foam follows the following strategy instead:
+
+1. there is a clear resolution mechanism (alphabetic) so that if nothing changes a non-unique identifier will always return the same note. Resolution has to be deterministic
+2. a diagnostic entry (warning or error) is showed to the user for non-unique identifiers, so she knows that she's using a "risky" identifier
+   1. The quick resolution for this item will show the available unique identifiers matching the non-unique one
+
+## Thanks 
+
+Thanks to [@memplex](https://github.com/memeplex) for helping with the thinking around this proposal.

--- a/packages/foam-vscode/CHANGELOG.md
+++ b/packages/foam-vscode/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the "foam-vscode" extension will be documented in this fi
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## Unreleased
+
+Features:
+
+- Added support for wikilinks across directories (#841)
+  - BREAKING CHANGE: wikilinks to attachments must now include the extension
+
 ## [0.15.9] - 2021-11-23
 
 Fixes and Improvements:

--- a/packages/foam-vscode/src/core/model/graph.ts
+++ b/packages/foam-vscode/src/core/model/graph.ts
@@ -2,7 +2,7 @@ import { diff } from 'fast-array-diff';
 import { isEqual } from 'lodash';
 import { Resource, ResourceLink } from './note';
 import { URI } from './uri';
-import { FoamWorkspace, uriToResourceName } from './workspace';
+import { FoamWorkspace } from './workspace';
 import { Range } from './range';
 import { IDisposable } from '../common/lifecycle';
 
@@ -99,16 +99,16 @@ export class FoamGraph implements IDisposable {
 
   private updateLinksRelatedToAddedResource(resource: Resource) {
     // check if any existing connection can be filled by new resource
-    const name = uriToResourceName(resource.uri);
-    const placeholder = this.placeholders.get(name);
-    if (placeholder) {
-      this.placeholders.delete(name);
-      const resourcesToUpdate = this.backlinks.get(placeholder.path) ?? [];
-      resourcesToUpdate.forEach(res =>
-        this.resolveResource(this.workspace.get(res.source))
-      );
+    let resourcesToUpdate: Resource[] = [];
+    for (const placeholderId of this.placeholders.keys()) {
+      // quick and dirty check for affected resources
+      if (resource.uri.path.endsWith(placeholderId + '.md')) {
+        resourcesToUpdate.push(resource);
+      }
     }
-
+    resourcesToUpdate.forEach(res =>
+      this.resolveResource(this.workspace.get(res.uri))
+    );
     // resolve the resource
     this.resolveResource(resource);
   }

--- a/packages/foam-vscode/src/core/model/workspace.test.ts
+++ b/packages/foam-vscode/src/core/model/workspace.test.ts
@@ -313,15 +313,14 @@ describe('Wikilinks', () => {
     expect(graph.getBacklinks(attachmentA.uri).map(l => l.source)).toEqual([
       noteA.uri,
     ]);
-    expect(graph.getBacklinks(attachmentB.uri).map(l => l.source)).toEqual([
-      noteA.uri,
-    ]);
+    // Attachments require extension
+    expect(graph.getBacklinks(attachmentB.uri).map(l => l.source)).toEqual([]);
   });
 
   it('Resolves conflicts alphabetically - part 1', () => {
     const noteA = createTestNote({
       uri: '/path/to/page-a.md',
-      links: [{ slug: 'attachment-a' }],
+      links: [{ slug: 'attachment-a.pdf' }],
     });
     const attachmentA = createTestNote({
       uri: '/path/to/more/attachment-a.pdf',
@@ -343,7 +342,7 @@ describe('Wikilinks', () => {
   it('Resolves conflicts alphabetically - part 2', () => {
     const noteA = createTestNote({
       uri: '/path/to/page-a.md',
-      links: [{ slug: 'attachment-a' }],
+      links: [{ slug: 'attachment-a.pdf' }],
     });
     const attachmentA = createTestNote({
       uri: '/path/to/more/attachment-a.pdf',
@@ -376,7 +375,7 @@ describe('Wikilinks', () => {
     expect(graph.getLinks(noteA.uri).map(l => l.target)).toEqual([noteB1.uri]);
   });
 
-  it('Handles capatalization of files and wikilinks correctly', () => {
+  it('Handles capitalization of files and wikilinks correctly', () => {
     const noteA = createTestNote({
       uri: '/path/to/page-a.md',
       links: [


### PR DESCRIPTION
In this PR the way wikilinks are handled changes in order to support disambiguation across directories.

See the documentation in the PR for more information.

In summary, the resource `/work/projects/foam/refactoring.md` can be identified by `[[refactoring]]`, `[[foam/refactoring]]`, `[[projects/foam/refactoring]]` and `[[work/projects/foam/refactoring]]` (and of course via a path-like wikilink).

Related: https://github.com/foambubble/foam/issues/806

### Backwards compatibility

- Existing links to notes are backwards compatible
- This PR introduces a **breaking change** in the links to attachments, which now  must include the extension (which was beforehand optional)