### PR TITLE
Add markup-converter recipe

### DIFF
--- a/docs/user/recipes/markup-converter.md
+++ b/docs/user/recipes/markup-converter.md
@@ -1,0 +1,43 @@
+# Markup Converter
+
+This #recipe allows you to convert any document into Markdown for storing them in your notes.
+
+We will be using [Pandoc](https://pandoc.org/), a popular universal document converter. It can convert documents in Microsoft Word, HTML, LaTeX, and many other formats to various formats including markdown and many others.
+
+## Instructions
+
+We will go through the example of converting Microsoft Word documents to Markdown. For detailed instructions on how to use Pandoc, please refer to the [Pandoc documentation](https://pandoc.org/MANUAL.html).
+
+1. [Install Pandoc](https://pandoc.org/installing.html)
+1. Open the terminal of your choice and verify that Pandoc is installed by running `pandoc --version`
+1. Copy the Microsoft Word documents that you want to convert into a new folder
+1. Change the current directory to the folder containing the Microsoft Word documents
+1. Copy one of the following commands (based on your operating system) into your terminal and press `Enter` to run
+
+### Linux and macOS (Bash)
+
+```bash
+find -name "*.docx" -type f -exec sh -c '
+      for f; do
+         pandoc --extract-media=./ -f docx -t markdown -o "${f%.*}.md" "$f"
+      done
+   ' find-sh {} +
+```
+
+### Windows (PowerShell)
+
+```powershell
+Get-ChildItem . -Filter *.docx | 
+Foreach-Object {
+    pandoc --extract-media=./ --from docx --to markdown $_ -o $_.Name.Replace('.docx', '.md')
+}
+```
+
+### Relevant Configurations
+
+[Pandoc](https://pandoc.org/) accepts a range of command line arguments to control the conversion process. Here, we'll mention a few that are relevant to the example above.
+
+- `--extract-media=./` is used to extract the images from the Microsoft Word documents and store them in a subfolder named `media`
+- `-t markdown` converts the Microsoft Word documents to [Pandoc’s Markdown](https://pandoc.org/MANUAL.html#pandocs-markdown). You can also use `-t gfm` to convert to [GitHub Flavored Markdown](https://docs.github.com/en/get-started/writing-on-github)
+
+Note that you may want to review the converted Markdown files to ensure that the conversion was successful. Then, You may want to delete the original Microsoft Word documents.

--- a/docs/user/recipes/recipes.md
+++ b/docs/user/recipes/recipes.md
@@ -24,6 +24,7 @@ A #recipe is a guide, tip or strategy for getting the most out of your Foam work
 
 - Introduction to Zettelkasten [[todo]]
 - Clip webpages with [[web-clipper]]
+- Convert Microsoft Word files into Markdown with [[markup-converter]]
 
 ## Discover
 
@@ -110,6 +111,7 @@ _See [[contribution-guide]] and [[how-to-write-recipes]]._
 [how-to-write-recipes]: how-to-write-recipes.md "How to Write Recipes"
 [todo]: ../../dev/todo.md "Todo"
 [web-clipper]: web-clipper.md "Web Clipper"
+[markup-converter]: markup-converter.md "Markup Converter"
 [graph-visualization]: ../features/graph-visualization.md "Graph Visualization"
 [backlinking]: ../features/backlinking.md "Backlinking"
 [unlinked-references]: ../../dev/unlinked-references.md "Unlinked references (stub)"


### PR DESCRIPTION
## Description

Fixes #295

- I decided to put the section under [Take Smart Notes](https://foambubble.github.io/foam/user/recipes/recipes#take-smart-notes) instead as I think this is somewhat related to "Clip webpages"
- I decided to use `markup-converter` as title to be more generic
- I have tested both commands on git bash and powershell (I'm a Windows user) and both are working alright
	- See the two docx files and the converted output all in the [ms](https://github.com/tlylt/foam-tlylt/tree/master/ms) folder
	- To repeat the test, [download just the folder](https://download-directory.github.io/?url=https%3A%2F%2Fgithub.com%2Ftlylt%2Ffoam-tlylt%2Ftree%2Fmaster%2Fms) or clone my repo and cd into the `ms` folder to run the commands