### PR TITLE
Template to better support custom paths checks

### DIFF
--- a/packages/foam-vscode/src/dated-notes.spec.ts
+++ b/packages/foam-vscode/src/dated-notes.spec.ts
@@ -81,7 +81,7 @@ describe('Daily note template', () => {
     const config = workspace.getConfiguration('foam');
     const uri = getDailyNotePath(config, targetDate);
 
-    await createDailyNoteIfNotExists(config, uri, targetDate);
+    await createDailyNoteIfNotExists(targetDate);
 
     const doc = await showInEditor(uri);
     const content = doc.editor.document.getText();

--- a/packages/foam-vscode/src/dated-notes.ts
+++ b/packages/foam-vscode/src/dated-notes.ts
@@ -1,14 +1,9 @@
 import { workspace, WorkspaceConfiguration } from 'vscode';
 import dateFormat from 'dateformat';
-import { existsInFs } from './core/utils/path';
 import { focusNote } from './utils';
 import { URI } from './core/model/uri';
 import { fromVsCodeUri, toVsCodeUri } from './utils/vsc-utils';
-import {
-  DAILY_NOTE_TEMPLATE_URI,
-  getTemplateInfo,
-  NoteFactory,
-} from './services/templates';
+import { NoteFactory } from './services/templates';
 
 /**
  * Open the daily note file.

--- a/packages/foam-vscode/src/dated-notes.ts
+++ b/packages/foam-vscode/src/dated-notes.ts
@@ -3,8 +3,12 @@ import dateFormat from 'dateformat';
 import { existsInFs } from './core/utils/path';
 import { focusNote } from './utils';
 import { URI } from './core/model/uri';
-import { fromVsCodeUri } from './utils/vsc-utils';
-import { NoteFactory } from './services/templates';
+import { fromVsCodeUri, toVsCodeUri } from './utils/vsc-utils';
+import {
+  DAILY_NOTE_TEMPLATE_URI,
+  getTemplateInfo,
+  NoteFactory,
+} from './services/templates';
 
 /**
  * Open the daily note file.
@@ -15,21 +19,14 @@ import { NoteFactory } from './services/templates';
  * @param date A given date to be formatted as filename.
  */
 export async function openDailyNoteFor(date?: Date) {
-  const foamConfiguration = workspace.getConfiguration('foam');
-  const currentDate = date instanceof Date ? date : new Date();
+  const targetDate = date instanceof Date ? date : new Date();
 
-  const dailyNotePath = getDailyNotePath(foamConfiguration, currentDate);
-
-  const isNew = await createDailyNoteIfNotExists(
-    foamConfiguration,
-    dailyNotePath,
-    currentDate
-  );
+  const { didCreateFile, uri } = await createDailyNoteIfNotExists(targetDate);
   // if a new file is created, the editor is automatically created
   // but forcing the focus will block the template placeholders from working
   // so we only explicitly focus on the note if the file already exists
-  if (!isNew) {
-    await focusNote(dailyNotePath, isNew);
+  if (!didCreateFile) {
+    await focusNote(uri, didCreateFile);
   }
 }
 
@@ -96,37 +93,31 @@ export function getDailyNoteFileName(
  * In the case that the folders referenced in the file path also do not exist,
  * this function will create all folders in the path.
  *
- * @param configuration The current workspace configuration.
- * @param dailyNotePath The path to daily note file.
  * @param currentDate The current date, to be used as a title.
  * @returns Wether the file was created.
  */
-export async function createDailyNoteIfNotExists(
-  configuration: WorkspaceConfiguration,
-  dailyNotePath: URI,
-  targetDate: Date
-) {
-  if (await existsInFs(dailyNotePath.toFsPath())) {
-    return false;
-  }
-
+export async function createDailyNoteIfNotExists(targetDate: Date) {
+  const configuration = workspace.getConfiguration('foam');
+  const pathFromLegacyConfiguration = getDailyNotePath(
+    configuration,
+    targetDate
+  );
   const titleFormat: string =
     configuration.get('openDailyNote.titleFormat') ??
     configuration.get('openDailyNote.filenameFormat');
 
   const templateFallbackText = `---
 foam_template:
-  name: New Daily Note
-  description: Foam's default daily note template
+  filepath: "${workspace.asRelativePath(
+    toVsCodeUri(pathFromLegacyConfiguration)
+  )}"
 ---
 # ${dateFormat(targetDate, titleFormat, false)}
 `;
 
-  await NoteFactory.createFromDailyNoteTemplate(
-    dailyNotePath,
+  return await NoteFactory.createFromDailyNoteTemplate(
+    pathFromLegacyConfiguration,
     templateFallbackText,
     targetDate
   );
-
-  return true;
 }

--- a/packages/foam-vscode/src/features/create-from-template.ts
+++ b/packages/foam-vscode/src/features/create-from-template.ts
@@ -117,7 +117,7 @@ const feature: FoamFeature = {
         () => {
           const resolver = new Resolver(new Map(), new Date());
 
-          NoteFactory.createFromTemplate(
+          return NoteFactory.createFromTemplate(
             DEFAULT_TEMPLATE_URI,
             resolver,
             undefined,

--- a/packages/foam-vscode/src/features/open-daily-note.ts
+++ b/packages/foam-vscode/src/features/open-daily-note.ts
@@ -1,15 +1,15 @@
-import { ExtensionContext, commands, workspace } from 'vscode';
+import { ExtensionContext, commands } from 'vscode';
 import { FoamFeature } from '../types';
 import { openDailyNoteFor } from '../dated-notes';
+import { getFoamVsCodeConfig } from '../services/config';
 
 const feature: FoamFeature = {
   activate: (context: ExtensionContext) => {
     context.subscriptions.push(
       commands.registerCommand('foam-vscode.open-daily-note', openDailyNoteFor)
     );
-    if (
-      workspace.getConfiguration('foam').get('openDailyNote.onStartup', false)
-    ) {
+
+    if (getFoamVsCodeConfig('openDailyNote.onStartup', false)) {
       commands.executeCommand('foam-vscode.open-daily-note');
     }
   },

--- a/packages/foam-vscode/src/features/open-dated-note.ts
+++ b/packages/foam-vscode/src/features/open-dated-note.ts
@@ -13,7 +13,6 @@ import {
   createDailyNoteIfNotExists,
   getDailyNoteFileName,
   openDailyNoteFor,
-  getDailyNotePath,
 } from '../dated-notes';
 import { FoamFeature } from '../types';
 

--- a/packages/foam-vscode/src/features/open-dated-note.ts
+++ b/packages/foam-vscode/src/features/open-dated-note.ts
@@ -215,11 +215,7 @@ const datedNoteCommand = (date: Date) => {
     return openDailyNoteFor(date);
   }
   if (foamNavigateOnSelect === 'createNote') {
-    return createDailyNoteIfNotExists(
-      foamConfig,
-      getDailyNotePath(foamConfig, date),
-      date
-    );
+    return createDailyNoteIfNotExists(date);
   }
 };
 

--- a/packages/foam-vscode/src/services/config.ts
+++ b/packages/foam-vscode/src/services/config.ts
@@ -4,8 +4,8 @@ export interface ConfigurationMonitor<T> extends Disposable {
   (): T;
 }
 
-export const getFoamVsCodeConfig = <T>(key: string): T =>
-  workspace.getConfiguration('foam').get(key);
+export const getFoamVsCodeConfig = <T>(key: string, defaultValue?: T): T =>
+  workspace.getConfiguration('foam').get(key, defaultValue);
 
 export const updateFoamVsCodeConfig = <T>(key: string, value: T) =>
   workspace.getConfiguration().update('foam.' + key, value);

--- a/packages/foam-vscode/src/services/templates.ts
+++ b/packages/foam-vscode/src/services/templates.ts
@@ -77,8 +77,9 @@ export async function getTemplateInfo(templateUri: URI, resolver: Resolver) {
         .then(bytes => bytes.toString())
     : '';
 
-  let templateWithResolvedVariables: string;
-  templateWithResolvedVariables = await resolver.resolveText(templateText);
+  const templateWithResolvedVariables = await resolver.resolveText(
+    templateText
+  );
 
   const [
     templateMetadata,

--- a/packages/foam-vscode/src/services/templates.ts
+++ b/packages/foam-vscode/src/services/templates.ts
@@ -13,6 +13,7 @@ import {
   replaceSelection,
 } from './editor';
 import { Resolver } from './variable-resolver';
+import dateFormat from 'dateformat';
 
 /**
  * The templates directory
@@ -69,6 +70,27 @@ export async function getTemplates(): Promise<URI[]> {
   return templates;
 }
 
+export async function getTemplateInfo(templateUri: URI, resolver: Resolver) {
+  const templateText = existsSync(templateUri.toFsPath())
+    ? await workspace.fs
+        .readFile(toVsCodeUri(templateUri))
+        .then(bytes => bytes.toString())
+    : '';
+
+  let templateWithResolvedVariables: string;
+  templateWithResolvedVariables = await resolver.resolveText(templateText);
+
+  const [
+    templateMetadata,
+    templateWithFoamFrontmatterRemoved,
+  ] = extractFoamTemplateFrontmatterMetadata(templateWithResolvedVariables);
+
+  return {
+    metadata: templateMetadata,
+    text: templateWithFoamFrontmatterRemoved,
+  };
+}
+
 export const NoteFactory = {
   /**
    * Creates a new note using a template.
@@ -81,71 +103,64 @@ export const NoteFactory = {
     templateUri: URI,
     resolver: Resolver,
     filepathFallbackURI?: URI,
-    templateFallbackText = ''
-  ): Promise<void> => {
-    const templateText = existsSync(templateUri.toFsPath())
-      ? await workspace.fs
-          .readFile(toVsCodeUri(templateUri))
-          .then(bytes => bytes.toString())
-      : templateFallbackText;
-
-    const selectedContent = findSelectionContent();
-
-    if (selectedContent?.content) {
-      resolver.define('FOAM_SELECTED_TEXT', selectedContent?.content);
-    }
-
-    let templateWithResolvedVariables: string;
+    templateFallbackText = '',
+    onFileExists?: (filePath: URI) => Promise<string | undefined>
+  ): Promise<{ didCreateFile: boolean; uri: URI | undefined }> => {
     try {
-      templateWithResolvedVariables = await resolver.resolveText(templateText);
+      onFileExists = onFileExists
+        ? onFileExists
+        : (existingFile: URI) => {
+            const filename = existingFile.getBasename();
+            return askUserForFilepathConfirmation(existingFile, filename);
+          };
+
+      const template = await getTemplateInfo(templateUri, resolver);
+
+      const selectedContent = findSelectionContent();
+      if (selectedContent?.content) {
+        resolver.define('FOAM_SELECTED_TEXT', selectedContent?.content);
+      }
+
+      const templateSnippet = new SnippetString(
+        template.text ?? templateFallbackText
+      );
+
+      let newFilePath = await determineNewNoteFilepath(
+        template.metadata.get('filepath'),
+        filepathFallbackURI,
+        resolver
+      );
+      while (existsSync(newFilePath.toFsPath())) {
+        const proposedNewFilepath = await onFileExists(newFilePath);
+
+        if (proposedNewFilepath === undefined) {
+          return { didCreateFile: false, uri: newFilePath };
+        }
+        newFilePath = URI.file(proposedNewFilepath);
+      }
+
+      await createDocAndFocus(
+        templateSnippet,
+        newFilePath,
+        selectedContent ? ViewColumn.Beside : ViewColumn.Active
+      );
+
+      if (selectedContent !== undefined) {
+        const newNoteTitle = newFilePath.getName();
+
+        await replaceSelection(
+          selectedContent.document,
+          selectedContent.selection,
+          `[[${newNoteTitle}]]`
+        );
+      }
+
+      return { didCreateFile: true, uri: newFilePath };
     } catch (err) {
       if (err instanceof UserCancelledOperation) {
         return;
       }
       throw err;
-    }
-
-    const [
-      templateMetadata,
-      templateWithFoamFrontmatterRemoved,
-    ] = extractFoamTemplateFrontmatterMetadata(templateWithResolvedVariables);
-    const templateSnippet = new SnippetString(
-      templateWithFoamFrontmatterRemoved
-    );
-
-    let filepath = await determineNewNoteFilepath(
-      templateMetadata.get('filepath'),
-      filepathFallbackURI,
-      resolver
-    );
-
-    if (existsSync(filepath.toFsPath())) {
-      const filename = filepath.getBasename();
-      const newFilepath = await askUserForFilepathConfirmation(
-        filepath,
-        filename
-      );
-
-      if (newFilepath === undefined) {
-        return;
-      }
-      filepath = URI.file(newFilepath);
-    }
-
-    await createDocAndFocus(
-      templateSnippet,
-      filepath,
-      selectedContent ? ViewColumn.Beside : ViewColumn.Active
-    );
-
-    if (selectedContent !== undefined) {
-      const newNoteTitle = filepath.getName();
-
-      await replaceSelection(
-        selectedContent.document,
-        selectedContent.selection,
-        `[[${newNoteTitle}]]`
-      );
     }
   },
 
@@ -158,13 +173,17 @@ export const NoteFactory = {
     filepathFallbackURI: URI,
     templateFallbackText: string,
     targetDate: Date
-  ): Promise<void> => {
-    const resolver = new Resolver(new Map(), targetDate);
+  ): Promise<{ didCreateFile: boolean; uri: URI | undefined }> => {
+    const resolver = new Resolver(
+      new Map().set('FOAM_TITLE', dateFormat(targetDate, 'yyyy-mm-dd', false)),
+      targetDate
+    );
     return NoteFactory.createFromTemplate(
       DAILY_NOTE_TEMPLATE_URI,
       resolver,
       filepathFallbackURI,
-      templateFallbackText
+      templateFallbackText,
+      _ => Promise.resolve(undefined)
     );
   },
 
@@ -176,7 +195,7 @@ export const NoteFactory = {
   createForPlaceholderWikilink: (
     wikilinkPlaceholder: string,
     filepathFallbackURI: URI
-  ): Promise<void> => {
+  ): Promise<{ didCreateFile: boolean; uri: URI | undefined }> => {
     const resolver = new Resolver(
       new Map().set('FOAM_TITLE', wikilinkPlaceholder),
       new Date()


### PR DESCRIPTION
Fix #967 

Take into account the path from the daily note template when checking if the note already exists.
General improvements around the template and dated notes code.