### PR TITLE
Support alias yaml property

### DIFF
--- a/packages/foam-vscode/src/core/model/note.ts
+++ b/packages/foam-vscode/src/core/model/note.ts
@@ -27,6 +27,11 @@ export interface Tag {
   range: Range;
 }
 
+export interface Alias {
+  title: string;
+  range: Range;
+}
+
 export interface Section {
   label: string;
   range: Range;
@@ -39,6 +44,7 @@ export interface Resource {
   properties: any;
   sections: Section[];
   tags: Tag[];
+  aliases: Alias[];
   links: ResourceLink[];
 
   // TODO to remove
@@ -65,6 +71,7 @@ export abstract class Resource {
       typeof (thing as Resource).type === 'string' &&
       typeof (thing as Resource).properties === 'object' &&
       typeof (thing as Resource).tags === 'object' &&
+      typeof (thing as Resource).aliases === 'object' &&
       typeof (thing as Resource).links === 'object'
     );
   }

--- a/packages/foam-vscode/src/core/services/markdown-parser.test.ts
+++ b/packages/foam-vscode/src/core/services/markdown-parser.test.ts
@@ -380,4 +380,61 @@ and some content`
       expect(note2.properties.hasHeading).toBeTruthy();
     });
   });
+  describe('Alias', () => {
+    it('can find tags in comma separated string', () => {
+      const note = parser.parse(
+        URI.file('/path/to/a'),
+        `
+---
+alias: alias 1, alias 2   , alias3 
+---
+This is a test note without headings.
+But with some content.
+`
+      );
+      expect(note.aliases).toEqual([
+        {
+          range: Range.create(1, 0, 3, 3),
+          title: 'alias 1',
+        },
+        {
+          range: Range.create(1, 0, 3, 3),
+          title: 'alias 2',
+        },
+        {
+          range: Range.create(1, 0, 3, 3),
+          title: 'alias3',
+        },
+      ]);
+    });
+  });
+  it('can find tags in yaml array', () => {
+    const note = parser.parse(
+      URI.file('/path/to/a'),
+      `
+---
+alias:
+- alias 1
+- alias 2
+- alias3
+---
+This is a test note without headings.
+But with some content.
+`
+    );
+    expect(note.aliases).toEqual([
+      {
+        range: Range.create(1, 0, 6, 3),
+        title: 'alias 1',
+      },
+      {
+        range: Range.create(1, 0, 6, 3),
+        title: 'alias 2',
+      },
+      {
+        range: Range.create(1, 0, 6, 3),
+        title: 'alias3',
+      },
+    ]);
+  });
 });

--- a/packages/foam-vscode/src/core/services/markdown-parser.ts
+++ b/packages/foam-vscode/src/core/services/markdown-parser.ts
@@ -40,6 +40,7 @@ export function createMarkdownParser(
     wikilinkPlugin,
     definitionsPlugin,
     tagsPlugin,
+    aliasesPlugin,
     sectionsPlugin,
     ...extraPlugins,
   ];
@@ -72,6 +73,7 @@ export function createMarkdownParser(
         title: '',
         sections: [],
         tags: [],
+        aliases: [],
         links: [],
         definitions: [],
         source: {
@@ -251,6 +253,23 @@ const titlePlugin: ParserPlugin = {
   onDidVisitTree: (tree, note) => {
     if (note.title === '') {
       note.title = note.uri.getName();
+    }
+  },
+};
+
+const aliasesPlugin: ParserPlugin = {
+  name: 'aliases',
+  onDidFindProperties: (props, note, node) => {
+    if (isSome(props.alias)) {
+      const aliases = Array.isArray(props.alias)
+        ? props.alias
+        : props.alias.split(',').map(m => m.trim());
+      for (const alias of aliases) {
+        note.aliases.push({
+          title: alias,
+          range: astPositionToFoamRange(node.position!),
+        });
+      }
     }
   },
 };

--- a/packages/foam-vscode/src/features/link-completion.spec.ts
+++ b/packages/foam-vscode/src/features/link-completion.spec.ts
@@ -157,4 +157,26 @@ Content of section 2
       new Set(['Section 1', 'Section 2'])
     );
   });
+
+  it('should return page alias', async () => {
+    const { uri, content } = await createFile(`
+---
+alias: alias-a
+---
+[[
+`);
+    ws.set(parser.parse(uri, content));
+
+    const { doc } = await showInEditor(uri);
+    const provider = new SectionCompletionProvider(ws);
+
+    const links = await provider.provideCompletionItems(
+      doc,
+      new vscode.Position(4, 2)
+    );
+
+    expect(new Set(links.items.map(i => i.label))).toEqual(
+      new Set(['alias-a'])
+    );
+  });
 });

--- a/packages/foam-vscode/src/features/link-completion.spec.ts
+++ b/packages/foam-vscode/src/features/link-completion.spec.ts
@@ -159,24 +159,28 @@ Content of section 2
   });
 
   it('should return page alias', async () => {
-    const { uri, content } = await createFile(`
+    const { uri, content } = await createFile(
+      `
 ---
 alias: alias-a
 ---
 [[
-`);
+`,
+      ['new-note-with-alias.md']
+    );
     ws.set(parser.parse(uri, content));
 
     const { doc } = await showInEditor(uri);
-    const provider = new SectionCompletionProvider(ws);
+    const provider = new CompletionProvider(ws, graph);
 
     const links = await provider.provideCompletionItems(
       doc,
       new vscode.Position(4, 2)
     );
 
-    expect(new Set(links.items.map(i => i.label))).toEqual(
-      new Set(['alias-a'])
-    );
+    const aliasCompletionItem = links.items.find(i => i.label === 'alias-a');
+    expect(aliasCompletionItem).not.toBeNull();
+    expect(aliasCompletionItem.label).toBe('alias-a');
+    expect(aliasCompletionItem.insertText).toBe('new-note-with-alias|alias-a');
   });
 });

--- a/packages/foam-vscode/src/test/test-utils.ts
+++ b/packages/foam-vscode/src/test/test-utils.ts
@@ -50,6 +50,7 @@ export const createTestNote = (params: {
   definitions?: NoteLinkDefinition[];
   links?: Array<{ slug: string } | { to: string }>;
   tags?: string[];
+  aliases?: string[];
   text?: string;
   sections?: string[];
   root?: URI;
@@ -68,6 +69,11 @@ export const createTestNote = (params: {
     tags:
       params.tags?.map(t => ({
         label: t,
+        range: Range.create(0, 0, 0, 0),
+      })) ?? [],
+    aliases:
+      params.aliases?.map(a => ({
+        title: a,
         range: Range.create(0, 0, 0, 0),
       })) ?? [],
     links: params.links


### PR DESCRIPTION
Adds "alias" yaml property that can be either a string or a list of string.

`title` property is not supported as it can be confusing with the existing Resource.title (which may come from multiple places).

Closes #461
