### PR TITLE
Add support for sections

### DIFF
--- a/packages/foam-vscode/README.md
+++ b/packages/foam-vscode/README.md
@@ -58,6 +58,11 @@ Embed the content from other notes.
 
 ![Note Embed](./assets/screenshots/feature-note-embed.gif)
 
+### Support for sections
+
+Foam supports autocompletion, navigation, embedding and diagnostics for note sections.
+Just use the standard wiki syntax of `[[resource#Section Title]]`.
+
 ### Link Alias
 
 Foam supports link aliasing, so you can have a `[[wikilink]]`, or a `[[wikilink|alias]]`.

--- a/packages/foam-vscode/src/core/markdown-provider.test.ts
+++ b/packages/foam-vscode/src/core/markdown-provider.test.ts
@@ -461,7 +461,7 @@ this is some text
   });
 });
 
-describe('Blocks plugin', () => {
+describe('Sections plugin', () => {
   it('should find sections within the note', () => {
     const note = createNoteFromMarkdown(
       '/dir1/page-a.md',
@@ -479,13 +479,13 @@ This is the content of section 1.1.
 This is the content of section 2.
       `
     );
-    expect(note.blocks).toHaveLength(3);
-    expect(note.blocks[0].label).toEqual('Section 1');
-    expect(note.blocks[0].range).toEqual(Range.create(1, 0, 9, 0));
-    expect(note.blocks[1].label).toEqual('Section 1.1');
-    expect(note.blocks[1].range).toEqual(Range.create(5, 0, 9, 0));
-    expect(note.blocks[2].label).toEqual('Section 2');
-    expect(note.blocks[2].range).toEqual(Range.create(9, 0, 13, 0));
+    expect(note.sections).toHaveLength(3);
+    expect(note.sections[0].label).toEqual('Section 1');
+    expect(note.sections[0].range).toEqual(Range.create(1, 0, 9, 0));
+    expect(note.sections[1].label).toEqual('Section 1.1');
+    expect(note.sections[1].range).toEqual(Range.create(5, 0, 9, 0));
+    expect(note.sections[2].label).toEqual('Section 2');
+    expect(note.sections[2].range).toEqual(Range.create(9, 0, 13, 0));
   });
 });
 

--- a/packages/foam-vscode/src/core/markdown-provider.test.ts
+++ b/packages/foam-vscode/src/core/markdown-provider.test.ts
@@ -485,7 +485,7 @@ This is the content of section 2.
     expect(note.blocks[1].label).toEqual('Section 1.1');
     expect(note.blocks[1].range).toEqual(Range.create(5, 0, 9, 0));
     expect(note.blocks[2].label).toEqual('Section 2');
-    expect(note.blocks[2].range).toEqual(Range.create(9, 0, 12, 6));
+    expect(note.blocks[2].range).toEqual(Range.create(9, 0, 13, 0));
   });
 });
 

--- a/packages/foam-vscode/src/core/markdown-provider.test.ts
+++ b/packages/foam-vscode/src/core/markdown-provider.test.ts
@@ -461,6 +461,34 @@ this is some text
   });
 });
 
+describe('Blocks plugin', () => {
+  it('should find sections within the note', () => {
+    const note = createNoteFromMarkdown(
+      '/dir1/page-a.md',
+      `
+# Section 1
+
+This is the content of section 1.
+
+## Section 1.1
+
+This is the content of section 1.1.
+
+# Section 2
+
+This is the content of section 2.
+      `
+    );
+    expect(note.blocks).toHaveLength(3);
+    expect(note.blocks[0].label).toEqual('Section 1');
+    expect(note.blocks[0].range).toEqual(Range.create(1, 0, 5, 0));
+    expect(note.blocks[1].label).toEqual('Section 1.1');
+    expect(note.blocks[1].range).toEqual(Range.create(5, 0, 9, 0));
+    expect(note.blocks[2].label).toEqual('Section 2');
+    expect(note.blocks[2].range).toEqual(Range.create(9, 0, 12, 6));
+  });
+});
+
 describe('parser plugins', () => {
   const testPlugin: ParserPlugin = {
     visit: (node, note) => {

--- a/packages/foam-vscode/src/core/markdown-provider.test.ts
+++ b/packages/foam-vscode/src/core/markdown-provider.test.ts
@@ -481,7 +481,7 @@ This is the content of section 2.
     );
     expect(note.blocks).toHaveLength(3);
     expect(note.blocks[0].label).toEqual('Section 1');
-    expect(note.blocks[0].range).toEqual(Range.create(1, 0, 5, 0));
+    expect(note.blocks[0].range).toEqual(Range.create(1, 0, 9, 0));
     expect(note.blocks[1].label).toEqual('Section 1.1');
     expect(note.blocks[1].range).toEqual(Range.create(5, 0, 9, 0));
     expect(note.blocks[2].label).toEqual('Section 2');

--- a/packages/foam-vscode/src/core/markdown-provider.ts
+++ b/packages/foam-vscode/src/core/markdown-provider.ts
@@ -237,7 +237,10 @@ const blocksPlugin: ParserPlugin = {
   },
   onDidVisitTree: (tree, note) => {
     if (note.blocks.length > 0) {
-      note.blocks[note.blocks.length - 1].range.end = note.source.end;
+      note.blocks[note.blocks.length - 1].range.end = Position.create(
+        note.source.end.line + 1,
+        0
+      );
     }
   },
 };

--- a/packages/foam-vscode/src/core/markdown-provider.ts
+++ b/packages/foam-vscode/src/core/markdown-provider.ts
@@ -110,9 +110,8 @@ export class MarkdownResourceProvider implements ResourceProvider {
   async readAsMarkdown(uri: URI): Promise<string | null> {
     let content = await this.dataStore.read(uri);
     if (isSome(content) && uri.fragment) {
-      const section = this.parser
-        .parse(uri, content)
-        .sections.find(b => b.label === uri.fragment);
+      const resource = this.parser.parse(uri, content);
+      const section = Resource.findSection(resource, uri.fragment);
       if (isSome(section)) {
         const rows = content.split('\n');
         content = rows

--- a/packages/foam-vscode/src/core/markdown-provider.ts
+++ b/packages/foam-vscode/src/core/markdown-provider.ts
@@ -151,15 +151,19 @@ export class MarkdownResourceProvider implements ResourceProvider {
             URI.placeholder(link.target);
 
           if (section && !URI.isPlaceholder(targetUri)) {
-            targetUri = URI.create({ ...targetUri, fragment: section });
+            targetUri = URI.withFragment(targetUri, section);
           }
         }
         break;
 
       case 'link':
+        const [target, section] = link.target.split('#');
         targetUri =
-          workspace.find(link.target, resource.uri)?.uri ??
+          workspace.find(target, resource.uri)?.uri ??
           URI.placeholder(URI.resolve(link.target, resource.uri).path);
+        if (section && !URI.isPlaceholder(targetUri)) {
+          targetUri = URI.withFragment(targetUri, section);
+        }
         break;
     }
     return targetUri;

--- a/packages/foam-vscode/src/core/markdown-provider.ts
+++ b/packages/foam-vscode/src/core/markdown-provider.ts
@@ -147,8 +147,10 @@ export class MarkdownResourceProvider implements ResourceProvider {
         } else {
           const [target, section] = link.target.split('#');
           targetUri =
-            workspace.find(target, resource.uri)?.uri ??
-            URI.placeholder(link.target);
+            target === ''
+              ? resource.uri
+              : workspace.find(target, resource.uri)?.uri ??
+                URI.placeholder(link.target);
 
           if (section) {
             targetUri = URI.withFragment(targetUri, section);

--- a/packages/foam-vscode/src/core/model/note.ts
+++ b/packages/foam-vscode/src/core/model/note.ts
@@ -38,12 +38,17 @@ export interface Tag {
   range: Range;
 }
 
+export interface NoteBlock {
+  label: string;
+  range: Range;
+}
+
 export interface Resource {
   uri: URI;
   type: string;
   title: string;
   properties: any;
-  // sections: NoteSection[]
+  blocks: NoteBlock[];
   tags: Tag[];
   links: ResourceLink[];
 

--- a/packages/foam-vscode/src/core/model/note.ts
+++ b/packages/foam-vscode/src/core/model/note.ts
@@ -38,7 +38,7 @@ export interface Tag {
   range: Range;
 }
 
-export interface NoteBlock {
+export interface Section {
   label: string;
   range: Range;
 }
@@ -48,7 +48,7 @@ export interface Resource {
   type: string;
   title: string;
   properties: any;
-  blocks: NoteBlock[];
+  sections: Section[];
   tags: Tag[];
   links: ResourceLink[];
 

--- a/packages/foam-vscode/src/core/model/note.ts
+++ b/packages/foam-vscode/src/core/model/note.ts
@@ -79,4 +79,11 @@ export abstract class Resource {
       typeof (thing as Resource).links === 'object'
     );
   }
+
+  public static findSection(resource: Resource, label: string): Section | null {
+    if (label) {
+      return resource.sections.find(s => s.label === label) ?? null;
+    }
+    return null;
+  }
 }

--- a/packages/foam-vscode/src/core/model/uri.test.ts
+++ b/packages/foam-vscode/src/core/model/uri.test.ts
@@ -11,7 +11,7 @@ describe('Foam URI', () => {
       ['https://www.google.com', URI.parse('https://www.google.com')],
       ['/path/to/a/file.md', URI.file('/path/to/a/file.md')],
       ['../relative/file.md', URI.file('/path/relative/file.md')],
-      ['#section', URI.create({ ...base, fragment: 'section' })],
+      ['#section', URI.withFragment(base, 'section')],
       [
         '../relative/file.md#section',
         URI.parse('file:/path/relative/file.md#section'),

--- a/packages/foam-vscode/src/core/model/uri.ts
+++ b/packages/foam-vscode/src/core/model/uri.ts
@@ -137,6 +137,13 @@ export abstract class URI {
     });
   }
 
+  static withFragment(uri: URI, fragment: string): URI {
+    return URI.create({
+      ...uri,
+      fragment,
+    });
+  }
+
   static relativePath(source: URI, target: URI): string {
     const relativePath = posix.relative(
       posix.dirname(source.path),

--- a/packages/foam-vscode/src/core/model/workspace.test.ts
+++ b/packages/foam-vscode/src/core/model/workspace.test.ts
@@ -182,6 +182,26 @@ describe('Identifier computation', () => {
     expect(ws.getIdentifier(second.uri)).toEqual('way/for/page-a');
     expect(ws.getIdentifier(third.uri)).toEqual('path/for/page-a');
   });
+
+  it('should support sections in identifier computation', () => {
+    const first = createTestNote({
+      uri: '/path/to/page-a.md',
+    });
+    const second = createTestNote({
+      uri: '/another/way/for/page-a.md',
+    });
+    const third = createTestNote({
+      uri: '/another/path/for/page-a.md',
+    });
+    const ws = new FoamWorkspace()
+      .set(first)
+      .set(second)
+      .set(third);
+
+    expect(
+      ws.getIdentifier(URI.withFragment(first.uri, 'section name'))
+    ).toEqual('to/page-a#section name');
+  });
 });
 
 describe('Wikilinks', () => {

--- a/packages/foam-vscode/src/core/model/workspace.test.ts
+++ b/packages/foam-vscode/src/core/model/workspace.test.ts
@@ -78,6 +78,15 @@ describe('Workspace resources', () => {
       .set(createTestNote({ uri: 'file.md' }));
     expect(ws.listById('file').length).toEqual(1);
   });
+
+  it('should include fragment when finding resource URI', () => {
+    const ws = createTestWorkspace()
+      .set(createTestNote({ uri: 'test-file.md' }))
+      .set(createTestNote({ uri: 'file.md' }));
+
+    const res = ws.find('test-file#my-section');
+    expect(res.uri.fragment).toEqual('my-section');
+  });
 });
 
 describe('Graph', () => {

--- a/packages/foam-vscode/src/core/model/workspace.ts
+++ b/packages/foam-vscode/src/core/model/workspace.ts
@@ -112,14 +112,20 @@ export class FoamWorkspace implements IDisposable {
         }
       }
     }
-    const identifier = getShortestIdentifier(
+    let identifier = getShortestIdentifier(
       forResource.path,
       amongst.map(uri => uri.path)
     );
 
-    // TODO maybe we should support sections here too..
+    identifier = identifier.endsWith('.md')
+      ? identifier.slice(0, -3)
+      : identifier;
 
-    return identifier.endsWith('.md') ? identifier.slice(0, -3) : identifier;
+    if (forResource.fragment) {
+      identifier += `#${forResource.fragment}`;
+    }
+
+    return identifier;
   }
 
   public find(resourceId: URI | string, reference?: URI): Resource | null {

--- a/packages/foam-vscode/src/core/model/workspace.ts
+++ b/packages/foam-vscode/src/core/model/workspace.ts
@@ -174,7 +174,7 @@ export class FoamWorkspace implements IDisposable {
     }
     return {
       ...resource,
-      uri: URI.create({ ...resource.uri, fragment }),
+      uri: URI.withFragment(resource.uri, fragment),
     };
   }
 

--- a/packages/foam-vscode/src/core/model/workspace.ts
+++ b/packages/foam-vscode/src/core/model/workspace.ts
@@ -63,9 +63,7 @@ export class FoamWorkspace implements IDisposable {
   }
 
   public exists(uri: URI): boolean {
-    return (
-      !URI.isPlaceholder(uri) && isSome(this.resources.get(normalize(uri.path)))
-    );
+    return isSome(this.find(uri));
   }
 
   public list(): Resource[] {
@@ -132,9 +130,9 @@ export class FoamWorkspace implements IDisposable {
     const refType = getReferenceType(resourceId);
     if (refType === 'uri') {
       const uri = resourceId as URI;
-      return this.exists(uri)
-        ? this.resources.get(normalize(uri.path)) ?? null
-        : null;
+      return URI.isPlaceholder(uri)
+        ? null
+        : this.resources.get(normalize(uri.path)) ?? null;
     }
 
     const [target, fragment] = (resourceId as string).split('#');

--- a/packages/foam-vscode/src/core/utils/core.test.ts
+++ b/packages/foam-vscode/src/core/utils/core.test.ts
@@ -1,5 +1,4 @@
 import { getShortestIdentifier } from './core';
-import { extractHashtags } from './index';
 import { Logger } from './log';
 
 Logger.setLevel('error');

--- a/packages/foam-vscode/src/features/link-completion.ts
+++ b/packages/foam-vscode/src/features/link-completion.ts
@@ -52,7 +52,7 @@ export class SectionCompletionProvider
     const resourceId = match[1].slice(0, -1);
     const resource = this.ws.find(resourceId);
     if (resource) {
-      const items = resource.blocks.map(b => {
+      const items = resource.sections.map(b => {
         return new ResourceCompletionItem(
           b.label,
           vscode.CompletionItemKind.Text,

--- a/packages/foam-vscode/src/features/link-completion.ts
+++ b/packages/foam-vscode/src/features/link-completion.ts
@@ -57,7 +57,7 @@ export class SectionCompletionProvider
         return new ResourceCompletionItem(
           b.label,
           vscode.CompletionItemKind.Text,
-          URI.create({ ...resource.uri, fragment: b.label })
+          URI.withFragment(resource.uri, b.label)
         );
       });
       return new vscode.CompletionList(items);

--- a/packages/foam-vscode/src/features/link-completion.ts
+++ b/packages/foam-vscode/src/features/link-completion.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode';
 import { Foam } from '../core/model/foam';
 import { FoamGraph } from '../core/model/graph';
-import { Resource } from '../core/model/note';
 import { URI } from '../core/model/uri';
 import { FoamWorkspace } from '../core/model/workspace';
 import { FoamFeature } from '../types';

--- a/packages/foam-vscode/src/features/navigation-provider.ts
+++ b/packages/foam-vscode/src/features/navigation-provider.ts
@@ -5,7 +5,7 @@ import { toVsCodeRange, toVsCodeUri } from '../utils/vsc-utils';
 import { OPEN_COMMAND } from './utility-commands';
 import { Foam } from '../core/model/foam';
 import { FoamWorkspace } from '../core/model/workspace';
-import { ResourceLink, ResourceParser } from '../core/model/note';
+import { Resource, ResourceLink, ResourceParser } from '../core/model/note';
 import { URI } from '../core/model/uri';
 import { Range } from '../core/model/range';
 import { FoamGraph } from '../core/model/graph';
@@ -114,13 +114,9 @@ export class NavigationProvider
       targetResource.source.contentStart,
       targetResource.source.end
     );
-    if (uri.fragment) {
-      const section = targetResource.sections.find(
-        b => b.label === uri.fragment
-      );
-      if (section) {
-        targetRange = section.range;
-      }
+    const section = Resource.findSection(targetResource, uri.fragment);
+    if (section) {
+      targetRange = section.range;
     }
     const result: vscode.LocationLink = {
       originSelectionRange: toVsCodeRange(targetLink.range),

--- a/packages/foam-vscode/src/features/navigation-provider.ts
+++ b/packages/foam-vscode/src/features/navigation-provider.ts
@@ -110,20 +110,22 @@ export class NavigationProvider
 
     const targetResource = this.workspace.get(uri);
 
+    let targetRange = Range.createFromPosition(
+      targetResource.source.contentStart,
+      targetResource.source.end
+    );
+    if (uri.fragment) {
+      const block = targetResource.blocks.find(b => b.label === uri.fragment);
+      if (block) {
+        targetRange = block.range;
+      }
+    }
     const result: vscode.LocationLink = {
       originSelectionRange: toVsCodeRange(targetLink.range),
       targetUri: toVsCodeUri(uri),
-      targetRange: toVsCodeRange(
-        Range.createFromPosition(
-          targetResource.source.contentStart,
-          targetResource.source.end
-        )
-      ),
+      targetRange: toVsCodeRange(targetRange),
       targetSelectionRange: toVsCodeRange(
-        Range.createFromPosition(
-          targetResource.source.contentStart,
-          targetResource.source.contentStart
-        )
+        Range.createFromPosition(targetRange.start, targetRange.start)
       ),
     };
     return [result];

--- a/packages/foam-vscode/src/features/navigation-provider.ts
+++ b/packages/foam-vscode/src/features/navigation-provider.ts
@@ -115,9 +115,11 @@ export class NavigationProvider
       targetResource.source.end
     );
     if (uri.fragment) {
-      const block = targetResource.blocks.find(b => b.label === uri.fragment);
-      if (block) {
-        targetRange = block.range;
+      const section = targetResource.sections.find(
+        b => b.label === uri.fragment
+      );
+      if (section) {
+        targetRange = section.range;
       }
     }
     const result: vscode.LocationLink = {

--- a/packages/foam-vscode/src/features/preview-navigation.spec.ts
+++ b/packages/foam-vscode/src/features/preview-navigation.spec.ts
@@ -1,7 +1,12 @@
 import MarkdownIt from 'markdown-it';
+import { createMarkdownParser } from '../core/markdown-provider';
 import { FoamWorkspace } from '../core/model/workspace';
 import { createTestNote } from '../test/test-utils';
-import { getUriInWorkspace } from '../test/test-utils-vscode';
+import {
+  createFile,
+  deleteFile,
+  getUriInWorkspace,
+} from '../test/test-utils-vscode';
 import {
   markdownItWithFoamLinks,
   markdownItWithFoamTags,
@@ -39,12 +44,7 @@ describe('Link generation in preview', () => {
 });
 
 describe('Stylable tag generation in preview', () => {
-  const noteB = createTestNote({
-    uri: 'note-b.md',
-    title: 'Note B',
-  });
-  const ws = new FoamWorkspace().set(noteB);
-  const md = markdownItWithFoamTags(MarkdownIt(), ws);
+  const md = markdownItWithFoamTags(MarkdownIt(), new FoamWorkspace());
 
   it('transforms a string containing multiple tags to a stylable html element', () => {
     expect(md.render(`Lorem #ipsum dolor #sit`)).toMatch(
@@ -60,25 +60,14 @@ describe('Stylable tag generation in preview', () => {
 });
 
 describe('Displaying included notes in preview', () => {
-  const noteA = createTestNote({
-    uri: 'note-a.md',
-    text: 'This is the text of note A',
-  });
-  const noteC = createTestNote({
-    uri: 'note-c.md',
-    text: 'This is the text of note C which includes ![[note-d]]',
-  });
-  const noteD = createTestNote({
-    uri: 'note-d.md',
-    text: 'This is the text of note D which includes ![[note-c]]',
-  });
-  const ws = new FoamWorkspace()
-    .set(noteA)
-    .set(noteC)
-    .set(noteD);
-  const md = markdownItWithNoteInclusion(MarkdownIt(), ws);
+  it('should render an included note', () => {
+    const note = createTestNote({
+      uri: 'note-a.md',
+      text: 'This is the text of note A',
+    });
+    const ws = new FoamWorkspace().set(note);
+    const md = markdownItWithNoteInclusion(MarkdownIt(), ws);
 
-  it('renders an included note', () => {
     expect(
       md.render(`This is the root node. 
 
@@ -90,20 +79,62 @@ describe('Displaying included notes in preview', () => {
     );
   });
 
-  it('displays the syntax when a note is not found', () => {
+  it('should render an included section', async () => {
+    // here we use createFile as the test note doesn't fill in
+    // all the metadata we need
+    const note = await createFile(
+      `
+# Section 1
+This is the first section of note D
+
+# Section 2 
+This is the second section of note D
+
+# Section 3
+This is the third section of note D
+    `,
+      ['note-e.md']
+    );
+    const parser = createMarkdownParser([]);
+    const ws = new FoamWorkspace().set(parser.parse(note.uri, note.content));
+    const md = markdownItWithNoteInclusion(MarkdownIt(), ws);
+
     expect(
-      md.render(`This is the root node.
-    ![[note-b]]`)
+      md.render(`This is the root node. 
+
+ ![[note-e#Section 2]]`)
     ).toMatch(
-      `<p>This is the root node.
-![[note-b]]</p>
-`
+      `<p>This is the root node.</p>
+<p><h1>Section 2</h1>
+<p>This is the second section of note D</p>
+</p>`
+    );
+
+    await deleteFile(note);
+  });
+
+  it('should fallback to the bare text when the note is not found', () => {
+    const md = markdownItWithNoteInclusion(MarkdownIt(), new FoamWorkspace());
+
+    expect(md.render(`This is the root node. ![[non-existing-note]]`)).toMatch(
+      `<p>This is the root node. ![[non-existing-note]]</p>`
     );
   });
 
-  it('displays a warning in case of cyclical inclusions', () => {
-    expect(md.render(noteD.source.text)).toMatch(
-      `<p>This is the text of note D which includes <p>This is the text of note C which includes <p>This is the text of note D which includes <div class="foam-cyclic-link-warning">Cyclic link detected for wikilink: note-c</div></p>
+  it('should display a warning in case of cyclical inclusions', () => {
+    const noteA = createTestNote({
+      uri: 'note-a.md',
+      text: 'This is the text of note A which includes ![[note-b]]',
+    });
+    const noteB = createTestNote({
+      uri: 'note-b.md',
+      text: 'This is the text of note B which includes ![[note-a]]',
+    });
+    const ws = new FoamWorkspace().set(noteA).set(noteB);
+    const md = markdownItWithNoteInclusion(MarkdownIt(), ws);
+
+    expect(md.render(noteB.source.text)).toMatch(
+      `<p>This is the text of note B which includes <p>This is the text of note A which includes <p>This is the text of note B which includes <div class="foam-cyclic-link-warning">Cyclic link detected for wikilink: note-a</div></p>
 </p>
 </p>
 `

--- a/packages/foam-vscode/src/features/preview-navigation.ts
+++ b/packages/foam-vscode/src/features/preview-navigation.ts
@@ -45,16 +45,17 @@ export const markdownItWithNoteInclusion = (
           return `![[${wikilink}]]`;
         }
 
-        const cyclicLinkDetected = refsStack.includes(wikilink);
+        const cyclicLinkDetected = refsStack.includes(
+          includedNote.uri.path.toLocaleLowerCase()
+        );
 
         if (!cyclicLinkDetected) {
-          refsStack.push(wikilink.toLowerCase());
+          refsStack.push(includedNote.uri.path.toLocaleLowerCase());
         }
 
         if (cyclicLinkDetected) {
           return `<div class="foam-cyclic-link-warning">Cyclic link detected for wikilink: ${wikilink}</div>`;
         } else {
-          refsStack.pop();
           let content = includedNote.source.text;
           if (isSome(content) && includedNote.uri.fragment) {
             const block = includedNote.blocks.find(
@@ -67,7 +68,9 @@ export const markdownItWithNoteInclusion = (
                 .join('\n');
             }
           }
-          return md.render(content);
+          const html = md.render(content);
+          refsStack.pop();
+          return html;
         }
       } catch (e) {
         Logger.error(

--- a/packages/foam-vscode/src/features/preview-navigation.ts
+++ b/packages/foam-vscode/src/features/preview-navigation.ts
@@ -6,6 +6,7 @@ import { Foam } from '../core/model/foam';
 import { FoamWorkspace } from '../core/model/workspace';
 import { Logger } from '../core/utils/log';
 import { toVsCodeUri } from '../utils/vsc-utils';
+import { Resource } from '../core/model/note';
 
 const ALIAS_DIVIDER_CHAR = '|';
 const refsStack: string[] = [];
@@ -57,16 +58,15 @@ export const markdownItWithNoteInclusion = (
           return `<div class="foam-cyclic-link-warning">Cyclic link detected for wikilink: ${wikilink}</div>`;
         } else {
           let content = includedNote.source.text;
-          if (isSome(content) && includedNote.uri.fragment) {
-            const section = includedNote.sections.find(
-              b => b.label === includedNote.uri.fragment
-            );
-            if (isSome(section)) {
-              const rows = content.split('\n');
-              content = rows
-                .slice(section.range.start.line, section.range.end.line)
-                .join('\n');
-            }
+          const section = Resource.findSection(
+            includedNote,
+            includedNote.uri.fragment
+          );
+          if (isSome(section)) {
+            const rows = content.split('\n');
+            content = rows
+              .slice(section.range.start.line, section.range.end.line)
+              .join('\n');
           }
           const html = md.render(content);
           refsStack.pop();

--- a/packages/foam-vscode/src/features/preview-navigation.ts
+++ b/packages/foam-vscode/src/features/preview-navigation.ts
@@ -58,13 +58,13 @@ export const markdownItWithNoteInclusion = (
         } else {
           let content = includedNote.source.text;
           if (isSome(content) && includedNote.uri.fragment) {
-            const block = includedNote.blocks.find(
+            const section = includedNote.sections.find(
               b => b.label === includedNote.uri.fragment
             );
-            if (isSome(block)) {
+            if (isSome(section)) {
               const rows = content.split('\n');
               content = rows
-                .slice(block.range.start.line, block.range.end.line)
+                .slice(section.range.start.line, section.range.end.line)
                 .join('\n');
             }
           }

--- a/packages/foam-vscode/src/features/tag-completion.spec.ts
+++ b/packages/foam-vscode/src/features/tag-completion.spec.ts
@@ -79,4 +79,18 @@ describe('Tag Completion', () => {
     expect(foamTags.tags.get('primary')).toBeTruthy();
     expect(tags.items.length).toEqual(3);
   });
+
+  it('should not provide suggestions when inside a wikilink', async () => {
+    const { uri } = await createFile('[[#prim');
+    const { doc } = await showInEditor(uri);
+    const provider = new TagCompletionProvider(foamTags);
+
+    const tags = await provider.provideCompletionItems(
+      doc,
+      new vscode.Position(0, 7)
+    );
+
+    expect(foamTags.tags.get('primary')).toBeTruthy();
+    expect(tags).toBeNull();
+  });
 });

--- a/packages/foam-vscode/src/features/tag-completion.ts
+++ b/packages/foam-vscode/src/features/tag-completion.ts
@@ -3,6 +3,9 @@ import { Foam } from '../core/model/foam';
 import { FoamTags } from '../core/model/tags';
 import { FoamFeature } from '../types';
 import { mdDocSelector } from '../utils';
+import { SECTION_REGEX } from './link-completion';
+
+export const TAG_REGEX = /#(.*)/;
 
 const feature: FoamFeature = {
   activate: async (
@@ -32,7 +35,8 @@ export class TagCompletionProvider
       .lineAt(position)
       .text.substr(0, position.character);
 
-    const requiresAutocomplete = cursorPrefix.match(/#(.*)/);
+    const requiresAutocomplete =
+      cursorPrefix.match(TAG_REGEX) && !cursorPrefix.match(SECTION_REGEX);
 
     if (!requiresAutocomplete) {
       return null;

--- a/packages/foam-vscode/src/features/utility-commands.ts
+++ b/packages/foam-vscode/src/features/utility-commands.ts
@@ -9,6 +9,7 @@ import {
 } from '../utils/vsc-utils';
 import { NoteFactory } from '../services/templates';
 import { Foam } from '../core/model/foam';
+import { Resource } from '../core/model/note';
 
 export const OPEN_COMMAND = {
   command: 'foam-vscode.open-resource',
@@ -33,9 +34,7 @@ const feature: FoamFeature = {
               if (uri.fragment) {
                 const foam = await foamPromise;
                 const resource = foam.workspace.get(uri);
-                const section = resource.sections.find(
-                  b => b.label === uri.fragment
-                );
+                const section = Resource.findSection(resource, uri.fragment);
                 if (section) {
                   selection = toVsCodeRange(section.range);
                 }

--- a/packages/foam-vscode/src/features/utility-commands.ts
+++ b/packages/foam-vscode/src/features/utility-commands.ts
@@ -28,11 +28,11 @@ const feature: FoamFeature = {
               if (uri.fragment) {
                 const foam = await foamPromise;
                 const resource = foam.workspace.get(uri);
-                const block = resource.blocks.find(
+                const section = resource.sections.find(
                   b => b.label === uri.fragment
                 );
-                if (block) {
-                  selection = toVsCodeRange(block.range);
+                if (section) {
+                  selection = toVsCodeRange(section.range);
                 }
               }
               return vscode.commands.executeCommand(

--- a/packages/foam-vscode/src/features/utility-commands.ts
+++ b/packages/foam-vscode/src/features/utility-commands.ts
@@ -1,7 +1,12 @@
 import * as vscode from 'vscode';
 import { FoamFeature } from '../types';
 import { URI } from '../core/model/uri';
-import { fromVsCodeUri, toVsCodeRange, toVsCodeUri } from '../utils/vsc-utils';
+import {
+  fromVsCodeUri,
+  toVsCodePosition,
+  toVsCodeRange,
+  toVsCodeUri,
+} from '../utils/vsc-utils';
 import { NoteFactory } from '../services/templates';
 import { Foam } from '../core/model/foam';
 
@@ -35,13 +40,15 @@ const feature: FoamFeature = {
                   selection = toVsCodeRange(section.range);
                 }
               }
-              return vscode.commands.executeCommand(
-                'vscode.open',
-                toVsCodeUri(uri),
-                {
-                  selection: selection,
-                }
-              );
+
+              const targetUri =
+                uri.path === vscode.window.activeTextEditor?.document.uri.path
+                  ? vscode.window.activeTextEditor?.document.uri
+                  : toVsCodeUri(uri);
+
+              return vscode.commands.executeCommand('vscode.open', targetUri, {
+                selection: selection,
+              });
 
             case 'placeholder':
               const title = uri.path.split('/').slice(-1)[0];

--- a/packages/foam-vscode/src/features/utility-commands.ts
+++ b/packages/foam-vscode/src/features/utility-commands.ts
@@ -1,41 +1,13 @@
 import * as vscode from 'vscode';
 import { FoamFeature } from '../types';
 import { URI } from '../core/model/uri';
-import { fromVsCodeUri, toVsCodeUri } from '../utils/vsc-utils';
+import { fromVsCodeUri, toVsCodeRange, toVsCodeUri } from '../utils/vsc-utils';
 import { NoteFactory } from '../services/templates';
+import { Foam } from '../core/model/foam';
 
 export const OPEN_COMMAND = {
   command: 'foam-vscode.open-resource',
   title: 'Foam: Open Resource',
-
-  execute: async (params: { uri: URI }) => {
-    const { uri } = params;
-    switch (uri.scheme) {
-      case 'file':
-        return vscode.commands.executeCommand('vscode.open', toVsCodeUri(uri));
-
-      case 'placeholder':
-        const title = uri.path.split('/').slice(-1)[0];
-
-        const basedir =
-          vscode.workspace.workspaceFolders.length > 0
-            ? fromVsCodeUri(vscode.workspace.workspaceFolders[0].uri)
-            : fromVsCodeUri(vscode.window.activeTextEditor?.document.uri)
-            ? URI.getDir(
-                fromVsCodeUri(vscode.window.activeTextEditor!.document.uri)
-              )
-            : undefined;
-
-        if (basedir === undefined) {
-          return;
-        }
-
-        const target = URI.createResourceUriFromPlaceholder(basedir, uri);
-
-        await NoteFactory.createForPlaceholderWikilink(title, target);
-        return;
-    }
-  },
 
   asURI: (uri: URI) =>
     vscode.Uri.parse(`command:${OPEN_COMMAND.command}`).with({
@@ -44,11 +16,57 @@ export const OPEN_COMMAND = {
 };
 
 const feature: FoamFeature = {
-  activate: (context: vscode.ExtensionContext) => {
+  activate: (context: vscode.ExtensionContext, foamPromise: Promise<Foam>) => {
     context.subscriptions.push(
       vscode.commands.registerCommand(
         OPEN_COMMAND.command,
-        OPEN_COMMAND.execute
+        async (params: { uri: URI }) => {
+          const { uri } = params;
+          switch (uri.scheme) {
+            case 'file':
+              let selection = new vscode.Range(1, 0, 1, 0);
+              if (uri.fragment) {
+                const foam = await foamPromise;
+                const resource = foam.workspace.get(uri);
+                const block = resource.blocks.find(
+                  b => b.label === uri.fragment
+                );
+                if (block) {
+                  selection = toVsCodeRange(block.range);
+                }
+              }
+              return vscode.commands.executeCommand(
+                'vscode.open',
+                toVsCodeUri(uri),
+                {
+                  selection: selection,
+                }
+              );
+
+            case 'placeholder':
+              const title = uri.path.split('/').slice(-1)[0];
+
+              const basedir =
+                vscode.workspace.workspaceFolders.length > 0
+                  ? fromVsCodeUri(vscode.workspace.workspaceFolders[0].uri)
+                  : fromVsCodeUri(vscode.window.activeTextEditor?.document.uri)
+                  ? URI.getDir(
+                      fromVsCodeUri(
+                        vscode.window.activeTextEditor!.document.uri
+                      )
+                    )
+                  : undefined;
+
+              if (basedir === undefined) {
+                return;
+              }
+
+              const target = URI.createResourceUriFromPlaceholder(basedir, uri);
+
+              await NoteFactory.createForPlaceholderWikilink(title, target);
+              return;
+          }
+        }
       )
     );
   },

--- a/packages/foam-vscode/src/features/wikilink-diagnostics.ts
+++ b/packages/foam-vscode/src/features/wikilink-diagnostics.ts
@@ -1,11 +1,12 @@
 import { debounce } from 'lodash';
 import * as vscode from 'vscode';
 import { Foam } from '../core/model/foam';
-import { ResourceParser } from '../core/model/note';
+import { Resource, ResourceParser } from '../core/model/note';
 import { Range } from '../core/model/range';
 import { FoamWorkspace } from '../core/model/workspace';
 import { getShortestIdentifier } from '../core/utils';
 import { FoamFeature } from '../types';
+import { isNone } from '../utils';
 import {
   fromVsCodeUri,
   toVsCodePosition,
@@ -156,8 +157,7 @@ export function updateDiagnostics(
         }
         if (section && targets.length === 1) {
           const resource = targets[0];
-          const found = resource.sections.find(b => b.label === section);
-          if (!found) {
+          if (isNone(Resource.findSection(resource, section))) {
             const range = Range.create(
               link.range.start.line,
               link.range.start.character + target.length + 2,

--- a/packages/foam-vscode/src/features/wikilink-diagnostics.ts
+++ b/packages/foam-vscode/src/features/wikilink-diagnostics.ts
@@ -185,7 +185,9 @@ export function updateDiagnostics(
         }
       }
     }
-    collection.set(document.uri, result);
+    if (result.length > 0) {
+      collection.set(document.uri, result);
+    }
   }
 }
 

--- a/packages/foam-vscode/src/features/wikilink-diagnostics.ts
+++ b/packages/foam-vscode/src/features/wikilink-diagnostics.ts
@@ -40,7 +40,7 @@ const FIND_IDENTIFER_COMMAND: FoamCommand<FindIdentifierCommandArgs> = {
         ? identifier.slice(0, -3)
         : identifier;
 
-      vscode.window.activeTextEditor.edit(builder => {
+      await vscode.window.activeTextEditor.edit(builder => {
         builder.replace(range, identifier);
       });
     }
@@ -55,7 +55,7 @@ interface ReplaceTextCommandArgs {
 const REPLACE_TEXT_COMMAND: FoamCommand<ReplaceTextCommandArgs> = {
   name: 'foam:replace-text',
   execute: async ({ range, value }) => {
-    vscode.window.activeTextEditor.edit(builder => {
+    await vscode.window.activeTextEditor.edit(builder => {
       builder.replace(range, value);
     });
   },

--- a/packages/foam-vscode/src/features/wikilink-diagnostics.ts
+++ b/packages/foam-vscode/src/features/wikilink-diagnostics.ts
@@ -2,12 +2,19 @@ import { debounce } from 'lodash';
 import * as vscode from 'vscode';
 import { Foam } from '../core/model/foam';
 import { ResourceParser } from '../core/model/note';
+import { Range } from '../core/model/range';
 import { FoamWorkspace } from '../core/model/workspace';
 import { getShortestIdentifier } from '../core/utils';
 import { FoamFeature } from '../types';
-import { fromVsCodeUri, toVsCodeRange, toVsCodeUri } from '../utils/vsc-utils';
+import {
+  fromVsCodeUri,
+  toVsCodePosition,
+  toVsCodeRange,
+  toVsCodeUri,
+} from '../utils/vsc-utils';
 
 const AMBIGUOUS_IDENTIFIER_CODE = 'ambiguous-identifier';
+const UNKNOWN_BLOCK_CODE = 'unknown-block';
 
 interface FoamCommand<T> {
   name: string;
@@ -37,6 +44,20 @@ const FIND_IDENTIFER_COMMAND: FoamCommand<FindIdentifierCommandArgs> = {
         builder.replace(range, identifier);
       });
     }
+  },
+};
+
+interface ReplaceTextCommandArgs {
+  range: vscode.Range;
+  value: string;
+}
+
+const REPLACE_TEXT_COMMAND: FoamCommand<ReplaceTextCommandArgs> = {
+  name: 'foam:replace-text',
+  execute: async ({ range, value }) => {
+    vscode.window.activeTextEditor.edit(builder => {
+      builder.replace(range, value);
+    });
   },
 };
 
@@ -85,6 +106,10 @@ const feature: FoamFeature = {
       vscode.commands.registerCommand(
         FIND_IDENTIFER_COMMAND.name,
         FIND_IDENTIFER_COMMAND.execute
+      ),
+      vscode.commands.registerCommand(
+        REPLACE_TEXT_COMMAND.name,
+        REPLACE_TEXT_COMMAND.execute
       )
     );
   },
@@ -97,6 +122,7 @@ export function updateDiagnostics(
   collection: vscode.DiagnosticCollection
 ): void {
   collection.clear();
+  const result = [];
   if (document && document.languageId === 'markdown') {
     const resource = parser.parse(
       fromVsCodeUri(document.uri),
@@ -105,32 +131,61 @@ export function updateDiagnostics(
 
     for (const link of resource.links) {
       if (link.type === 'wikilink') {
-        const targets = workspace.listById(link.target);
+        const [target, section] = link.target.split('#');
+        const targets = workspace.listById(target);
         if (targets.length > 1) {
-          collection.set(document.uri, [
-            {
-              code: AMBIGUOUS_IDENTIFIER_CODE,
-              message: 'Resource identifier is ambiguous',
-              range: toVsCodeRange(link.range),
+          result.push({
+            code: AMBIGUOUS_IDENTIFIER_CODE,
+            message: 'Resource identifier is ambiguous',
+            range: toVsCodeRange(link.range),
+            severity: vscode.DiagnosticSeverity.Warning,
+            source: 'Foam',
+            relatedInformation: targets.map(
+              t =>
+                new vscode.DiagnosticRelatedInformation(
+                  new vscode.Location(
+                    toVsCodeUri(t.uri),
+                    new vscode.Position(0, 0)
+                  ),
+                  `Possible target: ${vscode.workspace.asRelativePath(
+                    toVsCodeUri(t.uri)
+                  )}`
+                )
+            ),
+          });
+        }
+        if (section && targets.length === 1) {
+          const resource = targets[0];
+          const found = resource.blocks.find(b => b.label === section);
+          if (!found) {
+            const range = Range.create(
+              link.range.start.line,
+              link.range.start.character + target.length + 2,
+              link.range.end.line,
+              link.range.end.character
+            );
+            result.push({
+              code: UNKNOWN_BLOCK_CODE,
+              message: `Cannot find section "${section}" in document, available sections are:`,
+              range: toVsCodeRange(range),
               severity: vscode.DiagnosticSeverity.Warning,
               source: 'Foam',
-              relatedInformation: targets.map(
-                t =>
+              relatedInformation: resource.blocks.map(
+                b =>
                   new vscode.DiagnosticRelatedInformation(
                     new vscode.Location(
-                      toVsCodeUri(t.uri),
-                      new vscode.Position(0, 0)
+                      toVsCodeUri(resource.uri),
+                      toVsCodePosition(b.range.start)
                     ),
-                    `Possible target: ${vscode.workspace.asRelativePath(
-                      toVsCodeUri(t.uri)
-                    )}`
+                    b.label
                   )
               ),
-            },
-          ]);
+            });
+          }
         }
       }
     }
+    collection.set(document.uri, result);
   }
 }
 
@@ -145,50 +200,88 @@ export class IdentifierResolver implements vscode.CodeActionProvider {
     context: vscode.CodeActionContext,
     token: vscode.CancellationToken
   ): vscode.CodeAction[] {
-    return context.diagnostics
-      .filter(diagnostic => diagnostic.code === AMBIGUOUS_IDENTIFIER_CODE)
-      .reduce((acc, diagnostic) => {
+    return context.diagnostics.reduce((acc, diagnostic) => {
+      if (diagnostic.code === AMBIGUOUS_IDENTIFIER_CODE) {
         const res: vscode.CodeAction[] = [];
         const uris = diagnostic.relatedInformation.map(
           info => info.location.uri
         );
         for (const item of diagnostic.relatedInformation) {
           res.push(
-            this.createCommandCodeAction(diagnostic, item.location.uri, uris)
+            createFindIdentifierCommand(diagnostic, item.location.uri, uris)
           );
         }
         return [...acc, ...res];
-      }, [] as vscode.CodeAction[]);
-  }
-
-  private createCommandCodeAction(
-    diagnostic: vscode.Diagnostic,
-    target: vscode.Uri,
-    possibleTargets: vscode.Uri[]
-  ): vscode.CodeAction {
-    const action = new vscode.CodeAction(
-      `Use ${vscode.workspace.asRelativePath(target)}`,
-      vscode.CodeActionKind.QuickFix
-    );
-    action.command = {
-      command: FIND_IDENTIFER_COMMAND.name,
-      title: 'Link to this resource',
-      arguments: [
-        {
-          target: target,
-          amongst: possibleTargets,
-          range: new vscode.Range(
-            diagnostic.range.start.line,
-            diagnostic.range.start.character + 2,
-            diagnostic.range.end.line,
-            diagnostic.range.end.character - 2
-          ),
-        },
-      ],
-    };
-    action.diagnostics = [diagnostic];
-    return action;
+      }
+      if (diagnostic.code === UNKNOWN_BLOCK_CODE) {
+        const res: vscode.CodeAction[] = [];
+        const sections = diagnostic.relatedInformation.map(
+          info => info.message
+        );
+        for (const section of sections) {
+          res.push(createReplaceSectionCommand(diagnostic, section));
+        }
+        return [...acc, ...res];
+      }
+      return acc;
+    }, [] as vscode.CodeAction[]);
   }
 }
+
+const createReplaceSectionCommand = (
+  diagnostic: vscode.Diagnostic,
+  section: string
+): vscode.CodeAction => {
+  const action = new vscode.CodeAction(
+    `Use ${section}`,
+    vscode.CodeActionKind.QuickFix
+  );
+  action.command = {
+    command: REPLACE_TEXT_COMMAND.name,
+    title: `Use section ${section}`,
+    arguments: [
+      {
+        value: section,
+        range: new vscode.Range(
+          diagnostic.range.start.line,
+          diagnostic.range.start.character + 1,
+          diagnostic.range.end.line,
+          diagnostic.range.end.character - 2
+        ),
+      },
+    ],
+  };
+  action.diagnostics = [diagnostic];
+  return action;
+};
+
+const createFindIdentifierCommand = (
+  diagnostic: vscode.Diagnostic,
+  target: vscode.Uri,
+  possibleTargets: vscode.Uri[]
+): vscode.CodeAction => {
+  const action = new vscode.CodeAction(
+    `Use ${vscode.workspace.asRelativePath(target)}`,
+    vscode.CodeActionKind.QuickFix
+  );
+  action.command = {
+    command: FIND_IDENTIFER_COMMAND.name,
+    title: 'Link to this resource',
+    arguments: [
+      {
+        target: target,
+        amongst: possibleTargets,
+        range: new vscode.Range(
+          diagnostic.range.start.line,
+          diagnostic.range.start.character + 2,
+          diagnostic.range.end.line,
+          diagnostic.range.end.character - 2
+        ),
+      },
+    ],
+  };
+  action.diagnostics = [diagnostic];
+  return action;
+};
 
 export default feature;

--- a/packages/foam-vscode/src/features/wikilink-diagnostics.ts
+++ b/packages/foam-vscode/src/features/wikilink-diagnostics.ts
@@ -14,7 +14,7 @@ import {
 } from '../utils/vsc-utils';
 
 const AMBIGUOUS_IDENTIFIER_CODE = 'ambiguous-identifier';
-const UNKNOWN_BLOCK_CODE = 'unknown-block';
+const UNKNOWN_SECTION_CODE = 'unknown-section';
 
 interface FoamCommand<T> {
   name: string;
@@ -156,7 +156,7 @@ export function updateDiagnostics(
         }
         if (section && targets.length === 1) {
           const resource = targets[0];
-          const found = resource.blocks.find(b => b.label === section);
+          const found = resource.sections.find(b => b.label === section);
           if (!found) {
             const range = Range.create(
               link.range.start.line,
@@ -165,12 +165,12 @@ export function updateDiagnostics(
               link.range.end.character
             );
             result.push({
-              code: UNKNOWN_BLOCK_CODE,
+              code: UNKNOWN_SECTION_CODE,
               message: `Cannot find section "${section}" in document, available sections are:`,
               range: toVsCodeRange(range),
               severity: vscode.DiagnosticSeverity.Warning,
               source: 'Foam',
-              relatedInformation: resource.blocks.map(
+              relatedInformation: resource.sections.map(
                 b =>
                   new vscode.DiagnosticRelatedInformation(
                     new vscode.Location(
@@ -215,7 +215,7 @@ export class IdentifierResolver implements vscode.CodeActionProvider {
         }
         return [...acc, ...res];
       }
-      if (diagnostic.code === UNKNOWN_BLOCK_CODE) {
+      if (diagnostic.code === UNKNOWN_SECTION_CODE) {
         const res: vscode.CodeAction[] = [];
         const sections = diagnostic.relatedInformation.map(
           info => info.message

--- a/packages/foam-vscode/src/services/templates.spec.ts
+++ b/packages/foam-vscode/src/services/templates.spec.ts
@@ -43,7 +43,8 @@ describe('Create note from template', () => {
         })
       );
 
-      await deleteFile(fileA.uri);
+      await deleteFile(fileA);
+      await deleteFile(templateA);
     });
 
     it('should not ask a user for path if defined in template', async () => {
@@ -65,6 +66,9 @@ foam_template: # foam template metadata
         new Resolver(new Map(), new Date())
       );
       expect(spy).toHaveBeenCalledTimes(0);
+
+      await deleteFile(uri);
+      await deleteFile(templateA);
     });
 
     it('should focus the editor on the newly created note', async () => {
@@ -84,6 +88,7 @@ foam_template: # foam template metadata
       );
 
       await deleteFile(target);
+      await deleteFile(templateA);
     });
   });
 
@@ -104,8 +109,9 @@ foam_template: # foam template metadata
     expect(window.activeTextEditor.document.getText()).toEqual(
       `${new Date().getFullYear()}`
     );
+
     await deleteFile(target);
-    await deleteFile(template.uri);
+    await deleteFile(template);
   });
 
   describe('Creation with active text selection', () => {
@@ -124,6 +130,10 @@ foam_template: # foam template metadata
       expect(await resolver.resolve('FOAM_SELECTED_TEXT')).toEqual(
         'first file'
       );
+
+      await deleteFile(templateA);
+      await deleteFile(target);
+      await deleteFile(file);
     });
 
     it('should open created note in a new column if there was a selection', async () => {
@@ -148,7 +158,9 @@ foam_template: # foam template metadata
       expect(fromVsCodeUri(window.visibleTextEditors[1].document.uri)).toEqual(
         target
       );
+
       await deleteFile(target);
+      await deleteFile(templateA);
       await closeEditors();
     });
 

--- a/packages/foam-vscode/src/test/test-utils-vscode.ts
+++ b/packages/foam-vscode/src/test/test-utils-vscode.ts
@@ -28,7 +28,8 @@ export const closeEditors = async () => {
   await wait(100);
 };
 
-export const deleteFile = (uri: URI) => {
+export const deleteFile = (file: URI | { uri: URI }) => {
+  const uri = 'uri' in file ? file.uri : file;
   return vscode.workspace.fs.delete(toVsCodeUri(uri), { recursive: true });
 };
 

--- a/packages/foam-vscode/src/test/test-utils.ts
+++ b/packages/foam-vscode/src/test/test-utils.ts
@@ -59,6 +59,7 @@ export const createTestNote = (params: {
     properties: {},
     title: params.title ?? path.parse(strToUri(params.uri).path).base,
     definitions: params.definitions ?? [],
+    blocks: [],
     tags:
       params.tags?.map(t => ({
         label: t,

--- a/packages/foam-vscode/src/test/test-utils.ts
+++ b/packages/foam-vscode/src/test/test-utils.ts
@@ -50,6 +50,7 @@ export const createTestNote = (params: {
   links?: Array<{ slug: string } | { to: string }>;
   tags?: string[];
   text?: string;
+  sections?: string[];
   root?: URI;
 }): Resource => {
   const root = params.root ?? URI.file('/');
@@ -59,7 +60,10 @@ export const createTestNote = (params: {
     properties: {},
     title: params.title ?? path.parse(strToUri(params.uri).path).base,
     definitions: params.definitions ?? [],
-    sections: [],
+    sections: params.sections?.map(label => ({
+      label,
+      range: Range.create(0, 0, 1, 0),
+    })),
     tags:
       params.tags?.map(t => ({
         label: t,

--- a/packages/foam-vscode/src/test/test-utils.ts
+++ b/packages/foam-vscode/src/test/test-utils.ts
@@ -59,7 +59,7 @@ export const createTestNote = (params: {
     properties: {},
     title: params.title ?? path.parse(strToUri(params.uri).path).base,
     definitions: params.definitions ?? [],
-    blocks: [],
+    sections: [],
     tags:
       params.tags?.map(t => ({
         label: t,

--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,11 @@ Embed the content from other notes.
 
 ![Note Embed](./assets/screenshots/feature-note-embed.gif)
 
+### Support for sections
+
+Foam supports autocompletion, navigation, embedding and diagnostics for note sections.
+Just use the standard wiki syntax of `[[resource#Section Title]]`.
+
 ### Link Alias
 
 Foam supports link aliasing, so you can have a `[[wikilink]]`, or a `[[wikilink|alias]]`.


### PR DESCRIPTION
This PR adds support for sections in Foam.

That means that:
- `[[resource#section]]` will be recognized as a valid resource and not as a placeholder
- `[[resource#section]]` will navigate to the `section` line in the `resource` 
- Autocompletion for sections
- `![[resource#section]]` will embed only the text in `section` in the preview
- Diagnostics will report the usage of incorrect sections (e.g. `[[resource#section3]]` when no `section 3` exists in the file), with quick suggestions to fix the error


Note for reviewers: Even after the PR has been merged, feel free to leave comments, I will address them in a follow-up PR.  This is to not slow down work while waiting for feedback.