### PR TITLE
Use note title in link completion

### DIFF
--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -243,6 +243,21 @@
     "configuration": {
       "title": "Foam",
       "properties": {
+        "foam.completion.label": {
+          "type": "string",
+          "default": "path",
+          "description": "Describes what note property to use as a label for completion items",
+          "enum": [
+            "path",
+            "title",
+            "identifier"
+          ],
+          "enumDescriptions": [
+            "Use the path of the note",
+            "Use the title of the note",
+            "Use the identifier of the note"
+          ]
+        },
         "foam.files.ignore": {
           "type": [
             "array"

--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -258,6 +258,19 @@
             "Use the identifier of the note"
           ]
         },
+        "foam.completion.useAlias": {
+          "type": "string",
+          "default": "never",
+          "description": "Specifies in which cases to use an alias when creating a wikilink",
+          "enum": [
+            "never",
+            "whenPathDiffersFromTitle"
+          ],
+          "enumDescriptions": [
+            "Never use aliases in completion items",
+            "Use alias if resource path is different from title"
+          ]
+        },
         "foam.files.ignore": {
           "type": [
             "array"

--- a/packages/foam-vscode/src/features/link-completion.spec.ts
+++ b/packages/foam-vscode/src/features/link-completion.spec.ts
@@ -10,7 +10,7 @@ import {
 } from '../test/test-utils-vscode';
 import { fromVsCodeUri } from '../utils/vsc-utils';
 import {
-  CompletionProvider,
+  WikilinkCompletionProvider,
   SectionCompletionProvider,
 } from './link-completion';
 
@@ -63,7 +63,7 @@ describe('Link Completion', () => {
   it('should not return any link for empty documents', async () => {
     const { uri } = await createFile('');
     const { doc } = await showInEditor(uri);
-    const provider = new CompletionProvider(ws, graph);
+    const provider = new WikilinkCompletionProvider(ws, graph);
 
     const links = await provider.provideCompletionItems(
       doc,
@@ -76,7 +76,7 @@ describe('Link Completion', () => {
   it('should not return link outside the wikilink brackets', async () => {
     const { uri } = await createFile('[[file]] then');
     const { doc } = await showInEditor(uri);
-    const provider = new CompletionProvider(ws, graph);
+    const provider = new WikilinkCompletionProvider(ws, graph);
 
     const links = await provider.provideCompletionItems(
       doc,
@@ -90,7 +90,7 @@ describe('Link Completion', () => {
     for (const text of ['[[', '[[file]] [[', '[[file]] #tag [[']) {
       const { uri } = await createFile(text);
       const { doc } = await showInEditor(uri);
-      const provider = new CompletionProvider(ws, graph);
+      const provider = new WikilinkCompletionProvider(ws, graph);
 
       const links = await provider.provideCompletionItems(
         doc,
@@ -171,7 +171,7 @@ alias: alias-a
     ws.set(parser.parse(uri, content));
 
     const { doc } = await showInEditor(uri);
-    const provider = new CompletionProvider(ws, graph);
+    const provider = new WikilinkCompletionProvider(ws, graph);
 
     const links = await provider.provideCompletionItems(
       doc,

--- a/packages/foam-vscode/src/features/link-completion.ts
+++ b/packages/foam-vscode/src/features/link-completion.ts
@@ -215,8 +215,6 @@ export class WikilinkCompletionProvider
       item.sortText = resourceIsDocument
         ? `0-${item.label}`
         : `1-${item.label}`;
-      // TODO test this
-      item.filterText = resource.title + ' ' + resource.uri.getName();
 
       const useAlias =
         resourceIsDocument &&

--- a/packages/foam-vscode/src/features/link-completion.ts
+++ b/packages/foam-vscode/src/features/link-completion.ts
@@ -226,9 +226,9 @@ export class WikilinkCompletionProvider
       item.insertText = useAlias
         ? `${identifier}|${resource.title}`
         : identifier;
+      item.commitCharacters = useAlias ? [] : linkCommitCharacters;
       item.range = replacementRange;
       item.command = COMPLETION_CURSOR_MOVE;
-      item.commitCharacters = linkCommitCharacters;
       return item;
     });
     const aliases = this.ws.list().flatMap(resource =>


### PR DESCRIPTION
Fixes #1038

Use the note title instead of the filename in autocomplete.

We add 2 settings:
- `foam.completion.label` to select how to display items in the completion list
- `foam.completion.useAlias` to select whether to automatically add an alias to links where the note title doesn't match the note identifier (filename mostly, see https://github.com/foambubble/foam/blob/2385bd75b50b298e3cffc41cedc5545d3bb18114/docs/dev/proposals/wikilinks-in-foam.md)

A few considerations:
- because of the way autocompletion works in VS Code, when inserting the alias it's not possible to use the `#` commit char, so I just disabled it
- I tried to keep the path in the search text, but it doesn't seem to work as I would have expected - not a major issue anyhow

This can also be useful in the context of #872 
