### PR TITLE
Support for Emoji-Only Tags

### DIFF
--- a/packages/foam-vscode/src/core/utils/hashtags.ts
+++ b/packages/foam-vscode/src/core/utils/hashtags.ts
@@ -1,12 +1,17 @@
 import { isSome } from './core';
 const HASHTAG_REGEX = /(?<=^|\s)#([0-9]*[\p{L}/_-][\p{L}\p{N}/_-]*)/gmu;
 const WORD_REGEX = /(?<=^|\s)([0-9]*[\p{L}/_-][\p{L}\p{N}/_-]*)/gmu;
+// https://stackoverflow.com/a/67705964
+const EMOJI_HASHTAG_REGEX = /(?<=^|\s)#(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])/gm;
+const EMOJI_REGEX = /(?<=^|\s)(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])/gm;
 
 export const extractHashtags = (
   text: string
 ): Array<{ label: string; offset: number }> => {
+  const hashtagMatches = Array.from(text.matchAll(HASHTAG_REGEX));
+  const emojiHashtagMatches = Array.from(text.matchAll(EMOJI_HASHTAG_REGEX));
   return isSome(text)
-    ? Array.from(text.matchAll(HASHTAG_REGEX)).map(m => ({
+    ? hashtagMatches.concat(emojiHashtagMatches).map(m => ({
         label: m[1],
         offset: m.index!,
       }))
@@ -15,7 +20,7 @@ export const extractHashtags = (
 
 export const extractTagsFromProp = (prop: string | string[]): string[] => {
   const text = Array.isArray(prop) ? prop.join(' ') : prop;
-  return isSome(text)
-    ? Array.from(text.matchAll(WORD_REGEX)).map(m => m[1])
-    : [];
+  const wordMatches = Array.from(text.matchAll(WORD_REGEX));
+  const emojiMatches = Array.from(text.matchAll(EMOJI_REGEX));
+  return isSome(text) ? wordMatches.concat(emojiMatches).map(m => m[1]) : [];
 };


### PR DESCRIPTION
This does not fully address #903 as the requirements there include "text[emoji]", but I wanted to take a stab at it.
These extra captures will identify emoji-only tags. I'm thinking this might be useful for 🐛  or pithy tags like that.
It looks nice in the tag explorer:
![image](https://user-images.githubusercontent.com/4606342/161406908-9ebf77c7-728f-44ef-89b8-a294346eee36.png)
I tested this with: https://github.com/foambubble/foam-template
Any feedback is appreciated.