### PR TITLE
Added "create note" command

### DIFF
--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -29,6 +29,7 @@
     "onCommand:foam-vscode.copy-without-brackets",
     "onCommand:foam-vscode.show-graph",
     "onCommand:foam-vscode.create-new-template",
+    "onCommand:foam-vscode.create-note",
     "onCommand:foam-vscode.create-note-from-template",
     "onCommand:foam-vscode.create-note-from-default-template"
   ],
@@ -159,6 +160,10 @@
       ]
     },
     "commands": [
+      {
+        "command": "foam-vscode.create-note",
+        "title": "Create Note"
+      },
       {
         "command": "foam-vscode.clear-cache",
         "title": "Foam: Clear Cache"

--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -130,6 +130,10 @@
       ],
       "commandPalette": [
         {
+          "command": "foam-vscode.create-note-from-default-template",
+          "when": "false"
+        },
+        {
           "command": "foam-vscode.update-graph",
           "when": "false"
         },
@@ -162,7 +166,7 @@
     "commands": [
       {
         "command": "foam-vscode.create-note",
-        "title": "Create Note"
+        "title": "Foam: Create Note"
       },
       {
         "command": "foam-vscode.clear-cache",
@@ -206,7 +210,7 @@
       },
       {
         "command": "foam-vscode.create-note-from-template",
-        "title": "Foam: Create New Note From Template"
+        "title": "Foam: Create Note From Template"
       },
       {
         "command": "foam-vscode.create-note-from-default-template",

--- a/packages/foam-vscode/src/core/model/uri.ts
+++ b/packages/foam-vscode/src/core/model/uri.ts
@@ -5,6 +5,7 @@
 // See LICENSE for details
 
 import { CharCode } from '../common/charCode';
+import { isNone } from '../utils';
 import * as pathUtils from '../utils/path';
 
 /**
@@ -366,4 +367,44 @@ function encodeURIComponentMinimal(path: string): string {
     }
   }
   return res !== undefined ? res : path;
+}
+
+/**
+ * Turns a relative URI into an absolute URI given a collection of base folders.
+ * - if no workspace folder is provided, it will throw
+ * - if the given URI is already absolute, it will return it
+ * - if the given URI is relative
+ *   - if there is only one workspace folder, it will be relative to that
+ *   - if there is more than a workspace folder, it will search for the one matching the
+ *     first part of the URI
+ *   - if no matching workspace folder is found, it will use the first one
+ *   - if more than a folder matches the first part of the URI, it will return the first one
+ * @param uri the uri to evaluate
+ * @param baseFolders the base folders to use
+ * @returns an absolute uri
+ *
+ * TODO this probably needs to be moved to the workspace service
+ */
+export function asAbsoluteUri(uri: URI, baseFolders: URI[]): URI {
+  if (isNone(baseFolders) || baseFolders.length === 0) {
+    throw new Error('Cannot compute absolute URI without a base');
+  }
+  if (uri.isAbsolute()) {
+    return uri;
+  }
+  let tokens = uri.path.split('/');
+  const firstDir = tokens[0];
+  let base = baseFolders[0];
+  if (baseFolders.length > 1) {
+    for (const folder of baseFolders) {
+      const lastDir = folder.path.split('/').pop();
+      if (lastDir === firstDir) {
+        tokens = tokens.slice(1);
+        base = folder;
+        break;
+      }
+    }
+  }
+  const res = base.joinPath(...tokens);
+  return res;
 }

--- a/packages/foam-vscode/src/features/commands/create-note-from-default-template.ts
+++ b/packages/foam-vscode/src/features/commands/create-note-from-default-template.ts
@@ -1,14 +1,22 @@
-import { commands, ExtensionContext } from 'vscode';
+import { commands, window, ExtensionContext } from 'vscode';
 import { FoamFeature } from '../../types';
 import { getDefaultTemplateUri, NoteFactory } from '../../services/templates';
 import { Resolver } from '../../services/variable-resolver';
 
+/**
+ * Create a new note from the default template.
+ *
+ * @deprecated use 'foam-vscode.create-note' instead
+ */
 const feature: FoamFeature = {
   activate: (context: ExtensionContext) => {
     context.subscriptions.push(
       commands.registerCommand(
         'foam-vscode.create-note-from-default-template',
         () => {
+          window.showWarningMessage(
+            "This command is deprecated, use 'Foam: Create Note' (foam-vscode.create-note) instead"
+          );
           const resolver = new Resolver(new Map(), new Date());
 
           return NoteFactory.createFromTemplate(

--- a/packages/foam-vscode/src/features/commands/create-note.spec.ts
+++ b/packages/foam-vscode/src/features/commands/create-note.spec.ts
@@ -1,5 +1,4 @@
-import { commands, window, Uri } from 'vscode';
-import { URI } from '../../core/model/uri';
+import { commands, window } from 'vscode';
 import { readFile } from '../../services/editor';
 import {
   closeEditors,
@@ -23,7 +22,7 @@ describe('create-note command', () => {
     expect(spy).toBeCalled();
   });
 
-  it.skip('gives precedence to the template over the text', async () => {
+  it('gives precedence to the template over the text', async () => {
     const templateA = await createFile('Template A', [
       '.foam',
       'templates',

--- a/packages/foam-vscode/src/features/commands/create-note.spec.ts
+++ b/packages/foam-vscode/src/features/commands/create-note.spec.ts
@@ -1,5 +1,6 @@
 import { commands, window, Uri } from 'vscode';
 import { URI } from '../../core/model/uri';
+import { readFile } from '../../services/editor';
 import {
   closeEditors,
   createFile,
@@ -77,6 +78,9 @@ describe('create-note command', () => {
 
   it('supports various options to deal with existing notes', async () => {
     const target = await createFile('hello');
+    const content = await readFile(target.uri);
+    expect(content).toEqual('hello');
+
     await commands.executeCommand('foam-vscode.create-note', {
       notePath: target.uri.path,
       text: 'test overwrite',
@@ -106,24 +110,13 @@ describe('create-note command', () => {
     });
     expect(window.activeTextEditor).toBeUndefined();
 
-    await closeEditors();
-    await commands.executeCommand('foam-vscode.create-note', {
-      notePath: target.uri.path,
-      text: 'test overwrite 2',
-      onFileExists: 'overwrite',
-    });
-    expect(window.activeTextEditor.document.getText()).toEqual(
-      'test overwrite 2'
-    );
-    expectSameUri(window.activeTextEditor.document.uri, target.uri);
-
     const spy = jest
-      .spyOn(window, 'showQuickPick')
+      .spyOn(window, 'showInputBox')
       .mockImplementationOnce(jest.fn(() => Promise.resolve(undefined)));
     await closeEditors();
     await commands.executeCommand('foam-vscode.create-note', {
       notePath: target.uri.path,
-      text: 'let me think',
+      text: 'test ask',
       onFileExists: 'ask',
     });
     expect(spy).toBeCalled();

--- a/packages/foam-vscode/src/features/commands/create-note.spec.ts
+++ b/packages/foam-vscode/src/features/commands/create-note.spec.ts
@@ -1,5 +1,6 @@
 import { commands, window } from 'vscode';
-import { readFile } from '../../services/editor';
+import { URI } from '../../core/model/uri';
+import { asAbsoluteWorkspaceUri, readFile } from '../../services/editor';
 import {
   closeEditors,
   createFile,
@@ -13,13 +14,16 @@ describe('create-note command', () => {
     jest.clearAllMocks();
   });
 
-  it('fails if neither note path nor template path are provided', async () => {
+  it('uses sensible defaults to work even without params', async () => {
     const spy = jest
-      .spyOn(window, 'showErrorMessage')
-      .mockImplementationOnce(jest.fn(() => Promise.resolve(undefined)));
+      .spyOn(window, 'showInputBox')
+      .mockImplementationOnce(jest.fn(() => Promise.resolve('Test note')));
 
     await commands.executeCommand('foam-vscode.create-note');
     expect(spy).toBeCalled();
+    const target = asAbsoluteWorkspaceUri(URI.file('Test note.md'));
+    expectSameUri(target, window.activeTextEditor?.document.uri);
+    await deleteFile(target);
   });
 
   it('gives precedence to the template over the text', async () => {

--- a/packages/foam-vscode/src/features/commands/create-note.spec.ts
+++ b/packages/foam-vscode/src/features/commands/create-note.spec.ts
@@ -1,0 +1,128 @@
+import { commands, window } from 'vscode';
+import {
+  closeEditors,
+  createFile,
+  deleteFile,
+  getUriInWorkspace,
+} from '../../test/test-utils-vscode';
+
+describe('create-note command', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('fails if neither note path nor template path are provided', () => {
+    expect(() =>
+      commands.executeCommand('foam-vscode.create-note')
+    ).rejects.toThrow('Either notePath or templatePath must be provided');
+  });
+
+  it.skip('gives precedence to the template over the text', async () => {
+    const templateA = await createFile('Template A', [
+      '.foam',
+      'templates',
+      'template-for-create-note.md',
+    ]);
+    const target = getUriInWorkspace();
+    await commands.executeCommand('foam-vscode.create-note', {
+      notePath: target.path,
+      templatePath: templateA.uri.path,
+      text: 'hello',
+    });
+    expect(window.activeTextEditor?.document.getText()).toEqual('Template A');
+    expect(window.activeTextEditor.document.uri.path).toEqual(target.path);
+    await deleteFile(target);
+    await deleteFile(templateA.uri);
+  });
+
+  it('focuses on the newly created note', async () => {
+    const target = getUriInWorkspace();
+    await commands.executeCommand('foam-vscode.create-note', {
+      notePath: target.path,
+      text: 'hello',
+    });
+    expect(window.activeTextEditor?.document.getText()).toEqual('hello');
+    expect(window.activeTextEditor.document.uri.path).toEqual(target.path);
+    await deleteFile(target);
+  });
+
+  it('supports variables', async () => {
+    const target = getUriInWorkspace();
+    await commands.executeCommand('foam-vscode.create-note', {
+      notePath: target.path,
+      text: 'hello ${FOAM_TITLE}',
+      variables: { FOAM_TITLE: 'world' },
+    });
+    expect(window.activeTextEditor?.document.getText()).toEqual('hello world');
+    expect(window.activeTextEditor.document.uri.path).toEqual(target.path);
+    await deleteFile(target);
+  });
+
+  it('supports date variables', async () => {
+    const target = getUriInWorkspace();
+    await commands.executeCommand('foam-vscode.create-note', {
+      notePath: target.path,
+      text: 'hello ${FOAM_DATE_YEAR}',
+      date: '2021-10-01',
+    });
+    expect(window.activeTextEditor?.document.getText()).toEqual('hello 2021');
+    expect(window.activeTextEditor.document.uri.path).toEqual(target.path);
+    await deleteFile(target);
+  });
+
+  it('supports various options to deal with existing notes', async () => {
+    const target = await createFile('hello');
+    await commands.executeCommand('foam-vscode.create-note', {
+      notePath: target.uri.path,
+      text: 'test overwrite',
+      onFileExists: 'overwrite',
+    });
+    expect(window.activeTextEditor?.document.getText()).toEqual(
+      'test overwrite'
+    );
+    expect(window.activeTextEditor.document.uri.path).toEqual(target.uri.path);
+
+    await closeEditors();
+    await commands.executeCommand('foam-vscode.create-note', {
+      notePath: target.uri.path,
+      text: 'test open',
+      onFileExists: 'open',
+    });
+    expect(window.activeTextEditor?.document.getText()).toEqual(
+      'test overwrite'
+    );
+    expect(window.activeTextEditor.document.uri.path).toEqual(target.uri.path);
+
+    await closeEditors();
+    await commands.executeCommand('foam-vscode.create-note', {
+      notePath: target.uri.path,
+      text: 'test cancel',
+      onFileExists: 'cancel',
+    });
+    expect(window.activeTextEditor).toBeUndefined();
+
+    await closeEditors();
+    await commands.executeCommand('foam-vscode.create-note', {
+      notePath: target.uri.path,
+      text: 'test overwrite 2',
+      onFileExists: 'overwrite',
+    });
+    expect(window.activeTextEditor?.document.getText()).toEqual(
+      'test overwrite 2'
+    );
+    expect(window.activeTextEditor.document.uri.path).toEqual(target.uri.path);
+
+    const spy = jest
+      .spyOn(window, 'showQuickPick')
+      .mockImplementationOnce(jest.fn(() => Promise.resolve(undefined)));
+    await closeEditors();
+    await commands.executeCommand('foam-vscode.create-note', {
+      notePath: target.uri.path,
+      text: 'let me think',
+      onFileExists: 'ask',
+    });
+    expect(spy).toBeCalled();
+
+    await deleteFile(target);
+  });
+});

--- a/packages/foam-vscode/src/features/commands/create-note.ts
+++ b/packages/foam-vscode/src/features/commands/create-note.ts
@@ -55,33 +55,21 @@ async function createNote(args: CreateNoteArgs) {
     args.notePath && asAbsoluteWorkspaceUri(URI.file(args.notePath));
   const templateUri =
     args.templatePath && asAbsoluteWorkspaceUri(URI.file(args.templatePath));
-  const onFileExists = async (uri: URI) => {
-    switch (args.onFileExists) {
-      case 'open':
-        await vscode.commands.executeCommand('vscode.open', toVsCodeUri(uri));
-        return;
-      case 'overwrite':
-        await deleteFile(uri);
-        return uri;
-      case 'cancel':
-        return undefined;
-      case 'ask':
-        throw new Error('not implemented');
-      default:
-        vscode.commands.executeCommand('vscode.open', toVsCodeUri(uri));
-        return;
-    }
-  };
   if (await fileExists(templateUri)) {
     return NoteFactory.createFromTemplate(
       templateUri,
       resolver,
       noteUri,
       args.text,
-      onFileExists
+      args.onFileExists
     );
   } else {
-    return NoteFactory.createNote(noteUri, args.text, resolver, onFileExists);
+    return NoteFactory.createNote(
+      noteUri,
+      args.text,
+      resolver,
+      args.onFileExists
+    );
   }
 }
 

--- a/packages/foam-vscode/src/features/commands/create-note.ts
+++ b/packages/foam-vscode/src/features/commands/create-note.ts
@@ -75,9 +75,9 @@ export const CREATE_NOTE_COMMAND = {
   command: 'foam-vscode.create-note',
   title: 'Foam: Create Note',
 
-  asURI: (uri: URI) =>
+  asURI: (args: CreateNoteArgs) =>
     vscode.Uri.parse(`command:${CREATE_NOTE_COMMAND.command}`).with({
-      query: encodeURIComponent(JSON.stringify({ uri })),
+      query: encodeURIComponent(JSON.stringify(args)),
     }),
 };
 

--- a/packages/foam-vscode/src/features/commands/create-note.ts
+++ b/packages/foam-vscode/src/features/commands/create-note.ts
@@ -4,10 +4,8 @@ import { URI } from '../../core/model/uri';
 import { NoteFactory } from '../../services/templates';
 import { Foam } from '../../core/model/foam';
 import { Resolver } from '../../services/variable-resolver';
-import { toVsCodeUri } from '../../utils/vsc-utils';
 import { asAbsoluteWorkspaceUri, fileExists } from '../../services/editor';
 import { isSome, isNone } from '../../core/utils';
-import { deleteFile } from '../../test/test-utils-vscode';
 
 interface CreateNoteArgs {
   /**

--- a/packages/foam-vscode/src/features/commands/create-note.ts
+++ b/packages/foam-vscode/src/features/commands/create-note.ts
@@ -1,0 +1,84 @@
+import * as vscode from 'vscode';
+import { FoamFeature } from '../../types';
+import { URI } from '../../core/model/uri';
+import { NoteFactory } from '../../services/templates';
+import { Foam } from '../../core/model/foam';
+import { Resolver } from '../../services/variable-resolver';
+import { toVsCodeUri } from '../../utils/vsc-utils';
+import { isNone } from '../../utils';
+import { fileExists } from '../../services/editor';
+
+interface CreateNoteArgs {
+  notePath?: string;
+  templatePath?: string;
+  text?: string;
+  variables?: Map<string, string>;
+  date?: Date;
+  onFileExists?: 'overwrite' | 'open' | 'ask' | 'cancel';
+}
+
+async function createNote(args: CreateNoteArgs) {
+  const resolver = new Resolver(
+    new Map(Object.entries(args.variables)),
+    args.date ?? new Date()
+  );
+  if (isNone(args.notePath) && isNone(args.templatePath)) {
+    throw new Error('Either notePath or templatePath must be provided');
+  }
+  const noteUri = args.notePath && URI.file(args.notePath);
+  const templateUri = args.templatePath && URI.file(args.templatePath);
+  const onFileExists = async (uri: URI) => {
+    switch (args.onFileExists) {
+      case 'open':
+        vscode.commands.executeCommand('vscode.open', toVsCodeUri(uri));
+        return;
+      case 'overwrite':
+        await vscode.workspace.fs.delete(toVsCodeUri(uri));
+        return uri;
+      case 'cancel':
+        return undefined;
+      case 'ask':
+        throw new Error('not implemented');
+      default:
+        vscode.commands.executeCommand('vscode.open', toVsCodeUri(uri));
+        return;
+    }
+  };
+  if (await fileExists(templateUri)) {
+    return NoteFactory.createFromTemplate(
+      templateUri,
+      resolver,
+      noteUri,
+      args.text,
+      onFileExists
+    );
+  } else {
+    return NoteFactory.createNote(
+      noteUri,
+      new vscode.SnippetString(args.text),
+      resolver,
+      onFileExists,
+      true
+    );
+  }
+}
+
+export const CREATE_NOTE_COMMAND = {
+  command: 'foam-vscode.create-note',
+  title: 'Foam: Create Note',
+
+  asURI: (uri: URI) =>
+    vscode.Uri.parse(`command:${CREATE_NOTE_COMMAND.command}`).with({
+      query: encodeURIComponent(JSON.stringify({ uri })),
+    }),
+};
+
+const feature: FoamFeature = {
+  activate: (context: vscode.ExtensionContext, foamPromise: Promise<Foam>) => {
+    context.subscriptions.push(
+      vscode.commands.registerCommand(CREATE_NOTE_COMMAND.command, createNote)
+    );
+  },
+};
+
+export default feature;

--- a/packages/foam-vscode/src/features/commands/create-note.ts
+++ b/packages/foam-vscode/src/features/commands/create-note.ts
@@ -46,7 +46,10 @@ async function createNote(args: CreateNoteArgs) {
     date
   );
   if (isNone(args.notePath) && isNone(args.templatePath)) {
-    throw new Error('Either notePath or templatePath must be provided');
+    await vscode.window.showErrorMessage(
+      'Either notePath or templatePath must be provided when running create-note command'
+    );
+    return;
   }
   const noteUri =
     args.notePath && asAbsoluteWorkspaceUri(URI.file(args.notePath));

--- a/packages/foam-vscode/src/features/commands/create-note.ts
+++ b/packages/foam-vscode/src/features/commands/create-note.ts
@@ -55,7 +55,7 @@ async function createNote(args: CreateNoteArgs) {
   } else {
     return NoteFactory.createNote(
       noteUri,
-      new vscode.SnippetString(args.text),
+      args.text,
       resolver,
       onFileExists,
       true

--- a/packages/foam-vscode/src/features/commands/index.ts
+++ b/packages/foam-vscode/src/features/commands/index.ts
@@ -10,3 +10,4 @@ export { default as openRandomNoteCommand } from './open-random-note';
 export { default as openResource } from './open-resource';
 export { default as updateGraphCommand } from './update-graph';
 export { default as updateWikilinksCommand } from './update-wikilinks';
+export { default as createNote } from './create-note';

--- a/packages/foam-vscode/src/services/editor.spec.ts
+++ b/packages/foam-vscode/src/services/editor.spec.ts
@@ -1,11 +1,16 @@
 import { Selection, workspace } from 'vscode';
-import { fromVsCodeUri } from '../utils/vsc-utils';
+import { fromVsCodeUri, toVsCodeUri } from '../utils/vsc-utils';
 import {
   closeEditors,
   createFile,
   showInEditor,
 } from '../test/test-utils-vscode';
-import { getCurrentEditorDirectory, replaceSelection } from './editor';
+import {
+  asAbsoluteWorkspaceUri,
+  getCurrentEditorDirectory,
+  replaceSelection,
+} from './editor';
+import { URI } from '../core/model/uri';
 
 describe('Editor utils', () => {
   beforeAll(closeEditors);
@@ -36,6 +41,16 @@ describe('Editor utils', () => {
       await replaceSelection(doc.doc, selection, 'was');
 
       expect(doc.doc.getText()).toEqual('This was the file A');
+    });
+  });
+
+  describe('asAbsoluteWorkspaceUri', () => {
+    it('should work with the VS Code workspace folders if none are passed', () => {
+      const uri = URI.file('relative/path');
+      const workspaceFolder = workspace.workspaceFolders[0];
+      expect(asAbsoluteWorkspaceUri(uri)).toEqual(
+        fromVsCodeUri(workspaceFolder.uri).joinPath(uri.path)
+      );
     });
   });
 });

--- a/packages/foam-vscode/src/services/editor.ts
+++ b/packages/foam-vscode/src/services/editor.ts
@@ -1,4 +1,4 @@
-import { URI } from '../core/model/uri';
+import { asAbsoluteUri, URI } from '../core/model/uri';
 import { TextEncoder } from 'util';
 import {
   FileType,
@@ -103,4 +103,20 @@ export async function readFile(uri: URI): Promise<string | undefined> {
       .then(bytes => bytes.toString());
   }
   return undefined;
+}
+
+/**
+ * Turns a relative URI into an absolute URI for the given workspace.
+ * @param uri the uri to evaluate
+ * @returns an absolute uri
+ */
+export function asAbsoluteWorkspaceUri(uri: URI): URI {
+  if (workspace.workspaceFolders === undefined) {
+    throw new Error('An open folder or workspace is required');
+  }
+  const folders = workspace.workspaceFolders.map(folder =>
+    fromVsCodeUri(folder.uri)
+  );
+  const res = asAbsoluteUri(uri, folders);
+  return res;
 }

--- a/packages/foam-vscode/src/services/editor.ts
+++ b/packages/foam-vscode/src/services/editor.ts
@@ -1,6 +1,7 @@
 import { URI } from '../core/model/uri';
 import { TextEncoder } from 'util';
 import {
+  FileType,
   Selection,
   SnippetString,
   TextDocument,
@@ -84,4 +85,22 @@ export function getCurrentEditorDirectory(): URI {
   }
 
   throw new Error('A file must be open in editor, or workspace folder needed');
+}
+
+export async function fileExists(uri: URI): Promise<boolean> {
+  try {
+    const stat = await workspace.fs.stat(toVsCodeUri(uri));
+    return stat.type === FileType.File;
+  } catch (e) {
+    return false;
+  }
+}
+
+export async function readFile(uri: URI): Promise<string | undefined> {
+  if (await fileExists(uri)) {
+    return workspace.fs
+      .readFile(toVsCodeUri(uri))
+      .then(bytes => bytes.toString());
+  }
+  return undefined;
 }

--- a/packages/foam-vscode/src/services/editor.ts
+++ b/packages/foam-vscode/src/services/editor.ts
@@ -105,6 +105,10 @@ export async function readFile(uri: URI): Promise<string | undefined> {
   return undefined;
 }
 
+export const deleteFile = (uri: URI) => {
+  return workspace.fs.delete(toVsCodeUri(uri), { recursive: true });
+};
+
 /**
  * Turns a relative URI into an absolute URI for the given workspace.
  * @param uri the uri to evaluate

--- a/packages/foam-vscode/src/services/templates.spec.ts
+++ b/packages/foam-vscode/src/services/templates.spec.ts
@@ -1,13 +1,6 @@
-import {
-  Selection,
-  SnippetString,
-  ViewColumn,
-  window,
-  workspace,
-} from 'vscode';
-import { isWindows } from '../core/common/platform';
+import { Selection, ViewColumn, window } from 'vscode';
 import { fromVsCodeUri } from '../utils/vsc-utils';
-import { determineNewNoteFilepath, NoteFactory } from '../services/templates';
+import { NoteFactory } from '../services/templates';
 import {
   closeEditors,
   createFile,
@@ -233,90 +226,5 @@ describe('NoteFactory.createNote', () => {
     );
     await deleteFile(file.uri);
     await deleteFile(target);
-  });
-});
-
-describe('determineNewNoteFilepath', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    jest.restoreAllMocks();
-  });
-  it('should use the template path if absolute', async () => {
-    const winAbsolutePath = 'C:\\absolute_path\\journal\\My Note Title.md';
-    const linuxAbsolutePath = '/absolute_path/journal/My Note Title.md';
-    const winResult = await determineNewNoteFilepath(
-      winAbsolutePath,
-      undefined,
-      new Resolver(new Map(), new Date())
-    );
-    expect(winResult.toFsPath()).toMatch(winAbsolutePath);
-    const linuxResult = await determineNewNoteFilepath(
-      linuxAbsolutePath,
-      undefined,
-      new Resolver(new Map(), new Date())
-    );
-    expect(linuxResult.toFsPath()).toMatch(linuxAbsolutePath);
-  });
-
-  it('should compute the relative template filepath from the current directory', async () => {
-    const relativePath = isWindows
-      ? 'journal\\My Note Title.md'
-      : 'journal/My Note Title.md';
-    const resultFilepath = await determineNewNoteFilepath(
-      relativePath,
-      undefined,
-      new Resolver(new Map(), new Date())
-    );
-    const expectedPath = fromVsCodeUri(
-      workspace.workspaceFolders[0].uri
-    ).joinPath(relativePath);
-    expect(resultFilepath.toFsPath()).toMatch(expectedPath.toFsPath());
-  });
-
-  it('should use the note title if nothing else is available', async () => {
-    const noteTitle = 'My new note';
-    const resultFilepath = await determineNewNoteFilepath(
-      undefined,
-      undefined,
-      new Resolver(new Map().set('FOAM_TITLE', noteTitle), new Date())
-    );
-    const expectedPath = fromVsCodeUri(
-      workspace.workspaceFolders[0].uri
-    ).joinPath(`${noteTitle}.md`);
-    expect(resultFilepath.toFsPath()).toMatch(expectedPath.toFsPath());
-  });
-
-  it('should ask the user for a note title if nothing else is available', async () => {
-    const noteTitle = 'My new note';
-    const spy = jest
-      .spyOn(window, 'showInputBox')
-      .mockImplementationOnce(jest.fn(() => Promise.resolve(noteTitle)));
-    const resultFilepath = await determineNewNoteFilepath(
-      undefined,
-      undefined,
-      new Resolver(new Map(), new Date())
-    );
-    const expectedPath = fromVsCodeUri(
-      workspace.workspaceFolders[0].uri
-    ).joinPath(`${noteTitle}.md`);
-    expect(spy).toHaveBeenCalled();
-    expect(resultFilepath.toFsPath()).toMatch(expectedPath.toFsPath());
-  });
-
-  it('should filter invalid chars from the title #1042', async () => {
-    const noteTitle = 'My new note/';
-    const spy = jest
-      .spyOn(window, 'showInputBox')
-      .mockImplementationOnce(jest.fn(() => Promise.resolve(noteTitle)));
-    const resultFilepath = await determineNewNoteFilepath(
-      undefined,
-      undefined,
-      new Resolver(new Map(), new Date())
-    );
-    const expectedPath = fromVsCodeUri(
-      workspace.workspaceFolders[0].uri
-    ).joinPath(`My new note.md`);
-    expect(spy).toHaveBeenCalled();
-    expect(resultFilepath.toFsPath()).toMatch(expectedPath.toFsPath());
   });
 });

--- a/packages/foam-vscode/src/services/templates.ts
+++ b/packages/foam-vscode/src/services/templates.ts
@@ -129,13 +129,14 @@ export const NoteFactory = {
           case 'cancel':
             return undefined;
           case 'ask':
-          default:
+          default: {
             const filename = existingFile.getBasename();
             const newProposedPath = await askUserForFilepathConfirmation(
               existingFile,
               filename
             );
             return newProposedPath && URI.file(newProposedPath);
+          }
         }
       };
 

--- a/packages/foam-vscode/src/services/templates.ts
+++ b/packages/foam-vscode/src/services/templates.ts
@@ -101,7 +101,7 @@ export const NoteFactory = {
     text: string,
     resolver: Resolver,
     onFileExists?: (filePath: URI) => Promise<URI | undefined>,
-    replaceSelectionWithLink: boolean = true
+    replaceSelectionWithLink = true
   ): Promise<{ didCreateFile: boolean; uri: URI | undefined }> => {
     try {
       onFileExists = onFileExists

--- a/packages/foam-vscode/src/services/variable-resolver.spec.ts
+++ b/packages/foam-vscode/src/services/variable-resolver.spec.ts
@@ -1,6 +1,11 @@
-import { window } from 'vscode';
+import { Selection, window } from 'vscode';
 import { Resolver } from './variable-resolver';
 import { Variable } from '../core/common/snippetParser';
+import {
+  createFile,
+  deleteFile,
+  showInEditor,
+} from '../test/test-utils-vscode';
 
 describe('variable-resolver, text substitution', () => {
   it('should do nothing if no Foam-specific variables are used', async () => {
@@ -229,6 +234,17 @@ describe('variable-resolver, resolveText', () => {
     const expected = input;
     const resolver = new Resolver(new Map(), new Date());
     expect(await resolver.resolveText(input)).toEqual(expected);
+  });
+
+  it('should resolve FOAM_SELECTED_TEXT with the editor selection', async () => {
+    const file = await createFile('Content of note file');
+    const { editor } = await showInEditor(file.uri);
+    editor.selection = new Selection(0, 11, 1, 0);
+    const resolver = new Resolver(new Map(), new Date());
+    expect(await resolver.resolveFromName('FOAM_SELECTED_TEXT')).toEqual(
+      'note file'
+    );
+    await deleteFile(file);
   });
 
   it('should append FOAM_SELECTED_TEXT with a newline to the template if there is selected text but FOAM_SELECTED_TEXT is not referenced and the template ends in a newline', async () => {

--- a/packages/foam-vscode/src/test/test-utils-vscode.ts
+++ b/packages/foam-vscode/src/test/test-utils-vscode.ts
@@ -118,3 +118,21 @@ export const withModifiedConfiguration = async (key, value, fn: () => void) => {
  */
 export const withModifiedFoamConfiguration = (key, value, fn: () => void) =>
   withModifiedConfiguration(`foam.${key}`, value, fn);
+
+/**
+ * Utility function to check if two URIs are the same.
+ * It has the goal of supporting Uri and URI, and dealing with
+ * inconsistencies in the way they are represented (especially the
+ * drive letter in Windows)
+ *
+ * @param actual the actual value
+ * @param expected the expected value
+ */
+export const expectSameUri = (
+  actual: vscode.Uri | URI,
+  expected: vscode.Uri | URI
+) => {
+  expect(actual.path.toLocaleLowerCase()).toEqual(
+    expected.path.toLocaleLowerCase()
+  );
+};


### PR DESCRIPTION
The "create note" command is a generic command (and underlying API) to create a note in Foam.

The idea of this command is to be configurable enough that users will be able to customize it to fit their specific workflows and use cases.

The command takes the following parameters:

```
interface CreateNoteArgs {
  notePath?: string;
  templatePath?: string;
  text?: string;
  variables?: Map<string, string>;
  date?: Date;
  onFileExists?: 'overwrite' | 'open' | 'ask' | 'cancel';
}
```

TODO
- [x] improve error handling
- [x] add more tests
- [x] consolidate `notePath` resolution
- [ ] add documentation

ISSUES
- the `notePath` argument of the command ideally would resolve to an absolute path, but this is dependent on https://github.com/microsoft/vscode/issues/155868 (I mean, we could write up some workaround for it, but really?). In the meantime we'll use relative paths