### PR TITLE
Fix #920: Links in Markdown Preview not jumping to sections

### DIFF
--- a/packages/foam-vscode/src/features/preview/wikilink-navigation.spec.ts
+++ b/packages/foam-vscode/src/features/preview/wikilink-navigation.spec.ts
@@ -13,7 +13,13 @@ describe('Link generation in preview', () => {
     title: 'My note title',
     links: [{ slug: 'placeholder' }],
   });
-  const ws = new FoamWorkspace().set(noteA);
+  const noteB = createTestNote({
+    uri: './path2/to/note-b.md',
+    root: getUriInWorkspace('just-a-ref.md'),
+    title: 'My second note',
+    sections: ['sec1', 'sec2'],
+  });
+  const ws = new FoamWorkspace().set(noteA).set(noteB);
 
   const md = [
     markdownItWikilinkNavigation,
@@ -43,6 +49,36 @@ describe('Link generation in preview', () => {
     [note-a]: <note-a.md> "Note A"`;
     expect(md.render(note)).toEqual(
       `<p><a class='foam-note-link' title='${noteA.title}' href='/path/to/note-a.md' data-href='/path/to/note-a.md'>note-a</a>\n[note-a]: &lt;note-a.md&gt; &quot;Note A&quot;</p>\n`
+    );
+  });
+
+  it('generates a link to a note with a specific section', () => {
+    expect(md.render(`[[note-b#sec2]]`)).toEqual(
+      `<p><a class='foam-note-link' title='My second note#sec2' href='/path2/to/note-b.md#sec2' data-href='/path2/to/note-b.md#sec2'>note-b#sec2</a></p>\n`
+    );
+  });
+
+  it('generates a link to an aliased note with a specific section', () => {
+    expect(md.render(`[[note-b#sec2|this note]]`)).toEqual(
+      `<p><a class='foam-note-link' title='My second note#sec2' href='/path2/to/note-b.md#sec2' data-href='/path2/to/note-b.md#sec2'>this note</a></p>\n`
+    );
+  });
+
+  it('generates a link to a note if the note exists, but the section does not exist', () => {
+    expect(md.render(`[[note-b#nonexistentsec]]`)).toEqual(
+      `<p><a class='foam-note-link' title='My second note#nonexistentsec' href='/path2/to/note-b.md#nonexistentsec' data-href='/path2/to/note-b.md#nonexistentsec'>note-b#nonexistentsec</a></p>\n`
+    );
+  });
+
+  it('generates a placeholder link if the note does not exist and a section is specified', () => {
+    expect(md.render(`[[placeholder#sec2]]`)).toEqual(
+      `<p><a class='foam-placeholder-link' title="Link to non-existing resource" href="javascript:void(0);">placeholder#sec2</a></p>\n`
+    );
+  });
+
+  it('generates a placeholder link with alias if the note does not exist, but alias is given', () => {
+    expect(md.render(`[[placeholder#sec2|this note]]`)).toEqual(
+      `<p><a class='foam-placeholder-link' title="Link to non-existing resource" href="javascript:void(0);">this note</a></p>\n`
     );
   });
 });

--- a/packages/foam-vscode/src/features/preview/wikilink-navigation.ts
+++ b/packages/foam-vscode/src/features/preview/wikilink-navigation.ts
@@ -17,20 +17,24 @@ export const markdownItWikilinkNavigation = (
     regex: /(?=[^!])\[\[([^[\]]+?)\]\]/,
     replace: (wikilink: string) => {
       try {
-        const { target, alias } = MarkdownLink.analyzeLink({
+        const { target, section, alias } = MarkdownLink.analyzeLink({
           rawText: '[[' + wikilink + ']]',
           type: 'wikilink',
           range: Range.create(0, 0),
         });
-        const label = isEmpty(alias) ? target : alias;
+        const formattedSection = section ? `#${section}` : '';
+        const label = isEmpty(alias) ? `${target}${formattedSection}` : alias;
 
         const resource = workspace.find(target);
         if (isNone(resource)) {
           return getPlaceholderLink(label);
         }
 
-        const link = vscode.workspace.asRelativePath(toVsCodeUri(resource.uri));
-        return `<a class='foam-note-link' title='${resource.title}' href='/${link}' data-href='/${link}'>${label}</a>`;
+        const link = `${vscode.workspace.asRelativePath(
+          toVsCodeUri(resource.uri)
+        )}${formattedSection}`;
+        const title = `${resource.title}${formattedSection}`;
+        return `<a class='foam-note-link' title='${title}' href='/${link}' data-href='/${link}'>${label}</a>`;
       } catch (e) {
         Logger.error(
           `Error while creating link for [[${wikilink}]] in Preview panel`,


### PR DESCRIPTION
Resolves #920, but as mentioned in the comments, that issue is more accurately described here: https://github.com/foambubble/foam/issues/987#issuecomment-1178947779, as I believe it is not only specific to folder nested documents, but all wikilinks pointing to a section. 

Code isn't the prettiest, so looking for any feedback! 