### PR TITLE
Replace usages of fs with vscode.workspace.fs

### DIFF
--- a/packages/foam-vscode/src/core/janitor/generateHeadings.test.ts
+++ b/packages/foam-vscode/src/core/janitor/generateHeadings.test.ts
@@ -1,5 +1,5 @@
 import { generateHeading } from '.';
-import { TEST_DATA_DIR } from '../../test/test-utils';
+import { readFileFromFs, TEST_DATA_DIR } from '../../test/test-utils';
 import { MarkdownResourceProvider } from '../services/markdown-provider';
 import { bootstrap } from '../model/foam';
 import { Resource } from '../model/note';
@@ -20,8 +20,9 @@ describe('generateHeadings', () => {
 
   beforeAll(async () => {
     const matcher = new Matcher([TEST_DATA_DIR.joinPath('__scaffold__')]);
-    const mdProvider = new MarkdownResourceProvider(matcher);
-    const foam = await bootstrap(matcher, new FileDataStore(), [mdProvider]);
+    const dataStore = new FileDataStore(readFileFromFs);
+    const mdProvider = new MarkdownResourceProvider(matcher, dataStore);
+    const foam = await bootstrap(matcher, dataStore, [mdProvider]);
     _workspace = foam.workspace;
   });
 

--- a/packages/foam-vscode/src/core/janitor/generateLinkReferences.test.ts
+++ b/packages/foam-vscode/src/core/janitor/generateLinkReferences.test.ts
@@ -7,6 +7,8 @@ import { Range } from '../model/range';
 import { FoamWorkspace } from '../model/workspace';
 import { FileDataStore, Matcher } from '../services/datastore';
 import { Logger } from '../utils/log';
+import fs from 'fs';
+import { URI } from '../model/uri';
 
 Logger.setLevel('error');
 
@@ -21,8 +23,12 @@ describe('generateLinkReferences', () => {
 
   beforeAll(async () => {
     const matcher = new Matcher([TEST_DATA_DIR.joinPath('__scaffold__')]);
-    const mdProvider = new MarkdownResourceProvider(matcher);
-    const foam = await bootstrap(matcher, new FileDataStore(), [mdProvider]);
+    /** Use fs for reading files in units where vscode.workspace is unavailable */
+    const readFile = async (uri: URI) =>
+      (await fs.promises.readFile(uri.toFsPath())).toString();
+    const dataStore = new FileDataStore(readFile);
+    const mdProvider = new MarkdownResourceProvider(matcher, dataStore);
+    const foam = await bootstrap(matcher, dataStore, [mdProvider]);
     _workspace = foam.workspace;
   });
 

--- a/packages/foam-vscode/src/core/services/datastore.test.ts
+++ b/packages/foam-vscode/src/core/services/datastore.test.ts
@@ -1,4 +1,4 @@
-import { TEST_DATA_DIR } from '../../test/test-utils';
+import { readFileFromFs, TEST_DATA_DIR } from '../../test/test-utils';
 import { URI } from '../model/uri';
 import { Logger } from '../utils/log';
 import { FileDataStore, Matcher, toMatcherPathFormat } from './datastore';
@@ -87,7 +87,7 @@ describe('Matcher', () => {
 describe('Datastore', () => {
   it('uses the matcher to get the file list', async () => {
     const matcher = new Matcher([testFolder], ['**/*.md'], []);
-    const ds = new FileDataStore();
+    const ds = new FileDataStore(readFileFromFs);
     expect((await ds.list(matcher.include[0])).length).toEqual(4);
   });
 });

--- a/packages/foam-vscode/src/core/services/datastore.ts
+++ b/packages/foam-vscode/src/core/services/datastore.ts
@@ -1,5 +1,4 @@
 import micromatch from 'micromatch';
-import fs from 'fs';
 import { URI } from '../model/uri';
 import { Logger } from '../utils/log';
 import { glob } from 'glob';
@@ -115,6 +114,8 @@ export interface IDataStore {
  * File system based data store
  */
 export class FileDataStore implements IDataStore {
+  constructor(private readFile: (uri: URI) => Promise<string>) {}
+
   async list(glob: string, ignoreGlob?: string | string[]): Promise<URI[]> {
     const res = await findAllFiles(glob, {
       ignore: ignoreGlob,
@@ -125,7 +126,7 @@ export class FileDataStore implements IDataStore {
 
   async read(uri: URI) {
     try {
-      return (await fs.promises.readFile(uri.toFsPath())).toString();
+      return await this.readFile(uri);
     } catch (e) {
       Logger.error(
         `FileDataStore: error while reading uri: ${uri.path} - ${e}`

--- a/packages/foam-vscode/src/core/services/markdown-provider.ts
+++ b/packages/foam-vscode/src/core/services/markdown-provider.ts
@@ -8,7 +8,7 @@ import { isNone, isSome } from '../utils';
 import { Logger } from '../utils/log';
 import { URI } from '../model/uri';
 import { FoamWorkspace } from '../model/workspace';
-import { IDataStore, FileDataStore, IMatcher } from '../services/datastore';
+import { IDataStore, IMatcher } from '../services/datastore';
 import { IDisposable } from '../common/lifecycle';
 import { ResourceProvider } from '../model/provider';
 import { createMarkdownParser } from './markdown-parser';
@@ -19,13 +19,13 @@ export class MarkdownResourceProvider implements ResourceProvider {
 
   constructor(
     private readonly matcher: IMatcher,
+    private readonly dataStore: IDataStore,
     private readonly watcherInit?: (triggers: {
       onDidChange: (uri: URI) => void;
       onDidCreate: (uri: URI) => void;
       onDidDelete: (uri: URI) => void;
     }) => IDisposable[],
-    private readonly parser: ResourceParser = createMarkdownParser([]),
-    private readonly dataStore: IDataStore = new FileDataStore()
+    private readonly parser: ResourceParser = createMarkdownParser([])
   ) {}
 
   async init(workspace: FoamWorkspace) {

--- a/packages/foam-vscode/src/core/utils/path.ts
+++ b/packages/foam-vscode/src/core/utils/path.ts
@@ -1,6 +1,5 @@
 import { CharCode } from '../common/charCode';
 import { posix } from 'path';
-import { promises, constants } from 'fs';
 
 /**
  * Converts filesystem path to POSIX path. Supported inputs are:
@@ -145,21 +144,6 @@ export function joinPath(...paths: string[]): string {
  */
 export function relativeTo(path: string, basePath: string): string {
   return posix.relative(basePath, path);
-}
-
-/**
- * Asynchronously checks if there is an accessible file for a path.
- *
- * @param fsPath A filesystem-specific path.
- * @returns true if an accesible file exists, false otherwise.
- */
-export async function existsInFs(fsPath: string) {
-  try {
-    await promises.access(fsPath, constants.F_OK);
-    return true;
-  } catch (e) {
-    return false;
-  }
 }
 
 function hasDrive(path: string, idx = 0): boolean {

--- a/packages/foam-vscode/src/features/hover-provider.spec.ts
+++ b/packages/foam-vscode/src/features/hover-provider.spec.ts
@@ -3,7 +3,7 @@ import { createMarkdownParser } from '../core/services/markdown-parser';
 import { MarkdownResourceProvider } from '../core/services/markdown-provider';
 import { FoamGraph } from '../core/model/graph';
 import { FoamWorkspace } from '../core/model/workspace';
-import { Matcher } from '../core/services/datastore';
+import { FileDataStore, Matcher } from '../core/services/datastore';
 import {
   cleanWorkspace,
   closeEditors,
@@ -12,6 +12,7 @@ import {
 } from '../test/test-utils-vscode';
 import { fromVsCodeUri, toVsCodeUri } from '../utils/vsc-utils';
 import { HoverProvider } from './hover-provider';
+import { readFileFromFs } from '../test/test-utils';
 
 // We can't use createTestWorkspace from /packages/foam-vscode/src/test/test-utils.ts
 // because we need a MarkdownResourceProvider with a real instance of FileDataStore.
@@ -19,7 +20,8 @@ const createWorkspace = () => {
   const matcher = new Matcher(
     vscode.workspace.workspaceFolders.map(f => fromVsCodeUri(f.uri))
   );
-  const resourceProvider = new MarkdownResourceProvider(matcher);
+  const dataStore = new FileDataStore(readFileFromFs);
+  const resourceProvider = new MarkdownResourceProvider(matcher, dataStore);
   const workspace = new FoamWorkspace();
   workspace.registerProvider(resourceProvider);
   return workspace;

--- a/packages/foam-vscode/src/features/janitor.ts
+++ b/packages/foam-vscode/src/features/janitor.ts
@@ -5,14 +5,17 @@ import {
   commands,
   ProgressLocation,
 } from 'vscode';
-import * as fs from 'fs';
 import { FoamFeature } from '../types';
 
 import {
   getWikilinkDefinitionSetting,
   LinkReferenceDefinitionsSetting,
 } from '../settings';
-import { toVsCodePosition, toVsCodeRange } from '../utils/vsc-utils';
+import {
+  toVsCodePosition,
+  toVsCodeRange,
+  toVsCodeUri,
+} from '../utils/vsc-utils';
 import { Foam } from '../core/model/foam';
 import { Resource } from '../core/model/note';
 import { generateHeading, generateLinkReferences } from '../core/janitor';
@@ -125,7 +128,7 @@ async function runJanitor(foam: Foam) {
     text = definitions ? applyTextEdit(text, definitions) : text;
     text = heading ? applyTextEdit(text, heading) : text;
 
-    return fs.promises.writeFile(note.uri.toFsPath(), text);
+    return workspace.fs.writeFile(toVsCodeUri(note.uri), Buffer.from(text));
   });
 
   await Promise.all(fileWritePromises);

--- a/packages/foam-vscode/src/features/tags-tree-view.spec.ts
+++ b/packages/foam-vscode/src/features/tags-tree-view.spec.ts
@@ -1,4 +1,4 @@
-import { createTestNote } from '../test/test-utils';
+import { createTestNote, readFileFromFs } from '../test/test-utils';
 import { cleanWorkspace, closeEditors } from '../test/test-utils-vscode';
 import { TagItem, TagReference, TagsProvider } from './tags-tree-view';
 import { bootstrap, Foam } from '../core/model/foam';
@@ -9,8 +9,9 @@ describe('Tags tree panel', () => {
   let _foam: Foam;
   let provider: TagsProvider;
 
+  const dataStore = new FileDataStore(readFileFromFs);
   const matcher = new Matcher([]);
-  const mdProvider = new MarkdownResourceProvider(matcher);
+  const mdProvider = new MarkdownResourceProvider(matcher, dataStore);
 
   beforeAll(async () => {
     await cleanWorkspace();
@@ -22,7 +23,7 @@ describe('Tags tree panel', () => {
   });
 
   beforeEach(async () => {
-    _foam = await bootstrap(matcher, new FileDataStore(), [mdProvider]);
+    _foam = await bootstrap(matcher, dataStore, [mdProvider]);
     provider = new TagsProvider(_foam, _foam.workspace);
     await closeEditors();
   });

--- a/packages/foam-vscode/src/test/test-utils.ts
+++ b/packages/foam-vscode/src/test/test-utils.ts
@@ -1,6 +1,7 @@
 /*
  * This file should not depend on VS Code as it's used for unit tests
  */
+import fs from 'fs';
 import { Logger } from '../core/utils/log';
 import { Range } from '../core/model/range';
 import { URI } from '../core/model/uri';
@@ -35,7 +36,7 @@ export const strToUri = URI.file;
 export const createTestWorkspace = () => {
   const workspace = new FoamWorkspace();
   const matcher = new Matcher([URI.file('/')], ['**/*']);
-  const provider = new MarkdownResourceProvider(matcher, undefined, undefined, {
+  const provider = new MarkdownResourceProvider(matcher, {
     read: _ => Promise.resolve(''),
     list: _ => Promise.resolve([]),
   });
@@ -111,3 +112,7 @@ export const randomString = (len = 5) =>
 
 export const getRandomURI = () =>
   URI.file('/random-uri-root/' + randomString() + '.md');
+
+/** Use fs for reading files in units where vscode.workspace is unavailable */
+export const readFileFromFs = async (uri: URI) =>
+  (await fs.promises.readFile(uri.toFsPath())).toString();


### PR DESCRIPTION
Related to https://github.com/foambubble/foam/issues/749

This PR removes the hard dependencies on the `fs` module which is not available in the browser environment. `FileDataStore` now requires a `readFile` function which in tests uses `fs` but in extension mode uses `vscode.workspace.fs.readFile`. This is my first contribution to this project, so any feedback on how this is done is welcome.