### PR TITLE
Added cache for markdown parser

### DIFF
--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -160,6 +160,10 @@
     },
     "commands": [
       {
+        "command": "foam-vscode.clear-cache",
+        "title": "Foam: Clear Cache"
+      },
+      {
         "command": "foam-vscode.update-graph",
         "title": "Foam: Update graph"
       },

--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -463,6 +463,7 @@
     "glob": "^7.1.6",
     "gray-matter": "^4.0.2",
     "lodash": "^4.17.21",
+    "lru-cache": "^7.12.0",
     "markdown-it-regex": "^0.2.0",
     "micromatch": "^4.0.2",
     "remark-frontmatter": "^2.0.0",

--- a/packages/foam-vscode/src/core/janitor/generate-headings.test.ts
+++ b/packages/foam-vscode/src/core/janitor/generate-headings.test.ts
@@ -1,7 +1,6 @@
 import { generateHeading } from '.';
 import { readFileFromFs, TEST_DATA_DIR } from '../../test/test-utils';
 import { MarkdownResourceProvider } from '../services/markdown-provider';
-import { bootstrap } from '../model/foam';
 import { Resource } from '../model/note';
 import { Range } from '../model/range';
 import { FoamWorkspace } from '../model/workspace';

--- a/packages/foam-vscode/src/core/janitor/generate-headings.test.ts
+++ b/packages/foam-vscode/src/core/janitor/generate-headings.test.ts
@@ -8,6 +8,7 @@ import { FoamWorkspace } from '../model/workspace';
 import { FileDataStore, Matcher } from '../services/datastore';
 import { Logger } from '../utils/log';
 import detectNewline from 'detect-newline';
+import { createMarkdownParser } from '../services/markdown-parser';
 
 Logger.setLevel('error');
 
@@ -22,9 +23,9 @@ describe('generateHeadings', () => {
   beforeAll(async () => {
     const matcher = new Matcher([TEST_DATA_DIR.joinPath('__scaffold__')]);
     const dataStore = new FileDataStore(readFileFromFs);
-    const mdProvider = new MarkdownResourceProvider(matcher, dataStore);
-    const foam = await bootstrap(matcher, dataStore, [mdProvider]);
-    _workspace = foam.workspace;
+    const parser = createMarkdownParser();
+    const mdProvider = new MarkdownResourceProvider(matcher, dataStore, parser);
+    _workspace = await FoamWorkspace.fromProviders([mdProvider]);
   });
 
   it.skip('should add heading to a file that does not have them', async () => {

--- a/packages/foam-vscode/src/core/janitor/generate-link-references.test.ts
+++ b/packages/foam-vscode/src/core/janitor/generate-link-references.test.ts
@@ -1,7 +1,6 @@
 import { generateLinkReferences } from '.';
 import { TEST_DATA_DIR } from '../../test/test-utils';
 import { MarkdownResourceProvider } from '../services/markdown-provider';
-import { bootstrap } from '../model/foam';
 import { Resource } from '../model/note';
 import { Range } from '../model/range';
 import { FoamWorkspace } from '../model/workspace';

--- a/packages/foam-vscode/src/core/janitor/generate-link-references.test.ts
+++ b/packages/foam-vscode/src/core/janitor/generate-link-references.test.ts
@@ -10,6 +10,7 @@ import { Logger } from '../utils/log';
 import fs from 'fs';
 import { URI } from '../model/uri';
 import { EOL } from 'os';
+import { createMarkdownParser } from '../services/markdown-parser';
 
 Logger.setLevel('error');
 
@@ -28,9 +29,9 @@ describe('generateLinkReferences', () => {
     const readFile = async (uri: URI) =>
       (await fs.promises.readFile(uri.toFsPath())).toString();
     const dataStore = new FileDataStore(readFile);
-    const mdProvider = new MarkdownResourceProvider(matcher, dataStore);
-    const foam = await bootstrap(matcher, dataStore, [mdProvider]);
-    _workspace = foam.workspace;
+    const parser = createMarkdownParser();
+    const mdProvider = new MarkdownResourceProvider(matcher, dataStore, parser);
+    _workspace = await FoamWorkspace.fromProviders([mdProvider]);
   });
 
   it('initialised test graph correctly', () => {

--- a/packages/foam-vscode/src/core/model/foam.ts
+++ b/packages/foam-vscode/src/core/model/foam.ts
@@ -24,9 +24,9 @@ export interface Foam extends IDisposable {
 export const bootstrap = async (
   matcher: IMatcher,
   dataStore: IDataStore,
+  parser: ResourceParser,
   initialProviders: ResourceProvider[]
 ) => {
-  const parser = createMarkdownParser([]);
   const workspace = new FoamWorkspace();
   const tsStart = Date.now();
 

--- a/packages/foam-vscode/src/core/model/foam.ts
+++ b/packages/foam-vscode/src/core/model/foam.ts
@@ -4,7 +4,6 @@ import { FoamWorkspace } from './workspace';
 import { FoamGraph } from './graph';
 import { ResourceParser } from './note';
 import { ResourceProvider } from './provider';
-import { createMarkdownParser } from '../services/markdown-parser';
 import { FoamTags } from './tags';
 import { Logger } from '../utils/log';
 

--- a/packages/foam-vscode/src/core/model/graph.ts
+++ b/packages/foam-vscode/src/core/model/graph.ts
@@ -123,7 +123,7 @@ export class FoamGraph implements IDisposable {
     }
 
     const end = Date.now();
-    Logger.info(`Graph updated in ${end - start}ms`);
+    Logger.debug(`Graph updated in ${end - start}ms`);
     this.onDidUpdateEmitter.fire();
   }
 

--- a/packages/foam-vscode/src/core/model/workspace.ts
+++ b/packages/foam-vscode/src/core/model/workspace.ts
@@ -218,6 +218,16 @@ export class FoamWorkspace implements IDisposable {
 
     return identifier;
   }
+
+  static async fromProviders(
+    providers: ResourceProvider[]
+  ): Promise<FoamWorkspace> {
+    const workspace = new FoamWorkspace();
+    for (const provider of providers) {
+      await workspace.registerProvider(provider);
+    }
+    return workspace;
+  }
 }
 
 const normalize = (v: string) => v.toLocaleLowerCase();

--- a/packages/foam-vscode/src/core/services/markdown-parser.ts
+++ b/packages/foam-vscode/src/core/services/markdown-parser.ts
@@ -26,6 +26,11 @@ export interface ParserPlugin {
 
 type Checksum = string;
 
+export interface ParserCacheEntry {
+  checksum: Checksum;
+  resource: Resource;
+}
+
 /**
  * This caches the parsed markdown for a given URI.
  *
@@ -34,7 +39,7 @@ type Checksum = string;
  *
  * If the URI and the Checksum have not changed, the cached resource is returned.
  */
-export interface ParserCache extends ICache<URI, [Checksum, Resource]> {}
+export interface ParserCache extends ICache<URI, ParserCacheEntry> {}
 
 export function createMarkdownParser(
   extraPlugins: ParserPlugin[] = [],
@@ -138,13 +143,13 @@ export function createMarkdownParser(
     parse: (uri: URI, markdown: string): Resource => {
       const actualChecksum = hash(markdown);
       if (cache.has(uri)) {
-        const [expectedChecksum, cachedResource] = cache.get(uri);
-        if (actualChecksum === expectedChecksum) {
-          return cachedResource;
+        const { checksum, resource } = cache.get(uri);
+        if (actualChecksum === checksum) {
+          return resource;
         }
       }
       const resource = foamParser.parse(uri, markdown);
-      cache.set(uri, [actualChecksum, resource]);
+      cache.set(uri, { checksum: actualChecksum, resource });
       return resource;
     },
   };

--- a/packages/foam-vscode/src/core/services/markdown-parser.ts
+++ b/packages/foam-vscode/src/core/services/markdown-parser.ts
@@ -39,7 +39,7 @@ export interface ParserCacheEntry {
  *
  * If the URI and the Checksum have not changed, the cached resource is returned.
  */
-export interface ParserCache extends ICache<URI, ParserCacheEntry> {}
+export type ParserCache = ICache<URI, ParserCacheEntry>;
 
 export function createMarkdownParser(
   extraPlugins: ParserPlugin[] = [],

--- a/packages/foam-vscode/src/core/services/markdown-provider.ts
+++ b/packages/foam-vscode/src/core/services/markdown-provider.ts
@@ -20,8 +20,8 @@ export class MarkdownResourceProvider implements ResourceProvider {
   constructor(
     private readonly matcher: IMatcher,
     private readonly dataStore: IDataStore,
-    private readonly watcher?: IWatcher,
-    private readonly parser: ResourceParser = createMarkdownParser([])
+    private readonly parser: ResourceParser,
+    private readonly watcher?: IWatcher
   ) {}
 
   async init(workspace: FoamWorkspace) {

--- a/packages/foam-vscode/src/core/services/markdown-provider.ts
+++ b/packages/foam-vscode/src/core/services/markdown-provider.ts
@@ -11,7 +11,6 @@ import { FoamWorkspace } from '../model/workspace';
 import { IDataStore, IMatcher, IWatcher } from '../services/datastore';
 import { IDisposable } from '../common/lifecycle';
 import { ResourceProvider } from '../model/provider';
-import { createMarkdownParser } from './markdown-parser';
 import { MarkdownLink } from './markdown-link';
 
 export class MarkdownResourceProvider implements ResourceProvider {

--- a/packages/foam-vscode/src/core/utils/cache.ts
+++ b/packages/foam-vscode/src/core/utils/cache.ts
@@ -1,0 +1,7 @@
+export interface ICache<K, V> {
+  get(key: K): V | undefined;
+  has(key: K): boolean;
+  set(key: K, data: V): void;
+  del(key: K): void;
+  clear(): void;
+}

--- a/packages/foam-vscode/src/extension.ts
+++ b/packages/foam-vscode/src/extension.ts
@@ -12,7 +12,7 @@ import { fromVsCodeUri, toVsCodeUri } from './utils/vsc-utils';
 import { AttachmentResourceProvider } from './core/services/attachment-provider';
 import { VsCodeWatcher } from './services/watcher';
 import { createMarkdownParser } from './core/services/markdown-parser';
-import { VsCodeBasedParserCache } from './services/cache';
+import VsCodeBasedParserCache from './services/cache';
 
 export async function activate(context: ExtensionContext) {
   const logger = new VsCodeOutputLogger();
@@ -58,15 +58,15 @@ export async function activate(context: ExtensionContext) {
     const resPromises = features.map(f => f.activate(context, foamPromise));
 
     const foam = await foamPromise;
-    Logger.info(`Loaded ${foam.workspace.list().length} notes`);
+    Logger.info(`Loaded ${foam.workspace.list().length} resources`);
     context.subscriptions.push(
       foam,
       watcher,
       markdownProvider,
       attachmentProvider,
-      commands.registerCommand('foam-vscode.clear-cache', () => {
-        parserCache.clear();
-      })
+      commands.registerCommand('foam-vscode.clear-cache', () =>
+        parserCache.clear()
+      )
     );
 
     const res = (await Promise.all(resPromises)).filter(r => r != null);

--- a/packages/foam-vscode/src/extension.ts
+++ b/packages/foam-vscode/src/extension.ts
@@ -40,8 +40,8 @@ export async function activate(context: ExtensionContext) {
     const markdownProvider = new MarkdownResourceProvider(
       matcher,
       dataStore,
-      watcher,
-      parser
+      parser,
+      watcher
     );
     const attachmentProvider = new AttachmentResourceProvider(
       matcher,
@@ -49,7 +49,7 @@ export async function activate(context: ExtensionContext) {
       watcher
     );
 
-    const foamPromise = bootstrap(matcher, dataStore, [
+    const foamPromise = bootstrap(matcher, dataStore, parser, [
       markdownProvider,
       attachmentProvider,
     ]);

--- a/packages/foam-vscode/src/features/hover-provider.spec.ts
+++ b/packages/foam-vscode/src/features/hover-provider.spec.ts
@@ -21,7 +21,12 @@ const createWorkspace = () => {
     vscode.workspace.workspaceFolders.map(f => fromVsCodeUri(f.uri))
   );
   const dataStore = new FileDataStore(readFileFromFs);
-  const resourceProvider = new MarkdownResourceProvider(matcher, dataStore);
+  const parser = createMarkdownParser();
+  const resourceProvider = new MarkdownResourceProvider(
+    matcher,
+    dataStore,
+    parser
+  );
   const workspace = new FoamWorkspace();
   workspace.registerProvider(resourceProvider);
   return workspace;

--- a/packages/foam-vscode/src/features/tags-tree-view.spec.ts
+++ b/packages/foam-vscode/src/features/tags-tree-view.spec.ts
@@ -4,6 +4,7 @@ import { TagItem, TagReference, TagsProvider } from './tags-tree-view';
 import { bootstrap, Foam } from '../core/model/foam';
 import { MarkdownResourceProvider } from '../core/services/markdown-provider';
 import { FileDataStore, Matcher } from '../core/services/datastore';
+import { createMarkdownParser } from '../core/services/markdown-parser';
 
 describe('Tags tree panel', () => {
   let _foam: Foam;
@@ -11,7 +12,8 @@ describe('Tags tree panel', () => {
 
   const dataStore = new FileDataStore(readFileFromFs);
   const matcher = new Matcher([]);
-  const mdProvider = new MarkdownResourceProvider(matcher, dataStore);
+  const parser = createMarkdownParser();
+  const mdProvider = new MarkdownResourceProvider(matcher, dataStore, parser);
 
   beforeAll(async () => {
     await cleanWorkspace();
@@ -23,7 +25,7 @@ describe('Tags tree panel', () => {
   });
 
   beforeEach(async () => {
-    _foam = await bootstrap(matcher, dataStore, [mdProvider]);
+    _foam = await bootstrap(matcher, dataStore, parser, [mdProvider]);
     provider = new TagsProvider(_foam, _foam.workspace);
     await closeEditors();
   });

--- a/packages/foam-vscode/src/services/cache.ts
+++ b/packages/foam-vscode/src/services/cache.ts
@@ -1,0 +1,64 @@
+import { ExtensionContext } from 'vscode';
+import { Resource } from '../core/model/note';
+import { URI } from '../core/model/uri';
+import { ParserCache } from '../core/services/markdown-parser';
+import { Logger } from '../core/utils/log';
+
+/**
+ * This is a best effort implementation to cache resources.
+ * It's not a perfect solution, but it's a good start.
+ *
+ * We use the URI and a checksum of the markdown file to cache the resource.
+ */
+export class VsCodeBasedParserCache implements ParserCache {
+  private static CACHE_NAME = 'foam-cache';
+  private _cache: { [key: string]: [string, Resource] };
+
+  constructor(private context: ExtensionContext) {
+    this._cache = context.workspaceState.get(
+      VsCodeBasedParserCache.CACHE_NAME,
+      {}
+    );
+    Logger.info('Cache size: ' + Object.keys(this._cache).length);
+  }
+
+  get(uri: URI): [string, Resource] {
+    const result = this._cache[uri.toString()];
+    if (result) {
+      // The cache returns a plain object, but we need an actual
+      // instance of URI in the resource (we check instanceof in the code),
+      // so to be sure we convert it here.
+      const [checksum, resource] = result;
+      const rehydrated = {
+        ...resource,
+        uri: new URI(resource.uri),
+      };
+      return [checksum, rehydrated];
+    }
+    return undefined;
+  }
+
+  has(uri: URI): boolean {
+    return uri.toString() in this._cache;
+  }
+
+  set(uri: URI, data: [string, Resource]): void {
+    this._cache[uri.toString()] = data;
+    this.context.workspaceState.update(
+      VsCodeBasedParserCache.CACHE_NAME,
+      this._cache
+    );
+  }
+
+  del(uri: URI): void {
+    delete this._cache[uri.toString()];
+  }
+
+  clear(): void {
+    this._cache = {};
+    this.context.workspaceState.update(
+      VsCodeBasedParserCache.CACHE_NAME,
+      this._cache
+    );
+  }
+}

--- a/packages/foam-vscode/src/services/cache.ts
+++ b/packages/foam-vscode/src/services/cache.ts
@@ -1,7 +1,11 @@
+import { debounce } from 'lodash';
+import LRU from 'lru-cache';
 import { ExtensionContext } from 'vscode';
-import { Resource } from '../core/model/note';
 import { URI } from '../core/model/uri';
-import { ParserCache } from '../core/services/markdown-parser';
+import {
+  ParserCache,
+  ParserCacheEntry,
+} from '../core/services/markdown-parser';
 import { Logger } from '../core/utils/log';
 
 /**
@@ -10,55 +14,75 @@ import { Logger } from '../core/utils/log';
  *
  * We use the URI and a checksum of the markdown file to cache the resource.
  */
-export class VsCodeBasedParserCache implements ParserCache {
-  private static CACHE_NAME = 'foam-cache';
-  private _cache: { [key: string]: [string, Resource] };
+export default class VsCodeBasedParserCache implements ParserCache {
+  static CACHE_NAME = 'foam-cache';
+  private _cache: LRU<string, ParserCacheEntry>;
 
-  constructor(private context: ExtensionContext) {
-    this._cache = context.workspaceState.get(
+  constructor(private context: ExtensionContext, size = 10000) {
+    this._cache = new LRU({
+      max: size,
+      updateAgeOnGet: true,
+      updateAgeOnHas: false,
+    });
+    const source = context.workspaceState.get(
       VsCodeBasedParserCache.CACHE_NAME,
-      {}
+      []
     );
-    Logger.info('Cache size: ' + Object.keys(this._cache).length);
+    try {
+      this._cache.load(source);
+    } catch (e) {
+      Logger.warn(`Failed to load cache: ${e}`);
+      this.clear();
+    }
+    Logger.debug('Cache size: ' + this._cache.size);
   }
 
-  get(uri: URI): [string, Resource] {
-    const result = this._cache[uri.toString()];
+  clear(): void {
+    this._cache.clear();
+    this.context.workspaceState.update(VsCodeBasedParserCache.CACHE_NAME, []);
+  }
+
+  get(uri: URI): ParserCacheEntry {
+    const result = this._cache.get(uri.toString());
     if (result) {
       // The cache returns a plain object, but we need an actual
       // instance of URI in the resource (we check instanceof in the code),
       // so to be sure we convert it here.
-      const [checksum, resource] = result;
+      const { checksum, resource } = result;
       const rehydrated = {
         ...resource,
         uri: new URI(resource.uri),
       };
-      return [checksum, rehydrated];
+      return {
+        checksum,
+        resource: rehydrated,
+      };
     }
     return undefined;
   }
 
   has(uri: URI): boolean {
-    return uri.toString() in this._cache;
+    return this._cache.has(uri.toString());
   }
 
-  set(uri: URI, data: [string, Resource]): void {
-    this._cache[uri.toString()] = data;
-    this.context.workspaceState.update(
-      VsCodeBasedParserCache.CACHE_NAME,
-      this._cache
-    );
+  set(uri: URI, entry: ParserCacheEntry): void {
+    this._cache.set(uri.toString(), entry);
+    delayedSync(this._cache, this.context);
   }
 
   del(uri: URI): void {
-    delete this._cache[uri.toString()];
-  }
-
-  clear(): void {
-    this._cache = {};
-    this.context.workspaceState.update(
-      VsCodeBasedParserCache.CACHE_NAME,
-      this._cache
-    );
+    this._cache.delete(uri.toString());
+    delayedSync(this._cache, this.context);
   }
 }
+
+const delayedSync = debounce(
+  (cache: LRU<string, ParserCacheEntry>, context) => {
+    Logger.debug('Updating parser cache');
+    context.workspaceState.update(
+      VsCodeBasedParserCache.CACHE_NAME,
+      cache.dump()
+    );
+  },
+  1000
+);

--- a/packages/foam-vscode/src/test/test-utils.ts
+++ b/packages/foam-vscode/src/test/test-utils.ts
@@ -9,6 +9,7 @@ import { FoamWorkspace } from '../core/model/workspace';
 import { Matcher } from '../core/services/datastore';
 import { MarkdownResourceProvider } from '../core/services/markdown-provider';
 import { NoteLinkDefinition, Resource } from '../core/model/note';
+import { createMarkdownParser } from '../core/services/markdown-parser';
 
 export { default as waitForExpect } from 'wait-for-expect';
 
@@ -32,10 +33,15 @@ export const strToUri = URI.file;
 export const createTestWorkspace = () => {
   const workspace = new FoamWorkspace();
   const matcher = new Matcher([URI.file('/')], ['**/*']);
-  const provider = new MarkdownResourceProvider(matcher, {
-    read: _ => Promise.resolve(''),
-    list: _ => Promise.resolve([]),
-  });
+  const parser = createMarkdownParser();
+  const provider = new MarkdownResourceProvider(
+    matcher,
+    {
+      read: _ => Promise.resolve(''),
+      list: _ => Promise.resolve([]),
+    },
+    parser
+  );
   workspace.registerProvider(provider);
   return workspace;
 };

--- a/packages/foam-vscode/syntaxes/injection.json
+++ b/packages/foam-vscode/syntaxes/injection.json
@@ -1,6 +1,6 @@
 {
   "scopeName": "foam.wikilink.injection",
-  "injectionSelector": "L:meta.paragraph.markdown, L:markup.heading.markdown",
+  "injectionSelector": "L:meta.paragraph.markdown, L:markup.heading.markdown, L:markup.list.unnumbered.markdown",
   "patterns": [
     {
       "contentName": "string.other.link.title.markdown.foam",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7807,6 +7807,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lru-cache@^7.12.0:
+  version "7.12.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.12.0.tgz#be2649a992c8a9116efda5c487538dcf715f3476"
+  integrity sha512-OIP3DwzRZDfLg9B9VP/huWBlpvbkmbfiBy8xmsXp4RPmE4A3MhwNozc5ZJ3fWnSg8fDcdlE/neRTPG2ycEKliw==
+
 macos-release@^2.2.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.4.1.tgz#64033d0ec6a5e6375155a74b1a1eba8e509820ac"


### PR DESCRIPTION
This cache will speed up the loading time for notes.

It uses a checksum to verify the content of the file has not changed, and the file URI to minimize the number of entries in the cache.

It's saved in the VS Code `workspaceState`