### PR TITLE
Fix open-daily-note to only accept argument if it is a Date

### DIFF
--- a/packages/foam-vscode/src/dated-notes.ts
+++ b/packages/foam-vscode/src/dated-notes.ts
@@ -16,7 +16,7 @@ import { NoteFactory } from './services/templates';
  */
 export async function openDailyNoteFor(date?: Date) {
   const foamConfiguration = workspace.getConfiguration('foam');
-  const currentDate = date !== undefined ? date : new Date();
+  const currentDate = date instanceof Date ? date : new Date();
 
   const dailyNotePath = getDailyNotePath(foamConfiguration, currentDate);
 


### PR DESCRIPTION
I was trying to make VS Code automatically open my daily note with a task like this:

```json
{
  "version": "2.0.0",
  "tasks": [
    {
      "label": "Open daily note",
      "command": "${command:foam-vscode.open-daily-note}",
      "runOptions": { "runOn": "folderOpen" }
    }
  ]
}
```

However, running that task would produce an `Invalid date` error. It turns out that calling a command through a task passes in an array of arguments. This array was being treated as a `Date` and causing issues. This PR just makes sure that the argument coming through is an actual `Date`.