### PR TITLE
Graph improvements: light theme, zoom to fit canvas, dat.gui layout

### DIFF
--- a/packages/foam-vscode/src/features/dataviz.ts
+++ b/packages/foam-vscode/src/features/dataviz.ts
@@ -184,7 +184,7 @@ async function getWebviewContent(
   // Replace the script paths with the appropriate webview URI.
   const filled = new TextDecoder('utf-8')
     .decode(indexHtml)
-    .replace(/replace-data (src|href)="[^"]+"/g, match => {
+    .replace(/data-replace (src|href)="[^"]+"/g, match => {
       const i = match.indexOf(' ');
       const j = match.indexOf('=');
       const uri = getWebviewUri(match.slice(j + 2, -1).trim());

--- a/packages/foam-vscode/src/features/dataviz.ts
+++ b/packages/foam-vscode/src/features/dataviz.ts
@@ -184,8 +184,8 @@ async function getWebviewContent(
   // Replace the script paths with the appropriate webview URI.
   const filled = new TextDecoder('utf-8')
     .decode(indexHtml)
-    .replace(/replace-(src|href)="[^"]+"/g, match => {
-      const i = match.indexOf('-');
+    .replace(/replace-data (src|href)="[^"]+"/g, match => {
+      const i = match.indexOf(' ');
       const j = match.indexOf('=');
       const uri = getWebviewUri(match.slice(j + 2, -1).trim());
       return match.slice(i + 1, j) + '="' + uri.toString() + '"';

--- a/packages/foam-vscode/src/features/dataviz.ts
+++ b/packages/foam-vscode/src/features/dataviz.ts
@@ -184,11 +184,11 @@ async function getWebviewContent(
   // Replace the script paths with the appropriate webview URI.
   const filled = new TextDecoder('utf-8')
     .decode(indexHtml)
-    .replace(/<script data-replace src="([^"]+")/g, match => {
-      const fileName = match
-        .slice('<script data-replace src="'.length, -1)
-        .trim();
-      return '<script src="' + getWebviewUri(fileName).toString() + '"';
+    .replace(/replace-(src|href)="[^"]+"/g, match => {
+      const i = match.indexOf('-');
+      const j = match.indexOf('=');
+      const uri = getWebviewUri(match.slice(j + 2, -1).trim());
+      return match.slice(i + 1, j) + '="' + uri.toString() + '"';
     });
 
   return filled;

--- a/packages/foam-vscode/static/dataviz/graph.css
+++ b/packages/foam-vscode/static/dataviz/graph.css
@@ -1,0 +1,74 @@
+body {
+  overflow: hidden;
+}
+
+.dg .c {
+  width: 10%;
+}
+
+.dg .property-name {
+  width: 90%;
+}
+
+.vscode-light .dg.main.taller-than-window .close-button {
+border-top: 1px solid #ddd;
+}
+
+.vscode-light .dg.main .close-button {
+background-color: #ccc;
+}
+
+.vscode-light .dg.main .close-button:hover {
+background-color: #ddd;
+}
+
+.vscode-light .dg {
+color: #555;
+text-shadow: none !important;
+}
+
+.vscode-light .dg.main::-webkit-scrollbar {
+background: #fafafa;
+}
+
+.vscode-light .dg.main::-webkit-scrollbar-thumb {
+background: #bbb;
+}
+
+.vscode-light .dg li:not(.folder) {
+background: #fafafa;
+border-bottom: 1px solid #ddd;
+}
+
+.vscode-light .dg li.save-row .button {
+text-shadow: none !important;
+}
+
+.vscode-light .dg li.title {
+background: #e8e8e8 url(data:image/gif;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAAXNSR0IArs4c6QAAACVJREFUGFdjZMACGLEKRkfH/0eXAKtElli6dCEjXDtIAiQAUgQAF7UKGmOy49cAAAAASUVORK5CYII=) 6px 10px no-repeat;
+}
+
+.vscode-light .dg .cr.function:hover,.dg .cr.boolean:hover {
+background: #fff;
+}
+
+.vscode-light .dg .c input[type=text] {
+background: #e9e9e9;
+}
+
+.vscode-light .dg .c input[type=text]:hover {
+background: #eee;
+}
+
+.vscode-light .dg .c input[type=text]:focus {
+background: #eee;
+color: #555;
+}
+
+.vscode-light .dg .c .slider {
+background: #e9e9e9;
+}
+
+.vscode-light .dg .c .slider:hover {
+background: #eee;
+}

--- a/packages/foam-vscode/static/dataviz/graph.js
+++ b/packages/foam-vscode/static/dataviz/graph.js
@@ -136,7 +136,7 @@ const Actions = {
         }
       });
       types.forEach(type => {
-        if (model.showNodesOfType[type] == null) {
+        if (model.showNodesOfType[type] === null) {
           model.showNodesOfType[type] = true;
         }
       });
@@ -148,7 +148,7 @@ const Actions = {
       if (!isAppend) {
         m.selectedNodes.clear();
       }
-      if (nodeId != null) {
+      if (nodeId !== null) {
         m.selectedNodes.add(nodeId);
       }
     }),
@@ -205,7 +205,7 @@ function initDataviz(channel) {
     )
     .nodeCanvasObject((node, ctx, globalScale) => {
       const info = model.graph.nodeInfo[node.id];
-      if (info == null) {
+      if (info === null) {
         console.error(`Could not find info for node ${node.id} - skipping`);
         return;
       }
@@ -299,7 +299,7 @@ function updateForceGraphDataFromModel(m) {
   });
   // apply the delta
   nodeIdsToRemove.forEach(id => {
-    const index = m.data.nodes.findIndex(n => n.id == id);
+    const index = m.data.nodes.findIndex(n => n.id === id);
     m.data.nodes.splice(index, 1); // delete the element
   });
   nodeIdsToAdd.forEach(nodeId => {
@@ -312,19 +312,19 @@ function updateForceGraphDataFromModel(m) {
   m.data.links = m.graph.links
     .filter(link => {
       const isSource = Object.values(m.data.nodes).some(
-        node => node.id == link.source
+        node => node.id === link.source
       );
       const isTarget = Object.values(m.data.nodes).some(
-        node => node.id == link.target
+        node => node.id === link.target
       );
       return isSource && isTarget;
     })
     .map(link => ({ ...link }));
 
   // check that selected/hovered nodes are still valid (see #397)
-  m.hoverNode = m.graph.nodeInfo[m.hoverNode] != null ? m.hoverNode : null;
+  m.hoverNode = m.graph.nodeInfo[m.hoverNode] !== null ? m.hoverNode : null;
   m.selectedNodes = new Set(
-    Array.from(m.selectedNodes).filter(nId => m.graph.nodeInfo[nId] != null)
+    Array.from(m.selectedNodes).filter(nId => m.graph.nodeInfo[nId] !== null)
   );
 
   // annoying we need to call this function, but I haven't found a good workaround
@@ -399,7 +399,7 @@ function getLinkState(link, model) {
     ? 'regular'
     : Array.from(model.focusLinks).some(
         fLink =>
-          fLink.source == link.source.id && fLink.target == link.target.id
+          fLink.source === link.source.id && fLink.target === link.target.id
       )
     ? 'highlighted'
     : 'lessened';
@@ -501,6 +501,9 @@ try {
       case 'didUpdateGraphData':
         graphData = augmentGraphInfo(message.payload);
         Actions.refreshWorkspaceData(graphData);
+        graph.zoom(graph.zoom() * 1.5);
+        graph.cooldownTicks(100);
+        graph.onEngineStop(() => graph.zoomToFit(500));
         console.log('didUpdateGraphData', graphData);
         break;
       case 'didSelectNote':

--- a/packages/foam-vscode/static/dataviz/graph.js
+++ b/packages/foam-vscode/static/dataviz/graph.js
@@ -148,7 +148,7 @@ const Actions = {
       if (!isAppend) {
         m.selectedNodes.clear();
       }
-      if (nodeId !== null) {
+      if (nodeId != null) {
         m.selectedNodes.add(nodeId);
       }
     }),
@@ -205,7 +205,7 @@ function initDataviz(channel) {
     )
     .nodeCanvasObject((node, ctx, globalScale) => {
       const info = model.graph.nodeInfo[node.id];
-      if (info === null) {
+      if (info == null) {
         console.error(`Could not find info for node ${node.id} - skipping`);
         return;
       }
@@ -322,9 +322,9 @@ function updateForceGraphDataFromModel(m) {
     .map(link => ({ ...link }));
 
   // check that selected/hovered nodes are still valid (see #397)
-  m.hoverNode = m.graph.nodeInfo[m.hoverNode] !== null ? m.hoverNode : null;
+  m.hoverNode = m.graph.nodeInfo[m.hoverNode] != null ? m.hoverNode : null;
   m.selectedNodes = new Set(
-    Array.from(m.selectedNodes).filter(nId => m.graph.nodeInfo[nId] !== null)
+    Array.from(m.selectedNodes).filter(nId => m.graph.nodeInfo[nId] != null)
   );
 
   // annoying we need to call this function, but I haven't found a good workaround
@@ -473,6 +473,7 @@ class Painter {
 try {
   const vscode = acquireVsCodeApi();
   window.model = model;
+  window.graphUpdated = false;
 
   window.onload = () => {
     initDataviz(vscode);
@@ -501,9 +502,15 @@ try {
       case 'didUpdateGraphData':
         graphData = augmentGraphInfo(message.payload);
         Actions.refreshWorkspaceData(graphData);
-        graph.zoom(graph.zoom() * 1.5);
-        graph.cooldownTicks(100);
-        graph.onEngineStop(() => graph.zoomToFit(500));
+        if (!graphUpdated) {
+          window.graphUpdated = true;
+          graph.zoom(graph.zoom() * 1.5);
+          graph.cooldownTicks(100);
+          graph.onEngineStop(() => {
+            graph.onEngineStop(() => {});
+            graph.zoomToFit(500);
+          });
+        }
         console.log('didUpdateGraphData', graphData);
         break;
       case 'didSelectNote':

--- a/packages/foam-vscode/static/dataviz/graph.js
+++ b/packages/foam-vscode/static/dataviz/graph.js
@@ -136,7 +136,7 @@ const Actions = {
         }
       });
       types.forEach(type => {
-        if (model.showNodesOfType[type] === null) {
+        if (model.showNodesOfType[type] == null) {
           model.showNodesOfType[type] = true;
         }
       });

--- a/packages/foam-vscode/static/dataviz/index.html
+++ b/packages/foam-vscode/static/dataviz/index.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <script replace-src="./d3.v6.min.js"></script>
-    <script replace-src="./force-graph.1.40.5.min.js"></script>
-    <script replace-src="./dat.gui.min.js"></script>
-    <link replace-href="./graph.css" rel="stylesheet">
+    <script replace-data src="./d3.v6.min.js"></script>
+    <script replace-data src="./force-graph.1.40.5.min.js"></script>
+    <script replace-data src="./dat.gui.min.js"></script>
+    <link replace-data href="./graph.css" rel="stylesheet">
   </head>
   <body>
     <div
@@ -19,6 +19,6 @@
       4. open this file in a browser
     -->
     <!-- <script src="./test-data.js"></script> -->
-    <script replace-src="./graph.js"></script>
+    <script replace-data src="./graph.js"></script>
   </body>
 </html>

--- a/packages/foam-vscode/static/dataviz/index.html
+++ b/packages/foam-vscode/static/dataviz/index.html
@@ -2,14 +2,10 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <script data-replace src="./d3.v6.min.js"></script>
-    <script data-replace src="./force-graph.1.40.5.min.js"></script>
-    <script data-replace src="./dat.gui.min.js"></script>
-    <style>
-      body {
-        overflow: hidden;
-      }
-    </style>
+    <script replace-src="./d3.v6.min.js"></script>
+    <script replace-src="./force-graph.1.40.5.min.js"></script>
+    <script replace-src="./dat.gui.min.js"></script>
+    <link replace-href="./graph.css" rel="stylesheet">
   </head>
   <body>
     <div
@@ -23,6 +19,6 @@
       4. open this file in a browser
     -->
     <!-- <script src="./test-data.js"></script> -->
-    <script data-replace src="./graph.js"></script>
+    <script replace-src="./graph.js"></script>
   </body>
 </html>

--- a/packages/foam-vscode/static/dataviz/index.html
+++ b/packages/foam-vscode/static/dataviz/index.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <script replace-data src="./d3.v6.min.js"></script>
-    <script replace-data src="./force-graph.1.40.5.min.js"></script>
-    <script replace-data src="./dat.gui.min.js"></script>
-    <link replace-data href="./graph.css" rel="stylesheet">
+    <script data-replace src="./d3.v6.min.js"></script>
+    <script data-replace src="./force-graph.1.40.5.min.js"></script>
+    <script data-replace src="./dat.gui.min.js"></script>
+    <link data-replace href="./graph.css" rel="stylesheet">
   </head>
   <body>
     <div
@@ -19,6 +19,6 @@
       4. open this file in a browser
     -->
     <!-- <script src="./test-data.js"></script> -->
-    <script replace-data src="./graph.js"></script>
+    <script data-replace src="./graph.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Fix https://github.com/foambubble/foam/issues/852,  https://github.com/foambubble/foam/issues/853 and https://github.com/foambubble/foam/issues/854.

Generalize mechanism to load external resources. Then load new graph.css which:
- Resizes property/value from 40%/60% to 90%/10% (better suited to checkboxes).
- Adds a new light theme based on [1] (but with a darker arrow that I've created in order to increase contrast). This theme gets activated if the graph is loaded when vscode theme is light.

Also zooms the graph to fit the canvas at startup. This is a bit tricky because the graph engine needs some iterations (ticks) before cooling down. Initially the graph zoom level is  heuristically computed in a way that's inversely proportional to the number of nodes. I find this heuristic tends to compress the graph too much at the center of the webview, so I scaled the initial value x 1.5 (which still seems to be pretty conservative). Then the number of ticks to cool down is set to 100. Finally the graph is scaled to fit the canvas with a 0.5 seconds animation. Overall, the effect is nice and the resulting graph takes advantage of all available space. Values are based on [2].

```ts
        graph.zoom(graph.zoom() * 1.5);
        graph.cooldownTicks(100);
        graph.onEngineStop(() => graph.zoomToFit(500));
```

Little refactor: a number of `==` and `!=` in graph.js that the linter was complaining about were changed to `===` and `!==`.

---
[1] https://brm.io/dat-gui-light-theme/
[2] https://github.com/vasturiano/force-graph/blob/master/example/fit-to-canvas/index.html