### PR TITLE
Fix orphan, placeholder, tag-explorer counts

### DIFF
--- a/packages/foam-vscode/src/features/panels/orphans.ts
+++ b/packages/foam-vscode/src/features/panels/orphans.ts
@@ -51,8 +51,8 @@ const feature: FoamFeature = {
       vscode.window.registerTreeDataProvider('foam-vscode.orphans', provider),
       ...provider.commands,
       foam.graph.onDidUpdate(() => {
-        treeView.title = baseTitle + ` (${provider.numElements})`;
         provider.refresh();
+        treeView.title = baseTitle + ` (${provider.numElements})`;
       })
     );
   },

--- a/packages/foam-vscode/src/features/panels/placeholders.ts
+++ b/packages/foam-vscode/src/features/panels/placeholders.ts
@@ -39,8 +39,8 @@ const feature: FoamFeature = {
       treeView,
       ...provider.commands,
       foam.graph.onDidUpdate(() => {
-        treeView.title = baseTitle + ` (${provider.numElements})`;
         provider.refresh();
+        treeView.title = baseTitle + ` (${provider.numElements})`;
       })
     );
   },

--- a/packages/foam-vscode/src/features/panels/tags-explorer.ts
+++ b/packages/foam-vscode/src/features/panels/tags-explorer.ts
@@ -25,10 +25,10 @@ const feature: FoamFeature = {
     context.subscriptions.push(
       treeView,
       foam.tags.onDidUpdate(() => {
+        provider.refresh();
         treeView.title = baseTitle + ` (${foam.tags.tags.size})`;
       })
     );
-    foam.tags.onDidUpdate(() => provider.refresh());
   },
 };
 


### PR DESCRIPTION
I think there's a slight bug with change https://github.com/foambubble/foam/commit/7a2756eb1db155c4d4b301d0b0e577a9eb2986f7, where the counts are out of sync with the actual number of entries

To reproduce in new project:
1. create note1
2. create note2 and add a placeholder [[note3]]
3. note that orphans panel says `Orphans (2)` even though it only has note1 and placeholders panel says `Placeholders (0)` with the note3 entry
![Screenshot 2023-01-03 102024](https://user-images.githubusercontent.com/8953212/210388391-460008a6-236e-49be-bfe6-a24d1a5d0581.png)


I believe we just need to tweak the subscription logic so the panel title is set after we do the calculations for each panel.
