### PR TITLE
Error fix for janitor update links

### DIFF
--- a/packages/foam-vscode/src/core/janitor/apply-text-edit.ts
+++ b/packages/foam-vscode/src/core/janitor/apply-text-edit.ts
@@ -34,5 +34,6 @@ const getOffset = (
     offset = offset + lines[i].length + eolLen;
     i++;
   }
+  i = Math.min(i, lines.length - 1);
   return offset + Math.min(position.character, lines[i].length);
 };


### PR DESCRIPTION
`i` was able to have a value of `i = lines.length` which will result in `undefined TypeError` when attempting `lines[i].length`