### PR TITLE
docs: Remove reference to VSCode Markdown Notes

### DIFF
--- a/docs/features/backlinking.md
+++ b/docs/features/backlinking.md
@@ -1,6 +1,6 @@
 # Backlinking
 
-When using [[wikilinks]], you can find all notes that link to a specific note in the [VS Code Markdown Notes](https://marketplace.visualstudio.com/items?itemName=kortina.vscode-markdown-notes) **Backlinks Explorer**
+When using [[wikilinks]], you can find all notes that link to a specific note in the **Backlinks Explorer**
 
 - Run `Cmd` + `Shift` + `P` (`Ctrl` + `Shift` + `P` for Windows), type "backlinks" and run the **Explorer: Focus on Backlinks** view.
 - Keep this pane always visible to discover relationships between your thoughts


### PR DESCRIPTION
Remove mention of VSCode Markdown Notes as it is no longer a recommended extension or required for Backlinks (https://github.com/foambubble/foam-template/commit/ca8ee63cea4a846b3ce0606ff2252c64825ba89f, https://github.com/foambubble/foam/issues/719#issuecomment-880100159)