### PR TITLE
Square brackets on ref links

### DIFF
--- a/packages/foam-vscode/src/features/preview-navigation.spec.ts
+++ b/packages/foam-vscode/src/features/preview-navigation.spec.ts
@@ -11,6 +11,7 @@ import {
   markdownItWithFoamLinks,
   markdownItWithFoamTags,
   markdownItWithNoteInclusion,
+  markdownItWithRemoveLinkReferences,
 } from './preview-navigation';
 
 describe('Link generation in preview', () => {
@@ -22,7 +23,11 @@ describe('Link generation in preview', () => {
     links: [{ slug: 'placeholder' }],
   });
   const ws = new FoamWorkspace().set(noteA);
-  const md = markdownItWithFoamLinks(MarkdownIt(), ws);
+
+  const md = [
+    markdownItWithFoamLinks,
+    markdownItWithRemoveLinkReferences,
+  ].reduce((acc, extension) => extension(acc, ws), MarkdownIt());
 
   it('generates a link to a note', () => {
     expect(md.render(`[[note-a]]`)).toEqual(
@@ -39,6 +44,14 @@ describe('Link generation in preview', () => {
   it('generates a placeholder link to an unknown slug', () => {
     expect(md.render(`[[random-text]]`)).toEqual(
       `<p><a class='foam-placeholder-link' title="Link to non-existing resource" href="javascript:void(0);">random-text</a></p>\n`
+    );
+  });
+
+  it('generates a wikilink even when there is a link reference', () => {
+    const note = `[[note-a]]
+    [note-a]: <note-a.md> "Note A"`;
+    expect(md.render(note)).toEqual(
+      `<p><a class='foam-note-link' title='${noteA.title}' href='/path/to/note-a.md' data-href='/path/to/note-a.md'>note-a</a>\n[note-a]: &lt;note-a.md&gt; &quot;Note A&quot;</p>\n`
     );
   });
 });

--- a/packages/foam-vscode/src/features/preview-navigation.ts
+++ b/packages/foam-vscode/src/features/preview-navigation.ts
@@ -166,7 +166,7 @@ export const markdownItWithRemoveLinkReferences = (
         // need to remove that reference. This ensures the MarkdownIt parser
         // will not replace the wikilink syntax with an <a href> link and as a result
         // break our inclusion logic.
-        if (state.src.toLowerCase().includes(`![[${refKey.toLowerCase()}]]`)) {
+        if (state.src.toLowerCase().includes(`[[${refKey.toLowerCase()}]]`)) {
           delete state.env.references[refKey];
         }
       });

--- a/packages/foam-vscode/src/features/preview-navigation.ts
+++ b/packages/foam-vscode/src/features/preview-navigation.ts
@@ -155,18 +155,17 @@ export const markdownItWithRemoveLinkReferences = (
 ) => {
   md.inline.ruler.before('link', 'clear-references', state => {
     if (state.env.references) {
-      Object.keys(state.env.references).forEach(refKey => {
-        // Forget about reference links that contain an alias divider
-        // Aliased reference links will lead the MarkdownParser to include wrong link references
-        if (refKey.includes(ALIAS_DIVIDER_CHAR)) {
-          delete state.env.references[refKey];
-        }
+      const src = state.src.toLowerCase();
+      const foamLinkRegEx = /\[\[([^[\]]+?)\]\]/g;
+      const foamLinks = [...src.matchAll(foamLinkRegEx)].map(m =>
+        m[1].toLowerCase()
+      );
 
-        // When the reference is present due to an inclusion of that note, we
-        // need to remove that reference. This ensures the MarkdownIt parser
-        // will not replace the wikilink syntax with an <a href> link and as a result
-        // break our inclusion logic.
-        if (state.src.toLowerCase().includes(`[[${refKey.toLowerCase()}]]`)) {
+      Object.keys(state.env.references).forEach(refKey => {
+        // Remove all references that have corresponding wikilinks.
+        // If the markdown parser sees a reference, it will format it before
+        // we get a chance to create the wikilink.
+        if (foamLinks.includes(refKey.toLowerCase())) {
           delete state.env.references[refKey];
         }
       });


### PR DESCRIPTION
When rendering the preview, remove all reference links so that they don't get formatted by MarkdownIt. We want to format them ourselves.

This fixes #960.