### PR TITLE
Update contribution-guide.md with node version and fix broken link

### DIFF
--- a/docs/dev/contribution-guide.md
+++ b/docs/dev/contribution-guide.md
@@ -23,7 +23,7 @@ Finally, the easiest way to help, is to use it and provide feedback by [submitti
 
 ## Contributing
 
-If you're interested in contributing, this short guide will help you get things set up locally (assuming [node.js](https://nodejs.org/) and [yarn](https://yarnpkg.com/) are already installed on your system).
+If you're interested in contributing, this short guide will help you get things set up locally (assuming [node.js >= v12](https://nodejs.org/) and [yarn](https://yarnpkg.com/) are already installed on your system).
 
 1. Fork the project to your Github account by clicking the "Fork" button on the top right hand corner of the project's [home repository page](https://github.com/foambubble/foam).
 2. Clone your newly forked repo locally:
@@ -55,7 +55,7 @@ This project uses [Yarn workspaces](https://classic.yarnpkg.com/en/docs/workspac
 
 Originally Foam had:
 
-- [/packages/foam-core](https://github.com/foambubble/foam/tree/master/packages/foam-core) - Powers the core functionality in Foam across all platforms.
+- [/packages/foam-core](https://github.com/foambubble/foam/tree/ee7a8919761f168d3931079adf21c5ad4d63db59/packages/foam-core) - Powers the core functionality in Foam across all platforms.
 - [/packages/foam-vscode](https://github.com/foambubble/foam/tree/master/packages/foam-vscode) - The core VS Code plugin.
 
 To improve DX we have moved the `foam-core` module into `packages/foam-vscode/src/core`, but from a development point of view it's useful to think of the `foam-vscode/src/core` "submodule" as something that might be extracted in the future.

--- a/docs/dev/contribution-guide.md
+++ b/docs/dev/contribution-guide.md
@@ -23,7 +23,7 @@ Finally, the easiest way to help, is to use it and provide feedback by [submitti
 
 ## Contributing
 
-If you're interested in contributing, this short guide will help you get things set up locally (assuming [node.js >= v12](https://nodejs.org/) and [yarn](https://yarnpkg.com/) are already installed on your system).
+If you're interested in contributing, this short guide will help you get things set up locally (assuming [node.js >= v16](https://nodejs.org/) and [yarn](https://yarnpkg.com/) are already installed on your system).
 
 1. Fork the project to your Github account by clicking the "Fork" button on the top right hand corner of the project's [home repository page](https://github.com/foambubble/foam).
 2. Clone your newly forked repo locally:


### PR DESCRIPTION

## Description
A quick dev docs fix

- Found a broken link to `packages/foam-core` which no longer exists on the master branch ->I have replaced it to link to a commit where it previously existed
- Not sure what's the node.js version that devs should be using ->I have added that it should minimally be `v12` based on the [package.json](https://github.com/foambubble/foam/blob/7b4a56fe690cc98f8a0beb95cb95f929ea13d849/package.json#L28), though I should comment that v12 has already reached end-of-life and would be good to target a [higher version](https://github.com/nodejs/Release/#end-of-life-releases)

Please let me know if the changes are appropriate or require further edits, thanks!