### PR TITLE
Fix commented test case that might randomly fail

### DIFF
--- a/packages/foam-vscode/src/features/copy-without-brackets.spec.ts
+++ b/packages/foam-vscode/src/features/copy-without-brackets.spec.ts
@@ -7,8 +7,7 @@ import {
 
 describe('copyWithoutBrackets', () => {
   it('should get the input from the active editor selection', async () => {
-    await createFile('This is my [[test-content]].', ['hello.md']);
-    const uri = getUriInWorkspace('hello.md');
+    const { uri } = await createFile('This is my [[test-content]].');
     const { editor } = await showInEditor(uri);
     editor.selection = new Selection(new Position(0, 0), new Position(1, 0));
     await commands.executeCommand('foam-vscode.copy-without-brackets');

--- a/packages/foam-vscode/src/features/copy-without-brackets.spec.ts
+++ b/packages/foam-vscode/src/features/copy-without-brackets.spec.ts
@@ -1,21 +1,23 @@
-// import { env, window, Uri, Position, Selection, commands } from 'vscode';
-// import * as vscode from 'vscode';
+import { env, Position, Selection, commands } from 'vscode';
+import {
+  createFile,
+  getUriInWorkspace,
+  showInEditor,
+} from '../test/test-utils-vscode';
 
 describe('copyWithoutBrackets', () => {
   it('should pass CI', () => {
     expect(true).toBe(true);
   });
-  // it('should get the input from the active editor selection', async () => {
-  //   const doc = await vscode.workspace.openTextDocument(
-  //     Uri.parse('untitled:/hello.md')
-  //   );
-  //   const editor = await window.showTextDocument(doc);
-  //   editor.edit(builder => {
-  //     builder.insert(new Position(0, 0), 'This is my [[test-content]].');
-  //   });
-  //   editor.selection = new Selection(new Position(0, 0), new Position(1, 0));
-  //   await commands.executeCommand('foam-vscode.copy-without-brackets');
-  //   const value = await env.clipboard.readText();
-  //   expect(value).toEqual('This is my Test Content.');
-  // });
+
+  it('should get the input from the active editor selection', async () => {
+    await createFile('This is my [[test-content]].', ['hello.md']);
+    const uri = getUriInWorkspace('hello.md');
+    const { editor } = await showInEditor(uri);
+    editor.selection = new Selection(new Position(0, 0), new Position(1, 0));
+    await commands.executeCommand('foam-vscode.copy-without-brackets');
+    console.log(env.clipboard);
+    const value = await env.clipboard.readText();
+    expect(value).toEqual('This is my Test Content.');
+  });
 });

--- a/packages/foam-vscode/src/features/copy-without-brackets.spec.ts
+++ b/packages/foam-vscode/src/features/copy-without-brackets.spec.ts
@@ -6,17 +6,12 @@ import {
 } from '../test/test-utils-vscode';
 
 describe('copyWithoutBrackets', () => {
-  it('should pass CI', () => {
-    expect(true).toBe(true);
-  });
-
   it('should get the input from the active editor selection', async () => {
     await createFile('This is my [[test-content]].', ['hello.md']);
     const uri = getUriInWorkspace('hello.md');
     const { editor } = await showInEditor(uri);
     editor.selection = new Selection(new Position(0, 0), new Position(1, 0));
     await commands.executeCommand('foam-vscode.copy-without-brackets');
-    console.log(env.clipboard);
     const value = await env.clipboard.readText();
     expect(value).toEqual('This is my Test Content.');
   });


### PR DESCRIPTION
The test `should get the input from the active editor selection` was commented for `copyWithoutBrackets` (See #468 ).

Uncommented the test and fix the error that would cause it to randomly fail.