### PR TITLE
proof of concept for disabling markdown features

### DIFF
--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -439,6 +439,7 @@
     "lodash": "^4.17.21",
     "markdown-it-regex": "^0.2.0",
     "micromatch": "^4.0.2",
+    "remark-disable-tokenizers": "^1.1.0",
     "remark-frontmatter": "^2.0.0",
     "remark-parse": "^8.0.2",
     "remark-wiki-link": "^0.0.4",

--- a/packages/foam-vscode/src/core/services/markdown-parser.ts
+++ b/packages/foam-vscode/src/core/services/markdown-parser.ts
@@ -4,6 +4,7 @@ import unified from 'unified';
 import markdownParse from 'remark-parse';
 import wikiLinkPlugin from 'remark-wiki-link';
 import frontmatterPlugin from 'remark-frontmatter';
+import remarkDisableBlocks from 'remark-disable-tokenizers';
 import { parse as parseYAML } from 'yaml';
 import visit from 'unist-util-visit';
 import detectNewline from 'detect-newline';
@@ -14,7 +15,7 @@ import { Range } from '../model/range';
 import { extractHashtags, extractTagsFromProp, isSome } from '../utils';
 import { Logger } from '../utils/log';
 import { URI } from '../model/uri';
-import { getDisabledMarkdownFeatures } from '../../settings';
+import { DisableMarkdownFeaturesSetting } from '../../settings';
 
 export interface ParserPlugin {
   name?: string;
@@ -29,21 +30,14 @@ export interface ParserPlugin {
 const ALIAS_DIVIDER_CHAR = '|';
 
 export function createMarkdownParser(
-  extraPlugins: ParserPlugin[]
+  extraPlugins: ParserPlugin[],
+  disableMarkDownFeatures?: DisableMarkdownFeaturesSetting
 ): ResourceParser {
   const parser = unified()
     .use(markdownParse, { gfm: true })
     .use(frontmatterPlugin, ['yaml'])
-    .use(wikiLinkPlugin, { aliasDivider: ALIAS_DIVIDER_CHAR });
-
-  const disabledMarkdownFeatures = getDisabledMarkdownFeatures();
-  if (disabledMarkdownFeatures) {
-    if (disabledMarkdownFeatures.indentedCode) {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore
-      delete markdownParse?.Parser?.prototype?.blockTokenizers?.indentedCode;
-    }
-  }
+    .use(wikiLinkPlugin, { aliasDivider: ALIAS_DIVIDER_CHAR })
+    .use(remarkDisableBlocks, disableMarkDownFeatures);
 
   const plugins = [
     titlePlugin,

--- a/packages/foam-vscode/src/core/services/markdown-parser.ts
+++ b/packages/foam-vscode/src/core/services/markdown-parser.ts
@@ -14,6 +14,7 @@ import { Range } from '../model/range';
 import { extractHashtags, extractTagsFromProp, isSome } from '../utils';
 import { Logger } from '../utils/log';
 import { URI } from '../model/uri';
+import { getDisabledMarkdownFeatures } from '../../settings';
 
 export interface ParserPlugin {
   name?: string;
@@ -34,6 +35,15 @@ export function createMarkdownParser(
     .use(markdownParse, { gfm: true })
     .use(frontmatterPlugin, ['yaml'])
     .use(wikiLinkPlugin, { aliasDivider: ALIAS_DIVIDER_CHAR });
+
+  const disabledMarkdownFeatures = getDisabledMarkdownFeatures();
+  if (disabledMarkdownFeatures) {
+    if (disabledMarkdownFeatures.indentedCode) {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+      // @ts-ignore
+      delete markdownParse?.Parser?.prototype?.blockTokenizers?.indentedCode;
+    }
+  }
 
   const plugins = [
     titlePlugin,

--- a/packages/foam-vscode/src/settings.ts
+++ b/packages/foam-vscode/src/settings.ts
@@ -7,6 +7,10 @@ export enum LinkReferenceDefinitionsSetting {
   off = 'off',
 }
 
+export interface DisableMarkdownFeaturesSetting {
+  indentedCode: boolean;
+}
+
 export function getWikilinkDefinitionSetting(): LinkReferenceDefinitionsSetting {
   return workspace
     .getConfiguration('foam.edit')
@@ -36,6 +40,11 @@ export function getGraphStyle(): object {
 
 export function getFoamLoggerLevel(): LogLevel {
   return workspace.getConfiguration('foam.logging').get('level') ?? 'info';
+}
+
+export function getDisabledMarkdownFeatures(): DisableMarkdownFeaturesSetting {
+  // do setting things
+  // return workspace.getConfiguration('foam.disabled-markdown-features').
 }
 
 /** Retrieve the orphans configuration */

--- a/packages/foam-vscode/src/settings.ts
+++ b/packages/foam-vscode/src/settings.ts
@@ -8,7 +8,8 @@ export enum LinkReferenceDefinitionsSetting {
 }
 
 export interface DisableMarkdownFeaturesSetting {
-  indentedCode: boolean;
+  block: string[];
+  inline: string[];
 }
 
 export function getWikilinkDefinitionSetting(): LinkReferenceDefinitionsSetting {
@@ -42,10 +43,10 @@ export function getFoamLoggerLevel(): LogLevel {
   return workspace.getConfiguration('foam.logging').get('level') ?? 'info';
 }
 
-export function getDisabledMarkdownFeatures(): DisableMarkdownFeaturesSetting {
-  // do setting things
-  // return workspace.getConfiguration('foam.disabled-markdown-features').
-}
+// export function getDisabledMarkdownFeatures(): DisableMarkdownFeaturesSetting {
+//   // do setting things
+//   // return workspace.getConfiguration('foam.disabled-markdown-features').
+// }
 
 /** Retrieve the orphans configuration */
 export function getOrphansConfig(): GroupedResourcesConfig {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3665,6 +3665,11 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
+clone@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  integrity sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -9379,6 +9384,13 @@ regjsparser@^0.6.4:
   integrity sha512-ib77G0uxsA2ovgiYbCVGx4Pv3PSttAx2vIwidqQzbL2U5S4Q+j00HdSAneSBuyVcMvEnTXMjiGgB+DlXozVhpQ==
   dependencies:
     jsesc "~0.5.0"
+
+remark-disable-tokenizers@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/remark-disable-tokenizers/-/remark-disable-tokenizers-1.1.0.tgz#607dc77e7208eed85cef06aebd2e5a924c21b39f"
+  integrity sha512-49cCg4uSVKVmDHWKT5w+2mpDQ3G+xvt/GjypOqjlS0qTSs6/aBxE3iNWgX6ls2upXY17EKVlU0UpGcZjmGWI6A==
+  dependencies:
+    clone "^2.1.2"
 
 remark-frontmatter@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Hi ^^

Indentation is a big part of my note taking flow, and I'm on a quest to support it in my instance of foam.

Namely this involves removing the code-block markdown feature with https://www.npmjs.com/package/remark-disable-tokenizers so my markdown gets interpreted as I want even though it's indented

I've been able to do so by patching the source files, but it would be nice to not have to do that every time i install a foam update 😄

I've drafted up a setting that would enable one to disable remark features by providing a list of tokenisers to disable. Figured I might solicit comment before finishing it. Is this something you'd be interested in merging?