### PR TITLE
Fix broken markup.

### DIFF
--- a/docs/user/features/tags.md
+++ b/docs/user/features/tags.md
@@ -11,7 +11,7 @@ You can add tags to your notes to categorize or link notes together.
 There are two ways of creating a tag:
 
 - Adding a `#tag` anywhere in the text of the note, for example: #my-tag1
-- Using the `tags: tag1, tag2` yaml frontmatter [[note property|note-properties]]. Notice `my-tag1` and `my-tag2` tags which are added to this document this way.
+- Using the `tags: tag1, tag2` yaml frontmatter [[note property]]. Notice `my-tag1` and `my-tag2` tags which are added to this document this way.
 
 Tags can also be hierarchical, so you can have `#parent/child`.
 


### PR DESCRIPTION
Markdown was improperly formatting a line as a table (because of a "|" pipe being interpreted as a table delimiter instead of a logical OR?)