### PR TITLE
fix: temporary solution for root level file discovery in windows

### DIFF
--- a/packages/foam-vscode/src/core/services/datastore.ts
+++ b/packages/foam-vscode/src/core/services/datastore.ts
@@ -118,6 +118,7 @@ export class FileDataStore implements IDataStore {
   async list(glob: string, ignoreGlob?: string | string[]): Promise<URI[]> {
     const res = await findAllFiles(glob, {
       ignore: ignoreGlob,
+      strict: false,
     });
     return res.map(URI.file);
   }


### PR DESCRIPTION
According to #941

Set ```strict: false``` option for  [node-glob](https://github.com/isaacs/node-glob) to allow scanning root directories in windows. Without ```strict: false``` the scanning will be canceled with this error:
```
An error occurred while bootstrapping Foam
"Error: EPERM: operation not permitted, scandir 'C:\\StoragePool\\167GB-SSD\\System Volume Information'"
```

> ```strict``` When an unusual error is encountered when attempting to read a directory, the process will just continue on in search of other matches. Set the strict option to raise an error in these cases.
> --- [node-glob/README.md](https://github.com/isaacs/node-glob/blob/3bfec21dd180ddf4672880176ad33af6296a167e/README.md?plain=1#L232) 