### PR TITLE
fix #990: lost escape character (\) in table after rename a file

### DIFF
--- a/packages/foam-vscode/src/core/services/markdown-link.test.ts
+++ b/packages/foam-vscode/src/core/services/markdown-link.test.ts
@@ -188,6 +188,54 @@ describe('MarkdownLink', () => {
       expect(edit.newText).toEqual(`[[wikilink|new-alias]]`);
       expect(edit.selection).toEqual(link.range);
     });
+    it('should be able to rename the escaped alias divider', () => {
+      const link = parser.parse(
+        getRandomURI(),
+        `this is a [[wikilink\\|alias]]`
+      ).links[0];
+      const edit = MarkdownLink.createUpdateLinkEdit(link, {
+        target: 'new-link',
+      });
+      expect(edit.newText).toEqual(`[[new-link\\|alias]]`);
+      expect(edit.selection).toEqual(link.range);
+    });
+    
+    it('should be able to rename the escaped alias divider on \\ in file name', () => {
+      const link = parser.parse(
+        getRandomURI(),
+        `this is a [[wikilink\\|alias]]`
+      ).links[0];
+      const edit = MarkdownLink.createUpdateLinkEdit(link, {
+        target: 'new-link\\',
+      });
+      expect(edit.newText).toEqual(`[[new-link\\\\|alias]]`);
+      expect(edit.selection).toEqual(link.range);
+    });
+    
+
+    it('should be able to rename the escaped alias divider with section link', () => {
+      const link = parser.parse(
+        getRandomURI(),
+        `this is a [[wikilink#section\\|alias]]`
+      ).links[0];
+      const edit = MarkdownLink.createUpdateLinkEdit(link, {
+        target: 'new-link',
+      });
+      expect(edit.newText).toEqual(`[[new-link#section\\|alias]]`);
+      expect(edit.selection).toEqual(link.range);
+    });
+
+    it('should be able to rename the escaped alias divider with section link on \\ in file name', () => {
+      const link = parser.parse(
+        getRandomURI(),
+        `this is a [[wikilink\\#section\\|alias]]`
+      ).links[0];
+      const edit = MarkdownLink.createUpdateLinkEdit(link, {
+        target: 'new-link',
+      });
+      expect(edit.newText).toEqual(`[[new-link\\#section\\|alias]]`);
+      expect(edit.selection).toEqual(link.range);
+    });
   });
 
   describe('rename direct link', () => {

--- a/packages/foam-vscode/src/core/services/markdown-link.test.ts
+++ b/packages/foam-vscode/src/core/services/markdown-link.test.ts
@@ -73,6 +73,15 @@ describe('MarkdownLink', () => {
       expect(parsed.section).toEqual('section with spaces');
       expect(parsed.alias).toEqual('alias with spaces');
     });
+    it('should parse target section and filename end with \\', () => {
+      const link = parser.parse(
+        getRandomURI(),
+        `this is a [[wikilink\\#section]]`
+      ).links[0];
+      const parsed = MarkdownLink.analyzeLink(link);
+      expect(parsed.target).toEqual('wikilink\\');
+      expect(parsed.section).toEqual('section');
+    });
     it('should parse section', () => {
       const link = parser.parse(getRandomURI(), `this is a [[#section]]`)
         .links[0];

--- a/packages/foam-vscode/src/core/services/markdown-link.test.ts
+++ b/packages/foam-vscode/src/core/services/markdown-link.test.ts
@@ -188,7 +188,7 @@ describe('MarkdownLink', () => {
       expect(edit.newText).toEqual(`[[wikilink|new-alias]]`);
       expect(edit.selection).toEqual(link.range);
     });
-    it('should be able to rename the escaped alias divider', () => {
+    it('should be able to rename the table escaped alias divider', () => {
       const link = parser.parse(
         getRandomURI(),
         `this is a [[wikilink\\|alias]]`
@@ -199,21 +199,8 @@ describe('MarkdownLink', () => {
       expect(edit.newText).toEqual(`[[new-link\\|alias]]`);
       expect(edit.selection).toEqual(link.range);
     });
-    
-    it('should be able to rename the escaped alias divider on \\ in file name', () => {
-      const link = parser.parse(
-        getRandomURI(),
-        `this is a [[wikilink\\|alias]]`
-      ).links[0];
-      const edit = MarkdownLink.createUpdateLinkEdit(link, {
-        target: 'new-link\\',
-      });
-      expect(edit.newText).toEqual(`[[new-link\\\\|alias]]`);
-      expect(edit.selection).toEqual(link.range);
-    });
-    
 
-    it('should be able to rename the escaped alias divider with section link', () => {
+    it('should be able to rename the table escaped alias divider with section link', () => {
       const link = parser.parse(
         getRandomURI(),
         `this is a [[wikilink#section\\|alias]]`
@@ -222,18 +209,6 @@ describe('MarkdownLink', () => {
         target: 'new-link',
       });
       expect(edit.newText).toEqual(`[[new-link#section\\|alias]]`);
-      expect(edit.selection).toEqual(link.range);
-    });
-
-    it('should be able to rename the escaped alias divider with section link on \\ in file name', () => {
-      const link = parser.parse(
-        getRandomURI(),
-        `this is a [[wikilink\\#section\\|alias]]`
-      ).links[0];
-      const edit = MarkdownLink.createUpdateLinkEdit(link, {
-        target: 'new-link',
-      });
-      expect(edit.newText).toEqual(`[[new-link\\#section\\|alias]]`);
       expect(edit.selection).toEqual(link.range);
     });
   });

--- a/packages/foam-vscode/src/core/services/markdown-link.ts
+++ b/packages/foam-vscode/src/core/services/markdown-link.ts
@@ -15,6 +15,7 @@ export abstract class MarkdownLink {
           link.rawText
         );
         return {
+          rawTarget: target,
           target: target?.replace(/\\/g, '') ?? '',
           section: section ?? '',
           alias: alias ?? '',
@@ -40,8 +41,16 @@ export abstract class MarkdownLink {
     link: ResourceLink,
     delta: { target?: string; section?: string; alias?: string }
   ) {
-    const { target, section, alias } = MarkdownLink.analyzeLink(link);
-    const newTarget = delta.target ?? target;
+    const { target, section, alias, rawTarget } = MarkdownLink.analyzeLink(
+      link
+    );
+
+    let replacedTarget = null;
+    if (rawTarget && delta.target) {
+      replacedTarget = rawTarget.replace(target, delta.target);
+    }
+
+    const newTarget = replacedTarget ?? delta.target ?? target;
     const newSection = delta.section ?? section ?? '';
     const newAlias = delta.alias ?? alias ?? '';
     const sectionDivider = newSection ? '#' : '';


### PR DESCRIPTION
ref to #990.

