### PR TITLE
Feat #903: Added support for emoji tags

### DIFF
--- a/packages/foam-vscode/src/core/utils/hashtags.ts
+++ b/packages/foam-vscode/src/core/utils/hashtags.ts
@@ -1,6 +1,6 @@
 import { isSome } from './core';
-const HASHTAG_REGEX = /(?<=^|\s)#([0-9]*[\p{L}/_-][\p{L}\p{N}/_-]*)/gmu;
-const WORD_REGEX = /(?<=^|\s)([0-9]*[\p{L}/_-][\p{L}\p{N}/_-]*)/gmu;
+const HASHTAG_REGEX = /(?<=^|\s)#([0-9]*[\p{L}\p{Emoji_Presentation}/_-][\p{L}\p{Emoji_Presentation}\p{N}/_-]*)/gmu;
+const WORD_REGEX = /(?<=^|\s)([0-9]*[\p{L}\p{Emoji_Presentation}/_-][\p{L}\p{Emoji_Presentation}\p{N}/_-]*)/gmu;
 
 export const extractHashtags = (
   text: string

--- a/packages/foam-vscode/src/core/utils/utils.test.ts
+++ b/packages/foam-vscode/src/core/utils/utils.test.ts
@@ -7,7 +7,7 @@ describe('hashtag extraction', () => {
   it('returns empty list if no tags are present', () => {
     expect(extractHashtags('hello world')).toEqual([]);
   });
-  
+
   it('works with simple strings', () => {
     expect(
       extractHashtags('hello #world on #this planet').map(t => t.label)
@@ -27,7 +27,7 @@ describe('hashtag extraction', () => {
       extractHashtags('#hello world on this #planet').map(t => t.label)
     ).toEqual(['hello', 'planet']);
   });
-  
+
   it('supports _ and -', () => {
     expect(
       extractHashtags('#hello-world on #this_planet').map(t => t.label)
@@ -61,7 +61,7 @@ describe('hashtag extraction', () => {
       '123四',
     ]);
   });
-  
+
   it('supports emoji tags', () => {
     expect(
       extractHashtags(`this is a pure emoji #⭐, #⭐⭐, #👍👍🏽👍🏿 some mixed emoji #π🥧, #✅todo
@@ -71,7 +71,7 @@ describe('hashtag extraction', () => {
       '⭐',
       '⭐⭐',
       '👍👍🏽👍🏿',
-      'π🥧', 
+      'π🥧',
       '✅todo',
       'urgent❗',
       '❗❗urgent',

--- a/packages/foam-vscode/src/core/utils/utils.test.ts
+++ b/packages/foam-vscode/src/core/utils/utils.test.ts
@@ -7,11 +7,13 @@ describe('hashtag extraction', () => {
   it('returns empty list if no tags are present', () => {
     expect(extractHashtags('hello world')).toEqual([]);
   });
+  
   it('works with simple strings', () => {
     expect(
       extractHashtags('hello #world on #this planet').map(t => t.label)
     ).toEqual(['world', 'this']);
   });
+
   it('detects the offset of the tag', () => {
     expect(extractHashtags('#hello')).toEqual([{ label: 'hello', offset: 0 }]);
     expect(extractHashtags(' #hello')).toEqual([{ label: 'hello', offset: 1 }]);
@@ -19,21 +21,25 @@ describe('hashtag extraction', () => {
       { label: 'hello', offset: 3 },
     ]);
   });
+
   it('works with tags at beginning or end of text', () => {
     expect(
       extractHashtags('#hello world on this #planet').map(t => t.label)
     ).toEqual(['hello', 'planet']);
   });
+  
   it('supports _ and -', () => {
     expect(
       extractHashtags('#hello-world on #this_planet').map(t => t.label)
     ).toEqual(['hello-world', 'this_planet']);
   });
+
   it('supports nested tags', () => {
     expect(
       extractHashtags('#parent/child on #planet').map(t => t.label)
     ).toEqual(['parent/child', 'planet']);
   });
+
   it('ignores tags that only have numbers in text', () => {
     expect(
       extractHashtags('this #123 tag should be ignore, but not #123four').map(
@@ -41,7 +47,8 @@ describe('hashtag extraction', () => {
       )
     ).toEqual(['123four']);
   });
-  it('supports unicode letters like Chinese charaters', () => {
+
+  it('supports unicode letters like Chinese characters', () => {
     expect(
       extractHashtags(`
         this #tag_with_unicode_letters_汉字, pure Chinese tag like #纯中文标签 and 
@@ -52,6 +59,24 @@ describe('hashtag extraction', () => {
       '纯中文标签',
       '标签1',
       '123四',
+    ]);
+  });
+  
+  it('supports emoji tags', () => {
+    expect(
+      extractHashtags(`this is a pure emoji #⭐, #⭐⭐, #👍👍🏽👍🏿 some mixed emoji #π🥧, #✅todo
+       #urgent❗ or #❗❗urgent, and some nested emoji #📥/🟥 or #📥/🟢
+      `).map(t => t.label)
+    ).toEqual([
+      '⭐',
+      '⭐⭐',
+      '👍👍🏽👍🏿',
+      'π🥧', 
+      '✅todo',
+      'urgent❗',
+      '❗❗urgent',
+      '📥/🟥',
+      '📥/🟢',
     ]);
   });
 


### PR DESCRIPTION
![Capture](https://user-images.githubusercontent.com/8953212/209030205-3a05fe3f-12f8-4906-acd7-9f87b232eb1b.PNG)
Resolves #903; This should allow for most emojis to be supported with pure emoji tags, text + emoji tags, and nested emoji tags. I opted for `\p{Emoji_Presentation}` over `\p{Emoji}` because (TIL) numbers are emojis and the latter would permit pure number tags `#123` through, which we don't want.

This has weird behavior with keycap sequences such as 1️⃣, 9️⃣, as these are encoded as a digit, a variation selector, and enclosing number cap. So currently, a note with `#example1️⃣` and a note with `#example1` would result in sharing the same tag. I thought maybe this would be an edge case, but in case we do want full support, I can look into adding that, but it would probably mean adding something harder to read to the existing regex like `(\u00a9|\u00ae|[\u2000-\u3300]|\ud83d[\ud000-\udfff])`. 

Also, let me know if the tests are sufficient. I could add an e2e test to `tags.test.ts`, but wasn't sure since those test more general tag functionality than the type of tags. 

Appreciate any feedback!