### PR TITLE
Add Config: "foam.tags.poundSignTags"

### DIFF
--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -362,6 +362,11 @@
           "type": "object",
           "description": "Custom graph styling settings. An example is present in the documentation.",
           "default": {}
+        },
+        "foam.tags.poundSignTags": {
+          "type": "boolean",
+          "description": "Search tags starts with '#'",
+          "default": true
         }
       }
     },

--- a/packages/foam-vscode/src/core/markdown-provider.ts
+++ b/packages/foam-vscode/src/core/markdown-provider.ts
@@ -24,6 +24,7 @@ import { FoamWorkspace } from './model/workspace';
 import { IDataStore, FileDataStore, IMatcher } from './services/datastore';
 import { IDisposable } from './common/lifecycle';
 import { ResourceProvider } from './model/provider';
+import { getEnabledPoundTags } from '../settings';
 
 const ALIAS_DIVIDER_CHAR = '|';
 
@@ -186,6 +187,7 @@ const getTextFromChildren = (root: Node): string => {
   return text;
 };
 
+const poundSignTags: boolean = getEnabledPoundTags();
 const tagsPlugin: ParserPlugin = {
   name: 'tags',
   onDidFindProperties: (props, note, node) => {
@@ -200,7 +202,7 @@ const tagsPlugin: ParserPlugin = {
     }
   },
   visit: (node, note) => {
-    if (node.type === 'text') {
+    if (poundSignTags && node.type === 'text') {
       const tags = extractHashtags((node as any).value);
       tags.forEach(tag => {
         const start = astPointToFoamPosition(node.position!.start);

--- a/packages/foam-vscode/src/settings.ts
+++ b/packages/foam-vscode/src/settings.ts
@@ -54,6 +54,11 @@ export function getPlaceholdersConfig(): GroupedResourcesConfig {
   return { exclude, groupBy };
 }
 
+/** Retrieve the poundTags configuration */
+export function getEnabledPoundTags(): boolean {
+  return workspace.getConfiguration('foam.tags').get('poundSignTags');
+}
+
 export interface GroupedResourcesConfig {
   exclude: string[];
   groupBy: GroupedResoucesConfigGroupBy;


### PR DESCRIPTION
There are some `#xxx` in my markdown notes, which are not truly tags, and they take up most of the space in the tags explorer.

I need a approach to disable these 'fake tags', i only need the tags in markdown's metadata