### PR TITLE
Improved support for globs in multiroot workspace

### DIFF
--- a/packages/foam-vscode/src/core/model/uri.ts
+++ b/packages/foam-vscode/src/core/model/uri.ts
@@ -4,9 +4,7 @@
 // Some code in this file comes from https://github.com/microsoft/vscode/main/src/vs/base/common/uri.ts
 // See LICENSE for details
 
-import { isAbsolute } from 'path';
 import { CharCode } from '../common/charCode';
-import { isNone } from '../utils';
 import * as pathUtils from '../utils/path';
 
 /**

--- a/packages/foam-vscode/src/core/model/uri.ts
+++ b/packages/foam-vscode/src/core/model/uri.ts
@@ -4,6 +4,7 @@
 // Some code in this file comes from https://github.com/microsoft/vscode/main/src/vs/base/common/uri.ts
 // See LICENSE for details
 
+import { isAbsolute } from 'path';
 import { CharCode } from '../common/charCode';
 import { isNone } from '../utils';
 import * as pathUtils from '../utils/path';
@@ -371,14 +372,10 @@ function encodeURIComponentMinimal(path: string): string {
 
 /**
  * Turns a relative URI into an absolute URI given a collection of base folders.
- * - if no workspace folder is provided, it will throw
- * - if the given URI is already absolute, it will return it
- * - if the given URI is relative
- *   - if there is only one workspace folder, it will be relative to that
- *   - if there is more than a workspace folder, it will search for the one matching the
- *     first part of the URI
- *   - if no matching workspace folder is found, it will use the first one
- *   - if more than a folder matches the first part of the URI, it will return the first one
+ * In case of multiple matches it returns the first one.
+ *
+ * @see {@link pathUtils.asAbsolutePaths|path.asAbsolutePath}
+ *
  * @param uri the uri to evaluate
  * @param baseFolders the base folders to use
  * @returns an absolute uri
@@ -386,25 +383,10 @@ function encodeURIComponentMinimal(path: string): string {
  * TODO this probably needs to be moved to the workspace service
  */
 export function asAbsoluteUri(uri: URI, baseFolders: URI[]): URI {
-  if (isNone(baseFolders) || baseFolders.length === 0) {
-    throw new Error('Cannot compute absolute URI without a base');
-  }
-  if (uri.isAbsolute()) {
-    return uri;
-  }
-  let tokens = uri.path.split('/');
-  const firstDir = tokens[0];
-  let base = baseFolders[0];
-  if (baseFolders.length > 1) {
-    for (const folder of baseFolders) {
-      const lastDir = folder.path.split('/').pop();
-      if (lastDir === firstDir) {
-        tokens = tokens.slice(1);
-        base = folder;
-        break;
-      }
-    }
-  }
-  const res = base.joinPath(...tokens);
-  return res;
+  return URI.file(
+    pathUtils.asAbsolutePaths(
+      uri.path,
+      baseFolders.map(f => f.path)
+    )[0]
+  );
 }

--- a/packages/foam-vscode/src/core/services/datastore.test.ts
+++ b/packages/foam-vscode/src/core/services/datastore.test.ts
@@ -62,11 +62,11 @@ describe('Matcher', () => {
   });
 
   it('happy path', () => {
-    const matcher = new Matcher([URI.file('/')], ['**/*'], ['**/*.pdf']);
-    expect(matcher.isMatch(URI.file('/file.md'))).toBeTruthy();
-    expect(matcher.isMatch(URI.file('/file.pdf'))).toBeFalsy();
-    expect(matcher.isMatch(URI.file('/dir/file.md'))).toBeTruthy();
-    expect(matcher.isMatch(URI.file('/dir/file.pdf'))).toBeFalsy();
+    const matcher = new Matcher([URI.file('/root/')], ['**/*'], ['**/*.pdf']);
+    expect(matcher.isMatch(URI.file('/root/file.md'))).toBeTruthy();
+    expect(matcher.isMatch(URI.file('/root/file.pdf'))).toBeFalsy();
+    expect(matcher.isMatch(URI.file('/root/dir/file.md'))).toBeTruthy();
+    expect(matcher.isMatch(URI.file('/root/dir/file.pdf'))).toBeFalsy();
   });
 
   it('ignores files in the exclude list', () => {

--- a/packages/foam-vscode/src/core/services/datastore.ts
+++ b/packages/foam-vscode/src/core/services/datastore.ts
@@ -141,13 +141,3 @@ export class FileDataStore implements IDataStore {
     }
   }
 }
-
-export const folderPlusGlob = (folder: string) => (glob: string): string => {
-  if (folder.substr(-1) === '/') {
-    folder = folder.slice(0, -1);
-  }
-  if (glob.startsWith('/')) {
-    glob = glob.slice(1);
-  }
-  return folder.length > 0 ? `${folder}/${glob}` : glob;
-};

--- a/packages/foam-vscode/src/core/utils/path.test.ts
+++ b/packages/foam-vscode/src/core/utils/path.test.ts
@@ -1,0 +1,30 @@
+import { asAbsolutePaths } from './path';
+
+describe('path utils', () => {
+  describe('asAbsolutePaths', () => {
+    it('returns the path if already absolute', () => {
+      const paths = asAbsolutePaths('/path/to/test', [
+        '/root/Users',
+        '/root/tmp',
+      ]);
+      expect(paths).toEqual(['/path/to/test']);
+    });
+    it('returns the matching base if found', () => {
+      const paths = asAbsolutePaths('tmp/to/test', [
+        '/root/Users',
+        '/root/tmp',
+      ]);
+      expect(paths).toEqual(['/root/tmp/to/test']);
+    });
+    it('returns all bases if no match is found', () => {
+      const paths = asAbsolutePaths('path/to/test', [
+        '/root/Users',
+        '/root/tmp',
+      ]);
+      expect(paths).toEqual([
+        '/root/Users/path/to/test',
+        '/root/tmp/path/to/test',
+      ]);
+    });
+  });
+});

--- a/packages/foam-vscode/src/core/utils/path.ts
+++ b/packages/foam-vscode/src/core/utils/path.ts
@@ -1,5 +1,6 @@
 import { CharCode } from '../common/charCode';
 import { posix } from 'path';
+import { isNone } from './core';
 
 /**
  * Converts filesystem path to POSIX path. Supported inputs are:
@@ -173,4 +174,44 @@ function parseUNCShare(uncPath: string): [string, string] {
   } else {
     return [uncPath.substring(2, idx), uncPath.substring(idx) || '\\'];
   }
+}
+
+/**
+ * Turns a relative path into an absolute path given a collection of base folders.
+ * - if no base folder is provided, it will throw
+ * - if the given path is already absolute, it will return it
+ * - if the given path is relative it will return absolute paths for the ones matching the
+ *     first part of the path
+ * - if no matching base folder is found, it will return an absolute path per base folder
+ * @param path the path to evaluate
+ * @param baseFolders the base folders to use
+ * @returns an array of absolute path, guaranteed to have at least 1 element
+ */
+export function asAbsolutePaths(path: string, baseFolders: string[]): string[] {
+  if (isNone(baseFolders) || baseFolders.length === 0) {
+    throw new Error('Cannot compute absolute URI without a base');
+  }
+
+  if (isAbsolute(path)) {
+    return [path];
+  }
+  let tokens = path.split('/');
+  const firstDir = tokens[0];
+  const res = [];
+  if (baseFolders.length > 1) {
+    for (const folder of baseFolders) {
+      const lastDir = folder.split('/').pop();
+      if (lastDir === firstDir) {
+        tokens = tokens.slice(1);
+        res.push([folder, ...tokens].join('/'));
+        continue;
+      }
+    }
+  }
+  if (res.length === 0) {
+    for (const folder of baseFolders) {
+      res.push([folder, ...tokens].join('/'));
+    }
+  }
+  return res;
 }

--- a/packages/foam-vscode/src/core/utils/path.ts
+++ b/packages/foam-vscode/src/core/utils/path.ts
@@ -210,7 +210,10 @@ export function asAbsolutePaths(path: string, baseFolders: string[]): string[] {
   }
   if (res.length === 0) {
     for (const folder of baseFolders) {
-      res.push([folder, ...tokens].join('/'));
+      const match = folder.endsWith('/')
+        ? folder.substring(0, folder.length - 1)
+        : folder;
+      res.push([match, ...tokens].join('/'));
     }
   }
   return res;

--- a/packages/foam-vscode/src/dated-notes.ts
+++ b/packages/foam-vscode/src/dated-notes.ts
@@ -2,7 +2,7 @@ import { workspace } from 'vscode';
 import dateFormat from 'dateformat';
 import { focusNote } from './utils';
 import { URI } from './core/model/uri';
-import { fromVsCodeUri, toVsCodeUri } from './utils/vsc-utils';
+import { toVsCodeUri } from './utils/vsc-utils';
 import { NoteFactory } from './services/templates';
 import { getFoamVsCodeConfig } from './services/config';
 import { asAbsoluteWorkspaceUri } from './services/editor';

--- a/packages/foam-vscode/src/features/commands/create-note-from-template.ts
+++ b/packages/foam-vscode/src/features/commands/create-note-from-template.ts
@@ -1,10 +1,6 @@
-import { commands, ExtensionContext, QuickPickItem, window } from 'vscode';
+import { commands, ExtensionContext } from 'vscode';
 import { FoamFeature } from '../../types';
-import {
-  askUserForTemplate,
-  NoteFactory,
-  getTemplatesDir,
-} from '../../services/templates';
+import { askUserForTemplate, NoteFactory } from '../../services/templates';
 import { Resolver } from '../../services/variable-resolver';
 
 const feature: FoamFeature = {

--- a/packages/foam-vscode/src/features/hover-provider.ts
+++ b/packages/foam-vscode/src/features/hover-provider.ts
@@ -14,8 +14,6 @@ import { Range } from '../core/model/range';
 import { FoamGraph } from '../core/model/graph';
 import { OPEN_COMMAND } from './commands/open-resource';
 import { CREATE_NOTE_COMMAND } from './commands/create-note';
-import { askUserForTemplate } from '../services/templates';
-import { QuickPickItem } from 'vscode';
 
 export const CONFIG_KEY = 'links.hover.enable';
 

--- a/packages/foam-vscode/src/features/panels/tags-explorer.spec.ts
+++ b/packages/foam-vscode/src/features/panels/tags-explorer.spec.ts
@@ -5,13 +5,14 @@ import { bootstrap, Foam } from '../../core/model/foam';
 import { MarkdownResourceProvider } from '../../core/services/markdown-provider';
 import { FileDataStore, Matcher } from '../../core/services/datastore';
 import { createMarkdownParser } from '../../core/services/markdown-parser';
+import { URI } from '../../core/model/uri';
 
 describe('Tags tree panel', () => {
   let _foam: Foam;
   let provider: TagsProvider;
 
   const dataStore = new FileDataStore(readFileFromFs);
-  const matcher = new Matcher([]);
+  const matcher = new Matcher([URI.file('/root')]);
   const parser = createMarkdownParser();
   const mdProvider = new MarkdownResourceProvider(matcher, dataStore, parser);
 

--- a/packages/foam-vscode/src/services/templates.ts
+++ b/packages/foam-vscode/src/services/templates.ts
@@ -1,7 +1,6 @@
 import { URI } from '../core/model/uri';
 import { TextEncoder } from 'util';
 import {
-  FileType,
   SnippetString,
   ViewColumn,
   QuickPickItem,


### PR DESCRIPTION
Fixes #1063 #959 

Replaces #1065 

Currently globs are applied equally to all workspace folders
This approach is backwards compatible with single-root workspaces (and existing configuration)
It adds the possibility of limiting the glob to one of the directories by starting the glob pattern with the directory name.

### How it works

In case there is more than one workspace folder, the glob can include the folder name to limit its application to that folder. If the glob is generic it still applies to all folders. For example, given:

```
notes/
  family/
    family.md
  business/
    business.md
  random/
    family-note.md
```

and

```
work/
  company/
    file.md
  side-project/
    project.md
  random/
    work-note.md
```

Given the `random/**` glob
1. if only the `notes` folder is open it will ignore everything inside the `random` directory (**current behavior**)
2. if both directories are open, it will ignore everything inside `notes/random` and `work/random` (**current behavior**)

If I only want to only ignore the `random` directory in `notes`, this was not possible.
With this PR, I can use the glob `notes/random/**` to target only one of the root directories.

Can it be confusing? Maybe but I am optimistic it won't:
when the workspace has a single folder, you don't see the folder in the explorer, so intuitively you wouldn't use it in your glob (which is also the behavior today, and the reason why on simple projects we haven't had issues).

<img width="479" alt="image" src="https://user-images.githubusercontent.com/457005/188219194-ad8e3cac-ea3f-4b9e-a06e-053f833fedfa.png">

When the workspace has more than a folder, then they show up in the explorer, so it does "feel" more right to include it in the glob

<img width="484" alt="image" src="https://user-images.githubusercontent.com/457005/188219316-cf248e89-4e77-4107-8e01-70970e280988.png">

So the root folder "becomes" part of the explorer, and in the same way I can see how it could "become" part of the glob.

If a glob doesn't match a specific workspace folder it will apply equally to all of them (as it is today).