### PR TITLE
Add request timeout on CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-18.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v1
       - name: Setup Node
@@ -39,6 +40,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       OS: ${{ matrix.os }}
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v1
       - name: Setup Node
@@ -60,4 +62,4 @@ jobs:
       - name: Run Tests
         uses: GabrielBB/xvfb-action@v1.4
         with:
-          run: yarn test
+          run: yarn test --stream


### PR DESCRIPTION
In https://github.com/foambubble/foam/runs/6956872619, the CI job ran for 6 hours on Mac OS before timing out. This is a waste of resources and seem to have happened multiple times.

Additionally adds `--stream` flag to stream stdout stderr for root causing.

https://github.com/foambubble/foam/actions/runs/2437654207
https://github.com/foambubble/foam/actions/runs/2294122217
https://github.com/foambubble/foam/actions/runs/2384003934