### PR TITLE
Fixed regex for image placeholder in hover

### DIFF
--- a/packages/foam-vscode/src/core/services/attachment-provider.ts
+++ b/packages/foam-vscode/src/core/services/attachment-provider.ts
@@ -4,6 +4,7 @@ import { FoamWorkspace } from '../model/workspace';
 import { IDisposable } from '../common/lifecycle';
 import { ResourceProvider } from '../model/provider';
 import { getFoamVsCodeConfig } from '../../services/config';
+import { imageExtensions } from '../../utils';
 
 const attachmentExtConfig = getFoamVsCodeConfig(
   'files.attachmentExtensions',
@@ -12,7 +13,6 @@ const attachmentExtConfig = getFoamVsCodeConfig(
   .split(' ')
   .map(ext => '.' + ext.trim());
 
-const imageExtensions = ['.png', '.jpg', '.jpeg', '.gif', '.svg', '.webp'];
 const attachmentExtensions = [...attachmentExtConfig, ...imageExtensions];
 
 const asResource = (uri: URI): Resource => {

--- a/packages/foam-vscode/src/utils.ts
+++ b/packages/foam-vscode/src/utils.ts
@@ -22,6 +22,8 @@ export const mdDocSelector = [
   { language: 'markdown', scheme: 'untitled' },
 ];
 
+export const imageExtensions = ['.png', '.jpg', '.jpeg', '.gif', '.svg', '.webp'];
+
 export function loadDocConfig() {
   // Load workspace config
   const activeEditor = window.activeTextEditor;
@@ -215,9 +217,11 @@ export function stripFrontMatter(markdown: string): string {
   return matter(markdown).content.trim();
 }
 
+const imgRegex = new RegExp(`!\\[(.*)\\]\\(.*(${imageExtensions.join('|')})\\)`)
+
 export function stripImages(markdown: string): string {
   return markdown.replace(
-    /!\[(.*)\]\([-/\\.A-Za-z]*\)/gi,
+    imgRegex,
     '$1'.length ? '[Image: $1]' : ''
   );
 }

--- a/packages/foam-vscode/src/utils.ts
+++ b/packages/foam-vscode/src/utils.ts
@@ -22,7 +22,14 @@ export const mdDocSelector = [
   { language: 'markdown', scheme: 'untitled' },
 ];
 
-export const imageExtensions = ['.png', '.jpg', '.jpeg', '.gif', '.svg', '.webp'];
+export const imageExtensions = [
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.svg',
+  '.webp',
+];
 
 export function loadDocConfig() {
   // Load workspace config
@@ -217,11 +224,10 @@ export function stripFrontMatter(markdown: string): string {
   return matter(markdown).content.trim();
 }
 
-const imgRegex = new RegExp(`!\\[(.*)\\]\\(.*(${imageExtensions.join('|')})\\)`)
+const imgRegex = new RegExp(
+  `!\\[(.*)\\]\\(.*(${imageExtensions.join('|')})\\)`
+);
 
 export function stripImages(markdown: string): string {
-  return markdown.replace(
-    imgRegex,
-    '$1'.length ? '[Image: $1]' : ''
-  );
+  return markdown.replace(imgRegex, '$1'.length ? '[Image: $1]' : '');
 }


### PR DESCRIPTION
The regex that was replacing the image was no longer working.
It's been replaced with a more specific regex.
To keep compatibility with past expected behavior we are still not showing the image, but just a reference to it.
We could change that in the future (PR welcome) but for now I consider enough to remove the broken image from the preview. Fixing the image would probably require a bit more work, to properly locate the file and find a relative path from the source (or maybe an absolute would work?)