### PR TITLE
Fix #907: use VS Code to manage links

### DIFF
--- a/packages/foam-vscode/src/features/navigation-provider.spec.ts
+++ b/packages/foam-vscode/src/features/navigation-provider.spec.ts
@@ -54,7 +54,7 @@ describe('Document navigation', () => {
       expect(links.length).toEqual(0);
     });
 
-    it('should create links for wikilinks', async () => {
+    it('should not create links for wikilinks, as this is managed by the definition provider', async () => {
       const fileA = await createFile('# File A', ['file-a.md']);
       const fileB = await createFile(`this is a link to [[${fileA.name}]].`);
       const ws = createTestWorkspace()
@@ -66,9 +66,7 @@ describe('Document navigation', () => {
       const provider = new NavigationProvider(ws, graph, parser);
       const links = provider.provideDocumentLinks(doc);
 
-      expect(links.length).toEqual(1);
-      expect(links[0].target).toEqual(OPEN_COMMAND.asURI(fileA.uri));
-      expect(links[0].range).toEqual(new vscode.Range(0, 20, 0, 26));
+      expect(links.length).toEqual(0);
     });
 
     it('should create links for placeholders', async () => {

--- a/packages/foam-vscode/src/features/navigation-provider.ts
+++ b/packages/foam-vscode/src/features/navigation-provider.ts
@@ -159,22 +159,23 @@ export class NavigationProvider
       })
     );
 
-    return targets.map(o => {
-      const command = OPEN_COMMAND.asURI(o.target);
-      const documentLink = new vscode.DocumentLink(
-        new vscode.Range(
-          o.link.range.start.line,
-          o.link.range.start.character + 2,
-          o.link.range.end.line,
-          o.link.range.end.character - 2
-        ),
-        command
-      );
-      documentLink.tooltip = o.target.isPlaceholder()
-        ? `Create note for '${o.target.path}'`
-        : `Go to ${o.target.toFsPath()}`;
-      return documentLink;
-    });
+    return targets
+      .filter(o => o.target.isPlaceholder()) // links to resources are managed by the definition provider
+      .map(o => {
+        const command = OPEN_COMMAND.asURI(o.target);
+
+        const documentLink = new vscode.DocumentLink(
+          new vscode.Range(
+            o.link.range.start.line,
+            o.link.range.start.character + 2,
+            o.link.range.end.line,
+            o.link.range.end.character - 2
+          ),
+          command
+        );
+        documentLink.tooltip = `Create note for '${o.target.path}'`;
+        return documentLink;
+      });
   }
 }
 


### PR DESCRIPTION
Use definition provider for resource links, link provider for placeholder links.

This will fix #907 as well, allowing cmd+option+click to open link in new pane.