### PR TITLE
Added diagnostic for ambiguous wikilinks with quick fix actions

### DIFF
--- a/packages/foam-vscode/src/core/model/workspace.test.ts
+++ b/packages/foam-vscode/src/core/model/workspace.test.ts
@@ -1,4 +1,4 @@
-import { getReferenceType } from './workspace';
+import { FoamWorkspace, getReferenceType } from './workspace';
 import { FoamGraph } from './graph';
 import { Logger } from '../utils/log';
 import { URI } from './uri';
@@ -143,6 +143,28 @@ describe('Graph', () => {
 
     ws.dispose();
     graph.dispose();
+  });
+});
+
+describe('Identifier computation', () => {
+  it('should compute the minimum identifier to resolve a name clash', () => {
+    const first = createTestNote({
+      uri: '/path/to/page-a.md',
+    });
+    const second = createTestNote({
+      uri: '/another/way/for/page-a.md',
+    });
+    const third = createTestNote({
+      uri: '/another/path/for/page-a.md',
+    });
+    const ws = new FoamWorkspace()
+      .set(first)
+      .set(second)
+      .set(third);
+
+    expect(ws.getIdentifier(first.uri)).toEqual('to/page-a');
+    expect(ws.getIdentifier(second.uri)).toEqual('way/for/page-a');
+    expect(ws.getIdentifier(third.uri)).toEqual('path/for/page-a');
   });
 });
 

--- a/packages/foam-vscode/src/core/model/workspace.ts
+++ b/packages/foam-vscode/src/core/model/workspace.ts
@@ -1,6 +1,6 @@
 import { Resource, ResourceLink } from './note';
 import { URI } from './uri';
-import { isSome, isNone } from '../utils';
+import { isSome, isNone, getShortestIdentifier } from '../utils';
 import { Emitter } from '../common/event';
 import { ResourceProvider } from './provider';
 import { IDisposable } from '../common/lifecycle';
@@ -93,6 +93,29 @@ export class FoamWorkspace implements IDisposable {
       }
     }
     return resources;
+  }
+
+  /**
+   * Returns the minimal identifier for the given resource, either in the whole
+   * workspace, or in the provided set of URIs
+   *
+   * @param forResource the resource to compute the identifier for
+   * @param amongst an optional parameter to limit the computation to the provided URIs.
+   *                If not provided the identifier will be computed against all the resources in the workspace
+   */
+  public getIdentifier(forResource: URI, amongst?: URI[]): string {
+    if (isNone(amongst)) {
+      amongst = [];
+      for (const res of this.resources.values()) {
+        amongst.push(res.uri);
+      }
+    }
+    const identifier = getShortestIdentifier(
+      forResource.path,
+      amongst.map(uri => uri.path)
+    );
+
+    return identifier.endsWith('.md') ? identifier.slice(0, -3) : identifier;
   }
 
   public find(resourceId: URI | string, reference?: URI): Resource | null {

--- a/packages/foam-vscode/src/core/utils/core.test.ts
+++ b/packages/foam-vscode/src/core/utils/core.test.ts
@@ -1,0 +1,45 @@
+import { getShortestIdentifier } from './core';
+import { extractHashtags } from './index';
+import { Logger } from './log';
+
+Logger.setLevel('error');
+
+describe('getShortestIdentifier', () => {
+  const needle = '/project/car/todo';
+
+  test.each([
+    [['/project/home/todo', '/other/todo', '/something/else'], 'car/todo'],
+    [['/family/car/todo', '/other/todo'], 'project/car/todo'],
+    [[], 'todo'],
+  ])('Find shortest identifier', (haystack, id) => {
+    expect(getShortestIdentifier(needle, haystack)).toEqual(id);
+  });
+
+  it('should ignore same string in haystack', () => {
+    const haystack = [
+      needle,
+      '/project/home/todo',
+      '/other/todo',
+      '/something/else',
+    ];
+
+    expect(getShortestIdentifier(needle, haystack)).toEqual('car/todo');
+  });
+
+  it('should return best guess when no solution is possible', () => {
+    /**
+     * In this case there is no way to uniquely identify the element,
+     * our fallback is to just return the "least wrong" result, basically
+     * a full identifier
+     * This is an edge case that should never happen in a real repo
+     */
+    const haystack = [
+      '/parent/' + needle,
+      '/project/home/todo',
+      '/other/todo',
+      '/something/else',
+    ];
+
+    expect(getShortestIdentifier(needle, haystack)).toEqual('project/car/todo');
+  });
+});

--- a/packages/foam-vscode/src/core/utils/core.ts
+++ b/packages/foam-vscode/src/core/utils/core.ts
@@ -25,3 +25,43 @@ export const hash = (text: string) =>
     .createHash('sha1')
     .update(text)
     .digest('hex');
+
+/**
+ * Returns the minimal identifier for the given string amongst others
+ *
+ * @param forValue the value to compute the identifier for
+ * @param amongst the set of strings within which to find the identifier
+ */
+export const getShortestIdentifier = (
+  forValue: string,
+  amongst: string[]
+): string => {
+  const needleTokens = forValue.split('/').reverse();
+  const haystack = amongst
+    .filter(value => value !== forValue)
+    .map(value => value.split('/').reverse());
+
+  let tokenIndex = 0;
+  let res = needleTokens;
+  while (tokenIndex < needleTokens.length) {
+    for (let j = haystack.length - 1; j >= 0; j--) {
+      if (
+        haystack[j].length < tokenIndex ||
+        needleTokens[tokenIndex] !== haystack[j][tokenIndex]
+      ) {
+        haystack.splice(j, 1);
+      }
+    }
+    if (haystack.length === 0) {
+      res = needleTokens.splice(0, tokenIndex + 1);
+      break;
+    }
+    tokenIndex++;
+  }
+  const identifier = res
+    .filter(token => token.trim() !== '')
+    .reverse()
+    .join('/');
+
+  return identifier;
+};

--- a/packages/foam-vscode/src/features/index.ts
+++ b/packages/foam-vscode/src/features/index.ts
@@ -17,10 +17,12 @@ import completionProvider from './link-completion';
 import tagCompletionProvider from './tag-completion';
 import linkDecorations from './document-decorator';
 import navigationProviders from './navigation-provider';
+import wikilinkDiagnostics from './wikilink-diagnostics';
 import { FoamFeature } from '../types';
 
 export const features: FoamFeature[] = [
   navigationProviders,
+  wikilinkDiagnostics,
   tagsExplorer,
   createReferences,
   openDailyNote,

--- a/packages/foam-vscode/src/features/wikilink-diagnostics.spec.ts
+++ b/packages/foam-vscode/src/features/wikilink-diagnostics.spec.ts
@@ -1,0 +1,119 @@
+import * as vscode from 'vscode';
+import { createMarkdownParser } from '../core/markdown-provider';
+import { FoamWorkspace } from '../core/model/workspace';
+import {
+  cleanWorkspace,
+  closeEditors,
+  createFile,
+  showInEditor,
+} from '../test/test-utils-vscode';
+import { updateDiagnostics } from './wikilink-diagnostics';
+
+describe('Wikilink diagnostics', () => {
+  beforeEach(async () => {
+    await cleanWorkspace();
+    await closeEditors();
+  });
+  it('should show no warnings when there are no conflicts', async () => {
+    const fileA = await createFile('This is the todo file', [
+      'project',
+      'car',
+      'todo.md',
+    ]);
+    const fileB = await createFile('This is linked to [[todo]]');
+
+    const parser = createMarkdownParser([]);
+    const ws = new FoamWorkspace()
+      .set(parser.parse(fileA.uri, fileA.content))
+      .set(parser.parse(fileB.uri, fileB.content));
+
+    await showInEditor(fileB.uri);
+
+    const collection = vscode.languages.createDiagnosticCollection('foam-test');
+    updateDiagnostics(
+      ws,
+      parser,
+      vscode.window.activeTextEditor.document,
+      collection
+    );
+    expect(countEntries(collection)).toEqual(0);
+  });
+
+  it('should show no warnings in non-md files', async () => {
+    const fileA = await createFile('This is the todo file', [
+      'project',
+      'car',
+      'todo.md',
+    ]);
+    const fileB = await createFile('This is the todo file', [
+      'another',
+      'todo.md',
+    ]);
+    const fileC = await createFile('Link in JS file to [[todo]]', [
+      'path',
+      'file.js',
+    ]);
+
+    const parser = createMarkdownParser([]);
+    const ws = new FoamWorkspace()
+      .set(parser.parse(fileA.uri, fileA.content))
+      .set(parser.parse(fileB.uri, fileB.content))
+      .set(parser.parse(fileC.uri, fileC.content));
+
+    await showInEditor(fileC.uri);
+
+    const collection = vscode.languages.createDiagnosticCollection('foam-test');
+    updateDiagnostics(
+      ws,
+      parser,
+      vscode.window.activeTextEditor.document,
+      collection
+    );
+    expect(countEntries(collection)).toEqual(0);
+  });
+
+  it('should show a warning when a link cannot be resolved', async () => {
+    const fileA = await createFile('This is the todo file', [
+      'project',
+      'car',
+      'todo.md',
+    ]);
+    const fileB = await createFile('This is the todo file', [
+      'another',
+      'todo.md',
+    ]);
+    const fileC = await createFile('Link to [[todo]]');
+
+    const parser = createMarkdownParser([]);
+    const ws = new FoamWorkspace()
+      .set(parser.parse(fileA.uri, fileA.content))
+      .set(parser.parse(fileB.uri, fileB.content))
+      .set(parser.parse(fileC.uri, fileC.content));
+
+    await showInEditor(fileC.uri);
+
+    const collection = vscode.languages.createDiagnosticCollection('foam-test');
+    updateDiagnostics(
+      ws,
+      parser,
+      vscode.window.activeTextEditor.document,
+      collection
+    );
+    expect(countEntries(collection)).toEqual(1);
+    const items = collection.get(vscode.window.activeTextEditor.document.uri);
+    expect(items.length).toEqual(1);
+    expect(items[0].range).toEqual(new vscode.Range(0, 8, 0, 16));
+    expect(items[0].severity).toEqual(vscode.DiagnosticSeverity.Warning);
+    expect(
+      items[0].relatedInformation.map(info => info.location.uri.path)
+    ).toEqual([fileA.uri.path, fileB.uri.path]);
+  });
+});
+
+const countEntries = (collection: vscode.DiagnosticCollection): number => {
+  let count = 0;
+  collection.forEach(i => {
+    count++;
+  });
+  return count;
+};

--- a/packages/foam-vscode/src/features/wikilink-diagnostics.ts
+++ b/packages/foam-vscode/src/features/wikilink-diagnostics.ts
@@ -1,0 +1,194 @@
+import { debounce } from 'lodash';
+import * as vscode from 'vscode';
+import { Foam } from '../core/model/foam';
+import { ResourceParser } from '../core/model/note';
+import { FoamWorkspace } from '../core/model/workspace';
+import { getShortestIdentifier } from '../core/utils';
+import { FoamFeature } from '../types';
+import { fromVsCodeUri, toVsCodeRange, toVsCodeUri } from '../utils/vsc-utils';
+
+const AMBIGUOUS_IDENTIFIER_CODE = 'ambiguous-identifier';
+
+interface FoamCommand<T> {
+  name: string;
+  execute: (params: T) => Promise<void>;
+}
+
+interface FindIdentifierCommandArgs {
+  range: vscode.Range;
+  target: vscode.Uri;
+  amongst: vscode.Uri[];
+}
+
+const FIND_IDENTIFER_COMMAND: FoamCommand<FindIdentifierCommandArgs> = {
+  name: 'foam:compute-identifier',
+  execute: async ({ target, amongst, range }) => {
+    if (vscode.window.activeTextEditor) {
+      let identifier = getShortestIdentifier(
+        target.path,
+        amongst.map(uri => uri.path)
+      );
+
+      identifier = identifier.endsWith('.md')
+        ? identifier.slice(0, -3)
+        : identifier;
+
+      vscode.window.activeTextEditor.edit(builder => {
+        builder.replace(range, identifier);
+      });
+    }
+  },
+};
+
+const feature: FoamFeature = {
+  activate: async (
+    context: vscode.ExtensionContext,
+    foamPromise: Promise<Foam>
+  ) => {
+    const collection = vscode.languages.createDiagnosticCollection('foam');
+    const debouncedUpdateDiagnostics = debounce(updateDiagnostics, 500);
+    const foam = await foamPromise;
+    if (vscode.window.activeTextEditor) {
+      updateDiagnostics(
+        foam.workspace,
+        foam.services.parser,
+        vscode.window.activeTextEditor.document,
+        collection
+      );
+    }
+    context.subscriptions.push(
+      vscode.window.onDidChangeActiveTextEditor(editor => {
+        if (editor) {
+          updateDiagnostics(
+            foam.workspace,
+            foam.services.parser,
+            editor.document,
+            collection
+          );
+        }
+      }),
+      vscode.workspace.onDidChangeTextDocument(event => {
+        debouncedUpdateDiagnostics(
+          foam.workspace,
+          foam.services.parser,
+          event.document,
+          collection
+        );
+      }),
+      vscode.languages.registerCodeActionsProvider(
+        'markdown',
+        new IdentifierResolver(),
+        {
+          providedCodeActionKinds: IdentifierResolver.providedCodeActionKinds,
+        }
+      ),
+      vscode.commands.registerCommand(
+        FIND_IDENTIFER_COMMAND.name,
+        FIND_IDENTIFER_COMMAND.execute
+      )
+    );
+  },
+};
+
+export function updateDiagnostics(
+  workspace: FoamWorkspace,
+  parser: ResourceParser,
+  document: vscode.TextDocument,
+  collection: vscode.DiagnosticCollection
+): void {
+  collection.clear();
+  if (document && document.languageId === 'markdown') {
+    const resource = parser.parse(
+      fromVsCodeUri(document.uri),
+      document.getText()
+    );
+
+    for (const link of resource.links) {
+      if (link.type === 'wikilink') {
+        const targets = workspace.listById(link.target);
+        if (targets.length > 1) {
+          collection.set(document.uri, [
+            {
+              code: AMBIGUOUS_IDENTIFIER_CODE,
+              message: 'Resource identifier is ambiguous',
+              range: toVsCodeRange(link.range),
+              severity: vscode.DiagnosticSeverity.Warning,
+              source: 'Foam',
+              relatedInformation: targets.map(
+                t =>
+                  new vscode.DiagnosticRelatedInformation(
+                    new vscode.Location(
+                      toVsCodeUri(t.uri),
+                      new vscode.Position(0, 0)
+                    ),
+                    `Possible target: ${vscode.workspace.asRelativePath(
+                      toVsCodeUri(t.uri)
+                    )}`
+                  )
+              ),
+            },
+          ]);
+        }
+      }
+    }
+  }
+}
+
+export class IdentifierResolver implements vscode.CodeActionProvider {
+  public static readonly providedCodeActionKinds = [
+    vscode.CodeActionKind.QuickFix,
+  ];
+
+  provideCodeActions(
+    document: vscode.TextDocument,
+    range: vscode.Range | vscode.Selection,
+    context: vscode.CodeActionContext,
+    token: vscode.CancellationToken
+  ): vscode.CodeAction[] {
+    return context.diagnostics
+      .filter(diagnostic => diagnostic.code === AMBIGUOUS_IDENTIFIER_CODE)
+      .reduce((acc, diagnostic) => {
+        const res: vscode.CodeAction[] = [];
+        const uris = diagnostic.relatedInformation.map(
+          info => info.location.uri
+        );
+        for (const item of diagnostic.relatedInformation) {
+          res.push(
+            this.createCommandCodeAction(diagnostic, item.location.uri, uris)
+          );
+        }
+        return [...acc, ...res];
+      }, [] as vscode.CodeAction[]);
+  }
+
+  private createCommandCodeAction(
+    diagnostic: vscode.Diagnostic,
+    target: vscode.Uri,
+    possibleTargets: vscode.Uri[]
+  ): vscode.CodeAction {
+    const action = new vscode.CodeAction(
+      `Use ${vscode.workspace.asRelativePath(target)}`,
+      vscode.CodeActionKind.QuickFix
+    );
+    action.command = {
+      command: FIND_IDENTIFER_COMMAND.name,
+      title: 'Link to this resource',
+      arguments: [
+        {
+          target: target,
+          amongst: possibleTargets,
+          range: new vscode.Range(
+            diagnostic.range.start.line,
+            diagnostic.range.start.character + 2,
+            diagnostic.range.end.line,
+            diagnostic.range.end.character - 2
+          ),
+        },
+      ],
+    };
+    action.diagnostics = [diagnostic];
+    return action;
+  }
+}
+
+export default feature;


### PR DESCRIPTION
When a wikilink can refer to more than a resource, flag it as a warning for the user.

The user can also quickly correct the error by pressing `cmd+.` and selecting which resource the link is meant for

![feature-wikilink-diagnostics](https://user-images.githubusercontent.com/457005/143075422-31cd8bdf-3ac5-4eed-a8a8-454107363fbb.gif)
