### PR TITLE
Support for creating new note in current dir or root dir

### DIFF
--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -1,537 +1,537 @@
 {
-	"name": "foam-vscode",
-	"displayName": "Foam",
-	"description": "VS Code + Markdown + Wikilinks for your note taking and knowledge base",
-	"private": true,
-	"repository": {
-		"url": "https://github.com/foambubble/foam",
-		"type": "git"
-	},
-	"homepage": "https://github.com/foambubble/foam",
-	"version": "0.20.5",
-	"license": "MIT",
-	"publisher": "foam",
-	"engines": {
-		"vscode": "^1.70.0"
-	},
-	"icon": "assets/icon/FOAM_ICON_256.png",
-	"categories": [
-		"Other"
-	],
-	"activationEvents": [
-		"workspaceContains:.vscode/foam.json",
-		"onView:foam-vscode.tags-explorer",
-		"onCommand:foam-vscode.update-wikilinks",
-		"onCommand:foam-vscode.open-daily-note",
-		"onCommand:foam-vscode.update-graph",
-		"onCommand:foam-vscode.open-random-note",
-		"onCommand:foam-vscode.janitor",
-		"onCommand:foam-vscode.copy-without-brackets",
-		"onCommand:foam-vscode.show-graph",
-		"onCommand:foam-vscode.create-new-template",
-		"onCommand:foam-vscode.create-note",
-		"onCommand:foam-vscode.create-note-from-template",
-		"onCommand:foam-vscode.create-note-from-default-template"
-	],
-	"main": "./out/extension.js",
-	"contributes": {
-		"markdown.markdownItPlugins": true,
-		"markdown.previewStyles": [
-			"./static/preview/style.css"
-		],
-		"grammars": [
-			{
-				"path": "./syntaxes/injection.json",
-				"scopeName": "foam.wikilink.injection",
-				"injectTo": [
-					"text.html.markdown"
-				]
-			}
-		],
-		"colors": [
-			{
-				"id": "foam.placeholder",
-				"description": "Color of foam placeholders.",
-				"defaults": {
-					"dark": "editorWarning.foreground",
-					"light": "editorWarning.foreground",
-					"highContrast": "editorWarning.foreground"
-				}
-			}
-		],
-		"views": {
-			"explorer": [
-				{
-					"id": "foam-vscode.backlinks",
-					"name": "Backlinks",
-					"icon": "$(references)",
-					"contextualTitle": "Backlinks"
-				},
-				{
-					"id": "foam-vscode.tags-explorer",
-					"name": "Tag Explorer",
-					"icon": "$(tag)",
-					"contextualTitle": "Tags Explorer"
-				},
-				{
-					"id": "foam-vscode.orphans",
-					"name": "Orphans",
-					"icon": "$(debug-gripper)",
-					"contextualTitle": "Orphans"
-				},
-				{
-					"id": "foam-vscode.placeholders",
-					"name": "Placeholders",
-					"icon": "$(debug-disconnect)",
-					"contextualTitle": "Placeholders"
-				}
-			]
-		},
-		"viewsWelcome": [
-			{
-				"view": "foam-vscode.tags-explorer",
-				"contents": "No tags found. Notes that contain tags will show up here. You may add tags to a note with a hashtag (#tag) or by adding a tag list to the front matter (tags: tag1, tag2)."
-			},
-			{
-				"view": "foam-vscode.backlinks",
-				"contents": "No backlinks found for selected resource."
-			},
-			{
-				"view": "foam-vscode.orphans",
-				"contents": "No orphans found. Notes that have no backlinks nor links will show up here."
-			},
-			{
-				"view": "foam-vscode.placeholders",
-				"contents": "No placeholders found. Pending links and notes without content will show up here."
-			}
-		],
-		"menus": {
-			"view/title": [
-				{
-					"command": "foam-vscode.group-orphans-by-folder",
-					"when": "view == foam-vscode.orphans && foam-vscode.orphans-grouped-by-folder == false",
-					"group": "navigation"
-				},
-				{
-					"command": "foam-vscode.group-orphans-off",
-					"when": "view == foam-vscode.orphans && foam-vscode.orphans-grouped-by-folder == true",
-					"group": "navigation"
-				},
-				{
-					"command": "foam-vscode.group-placeholders-by-folder",
-					"when": "view == foam-vscode.placeholders && foam-vscode.placeholders-grouped-by-folder == false",
-					"group": "navigation"
-				},
-				{
-					"command": "foam-vscode.group-placeholders-off",
-					"when": "view == foam-vscode.placeholders && foam-vscode.placeholders-grouped-by-folder == true",
-					"group": "navigation"
-				}
-			],
-			"commandPalette": [
-				{
-					"command": "foam-vscode.create-note-from-default-template",
-					"when": "false"
-				},
-				{
-					"command": "foam-vscode.update-graph",
-					"when": "false"
-				},
-				{
-					"command": "foam-vscode.group-orphans-by-folder",
-					"when": "false"
-				},
-				{
-					"command": "foam-vscode.group-orphans-off",
-					"when": "false"
-				},
-				{
-					"command": "foam-vscode.group-placeholders-by-folder",
-					"when": "false"
-				},
-				{
-					"command": "foam-vscode.group-placeholders-off",
-					"when": "false"
-				},
-				{
-					"command": "foam-vscode.open-resource",
-					"when": "false"
-				},
-				{
-					"command": "foam-vscode.completion-move-cursor",
-					"when": "false"
-				}
-			]
-		},
-		"commands": [
-			{
-				"command": "foam-vscode.create-note",
-				"title": "Foam: Create New Note"
-			},
-			{
-				"command": "foam-vscode.clear-cache",
-				"title": "Foam: Clear Cache"
-			},
-			{
-				"command": "foam-vscode.update-graph",
-				"title": "Foam: Update graph"
-			},
-			{
-				"command": "foam-vscode.set-log-level",
-				"title": "Foam: Set log level"
-			},
-			{
-				"command": "foam-vscode.show-graph",
-				"title": "Foam: Show graph"
-			},
-			{
-				"command": "foam-vscode.update-wikilinks",
-				"title": "Foam: Update Markdown Reference List"
-			},
-			{
-				"command": "foam-vscode.open-daily-note",
-				"title": "Foam: Open Today's Note"
-			},
-			{
-				"command": "foam-vscode.open-daily-note-for-date",
-				"title": "Foam: Open Daily Note"
-			},
-			{
-				"command": "foam-vscode.open-random-note",
-				"title": "Foam: Open Random Note"
-			},
-			{
-				"command": "foam-vscode.janitor",
-				"title": "Foam: Run Janitor (Experimental)"
-			},
-			{
-				"command": "foam-vscode.copy-without-brackets",
-				"title": "Foam: Copy To Clipboard Without Brackets"
-			},
-			{
-				"command": "foam-vscode.create-note-from-template",
-				"title": "Foam: Create New Note From Template"
-			},
-			{
-				"command": "foam-vscode.create-note-from-default-template",
-				"title": "Foam: Create New Note"
-			},
-			{
-				"command": "foam-vscode.open-resource",
-				"title": "Foam: Open Resource"
-			},
-			{
-				"command": "foam-vscode.group-orphans-by-folder",
-				"title": "Foam: Group Orphans By Folder",
-				"icon": "$(list-tree)"
-			},
-			{
-				"command": "foam-vscode.group-orphans-off",
-				"title": "Foam: Don't Group Orphans",
-				"icon": "$(list-flat)"
-			},
-			{
-				"command": "foam-vscode.group-placeholders-by-folder",
-				"title": "Foam: Group Placeholders By Folder",
-				"icon": "$(list-tree)"
-			},
-			{
-				"command": "foam-vscode.group-placeholders-off",
-				"title": "Foam: Don't Group Placeholders",
-				"icon": "$(list-flat)"
-			},
-			{
-				"command": "foam-vscode.create-new-template",
-				"title": "Foam: Create New Template"
-			},
-			{
-				"command": "foam-vscode.completion-move-cursor",
-				"title": "Foam: Move cursor after completion"
-			}
-		],
-		"configuration": {
-			"title": "Foam",
-			"properties": {
-				"foam.newNote.path": {
-					"type": "string",
-					"default": "root",
-					"description": "Specifies where to create a new note. It is overruled by the template",
-					"enum": [
-						"root",
-						"currentDir"
-					],
-					"enumDescriptions": [
-						"Use the root of the workspace",
-						"Use the directory of the file in the current editor"
-					]
-				},
-				"foam.completion.label": {
-					"type": "string",
-					"default": "path",
-					"description": "Describes what note property to use as a label for completion items",
-					"enum": [
-						"path",
-						"title",
-						"identifier"
-					],
-					"enumDescriptions": [
-						"Use the path of the note",
-						"Use the title of the note",
-						"Use the identifier of the note"
-					]
-				},
-				"foam.completion.useAlias": {
-					"type": "string",
-					"default": "never",
-					"description": "Specifies in which cases to use an alias when creating a wikilink",
-					"enum": [
-						"never",
-						"whenPathDiffersFromTitle"
-					],
-					"enumDescriptions": [
-						"Never use aliases in completion items",
-						"Use alias if resource path is different from title"
-					]
-				},
-				"foam.files.ignore": {
-					"type": [
-						"array"
-					],
-					"default": [
-						"**/.vscode/**/*",
-						"**/_layouts/**/*",
-						"**/_site/**/*",
-						"**/node_modules/**/*"
-					],
-					"description": "Specifies the list of globs that will be ignored by Foam (e.g. they will not be considered when creating the graph). To ignore the all the content of a given folder, use `<folderName>/**/*`"
-				},
-				"foam.files.attachmentExtensions": {
-					"type": "string",
-					"default": "pdf mp3 webm wav m4a mp4 avi mov rtf txt doc docx pages xls xlsx numbers ppt pptm pptx",
-					"description": "Space separated list of file extensions that will be considered attachments"
-				},
-				"foam.logging.level": {
-					"type": "string",
-					"default": "info",
-					"enum": [
-						"off",
-						"debug",
-						"info",
-						"warn",
-						"error"
-					]
-				},
-				"foam.edit.linkReferenceDefinitions": {
-					"type": "string",
-					"default": "off",
-					"enum": [
-						"withExtensions",
-						"withoutExtensions",
-						"off"
-					],
-					"enumDescriptions": [
-						"Include extension in wikilinks paths",
-						"Remove extension in wikilink paths",
-						"Disable wikilink definitions generation"
-					]
-				},
-				"foam.links.sync.enable": {
-					"description": "Enable synching links when moving/renaming notes",
-					"type": "boolean",
-					"default": true
-				},
-				"foam.links.hover.enable": {
-					"description": "Enable displaying note content on hover links",
-					"type": "boolean",
-					"default": true
-				},
-				"foam.openDailyNote.onStartup": {
-					"type": "boolean",
-					"default": false
-				},
-				"foam.openDailyNote.fileExtension": {
-					"type": "string",
-					"default": "md"
-				},
-				"foam.openDailyNote.filenameFormat": {
-					"type": "string",
-					"default": "isoDate",
-					"markdownDescription": "Specifies how the daily note filename is formatted. See the [dateformat docs](https://www.npmjs.com/package/dateformat) for valid formats"
-				},
-				"foam.openDailyNote.titleFormat": {
-					"type": [
-						"string",
-						"null"
-					],
-					"default": null,
-					"markdownDescription": "Specifies how the daily note title is formatted. Will default to the filename format if set to null. See the [dateformat docs](https://www.npmjs.com/package/dateformat) for valid formats"
-				},
-				"foam.openDailyNote.directory": {
-					"type": [
-						"string",
-						"null"
-					],
-					"default": null,
-					"description": "The directory into which daily notes should be created. Defaults to the workspace root."
-				},
-				"foam.orphans.exclude": {
-					"type": [
-						"array"
-					],
-					"default": [],
-					"markdownDescription": "Specifies the list of glob patterns that will be excluded from the orphans report. To ignore the all the content of a given folder, use `**<folderName>/**/*`"
-				},
-				"foam.orphans.groupBy": {
-					"type": [
-						"string"
-					],
-					"enum": [
-						"off",
-						"folder"
-					],
-					"enumDescriptions": [
-						"Disable grouping",
-						"Group by folder"
-					],
-					"default": "folder",
-					"markdownDescription": "Group orphans report entries by."
-				},
-				"foam.placeholders.exclude": {
-					"type": [
-						"array"
-					],
-					"default": [],
-					"markdownDescription": "Specifies the list of glob patterns that will be excluded from the placeholders report. To ignore the all the content of a given folder, use `**<folderName>/**/*`"
-				},
-				"foam.placeholders.groupBy": {
-					"type": [
-						"string"
-					],
-					"enum": [
-						"off",
-						"folder"
-					],
-					"enumDescriptions": [
-						"Disable grouping",
-						"Group by folder"
-					],
-					"default": "folder",
-					"markdownDescription": "Group blank note report entries by."
-				},
-				"foam.dateSnippets.afterCompletion": {
-					"type": "string",
-					"default": "createNote",
-					"enum": [
-						"noop",
-						"createNote",
-						"navigateToNote"
-					],
-					"enumDescriptions": [
-						"Nothing happens after selecting the completion item",
-						"The note is created following your daily note settings if it does not exist, but no navigation takes place",
-						"Navigates to the note, creating it following your daily note settings if it does not exist"
-					],
-					"description": "Whether or not to navigate to the target daily note when a daily note snippet is selected."
-				},
-				"foam.preview.embedNoteInContainer": {
-					"type": "boolean",
-					"default": true,
-					"description": "Wrap embedded notes in a container when displayed in preview panel"
-				},
-				"foam.graph.titleMaxLength": {
-					"type": "number",
-					"default": 24,
-					"description": "The maximum title length before being abbreviated. Set to 0 or less to disable."
-				},
-				"foam.graph.style": {
-					"type": "object",
-					"description": "Custom graph styling settings. An example is present in the documentation.",
-					"default": {}
-				}
-			}
-		},
-		"keybindings": [
-			{
-				"command": "foam-vscode.open-daily-note",
-				"key": "alt+d"
-			},
-			{
-				"command": "foam-vscode.open-daily-note-for-date",
-				"key": "alt+h"
-			}
-		]
-	},
-	"scripts": {
-		"build": "tsc -p ./",
-		"pretest": "yarn build",
-		"test": "node ./out/test/run-tests.js",
-		"pretest:unit": "yarn build",
-		"test:unit": "node ./out/test/run-tests.js --unit",
-		"pretest:e2e": "yarn build",
-		"test:e2e": "node ./out/test/run-tests.js --e2e",
-		"lint": "tsdx lint src",
-		"clean": "rimraf out",
-		"watch": "tsc --build ./tsconfig.json --watch",
-		"vscode:start-debugging": "yarn clean && yarn watch",
-		"esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node",
-		"vscode:prepublish": "yarn run esbuild-base -- --minify",
-		"package-extension": "npx vsce package --yarn",
-		"install-extension": "code --install-extension ./foam-vscode-$npm_package_version.vsix",
-		"publish-extension-openvsx": "npx ovsx publish foam-vscode-$npm_package_version.vsix -p $OPENVSX_TOKEN",
-		"publish-extension-vscode": "npx vsce publish --packagePath foam-vscode-$npm_package_version.vsix",
-		"publish-extension": "yarn publish-extension-vscode && yarn publish-extension-openvsx"
-	},
-	"devDependencies": {
-		"@types/dateformat": "^3.0.1",
-		"@types/glob": "^7.1.1",
-		"@types/lodash": "^4.14.157",
-		"@types/markdown-it": "^12.0.1",
-		"@types/micromatch": "^4.0.1",
-		"@types/node": "^13.11.0",
-		"@types/picomatch": "^2.2.1",
-		"@types/remove-markdown": "^0.1.1",
-		"@types/vscode": "^1.47.1",
-		"@typescript-eslint/eslint-plugin": "^2.30.0",
-		"@typescript-eslint/parser": "^2.30.0",
-		"esbuild": "^0.14.45",
-		"eslint": "^6.8.0",
-		"eslint-import-resolver-typescript": "^2.5.0",
-		"eslint-plugin-import": "^2.24.2",
-		"eslint-plugin-jest": "^25.3.0",
-		"glob": "^7.1.6",
-		"husky": "^4.2.5",
-		"jest": "^26.2.2",
-		"jest-extended": "^0.11.5",
-		"markdown-it": "^12.0.4",
-		"micromatch": "^4.0.2",
-		"rimraf": "^3.0.2",
-		"ts-jest": "^26.4.4",
-		"tsdx": "^0.13.2",
-		"tslib": "^2.0.0",
-		"typescript": "^3.9.5",
-		"vscode-test": "^1.3.0",
-		"wait-for-expect": "^3.0.2"
-	},
-	"dependencies": {
-		"dateformat": "^3.0.3",
-		"detect-newline": "^3.1.0",
-		"github-slugger": "^1.4.0",
-		"gray-matter": "^4.0.2",
-		"lodash": "^4.17.21",
-		"lru-cache": "^7.12.0",
-		"markdown-it-regex": "^0.2.0",
-		"remark-frontmatter": "^2.0.0",
-		"remark-parse": "^8.0.2",
-		"remark-wiki-link": "^0.0.4",
-		"title-case": "^3.0.2",
-		"unified": "^9.0.0",
-		"unist-util-visit": "^2.0.2",
-		"yaml": "^1.10.0"
-	},
-	"__metadata": {
-		"id": "b85c6625-454b-4b61-8a22-c42f3d0f2e1e",
-		"publisherDisplayName": "Foam",
-		"publisherId": "34339645-24f0-4619-9917-12157fd92446",
-		"isPreReleaseVersion": false
-	}
+  "name": "foam-vscode",
+  "displayName": "Foam",
+  "description": "VS Code + Markdown + Wikilinks for your note taking and knowledge base",
+  "private": true,
+  "repository": {
+    "url": "https://github.com/foambubble/foam",
+    "type": "git"
+  },
+  "homepage": "https://github.com/foambubble/foam",
+  "version": "0.20.5",
+  "license": "MIT",
+  "publisher": "foam",
+  "engines": {
+    "vscode": "^1.70.0"
+  },
+  "icon": "assets/icon/FOAM_ICON_256.png",
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    "workspaceContains:.vscode/foam.json",
+    "onView:foam-vscode.tags-explorer",
+    "onCommand:foam-vscode.update-wikilinks",
+    "onCommand:foam-vscode.open-daily-note",
+    "onCommand:foam-vscode.update-graph",
+    "onCommand:foam-vscode.open-random-note",
+    "onCommand:foam-vscode.janitor",
+    "onCommand:foam-vscode.copy-without-brackets",
+    "onCommand:foam-vscode.show-graph",
+    "onCommand:foam-vscode.create-new-template",
+    "onCommand:foam-vscode.create-note",
+    "onCommand:foam-vscode.create-note-from-template",
+    "onCommand:foam-vscode.create-note-from-default-template"
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "markdown.markdownItPlugins": true,
+    "markdown.previewStyles": [
+      "./static/preview/style.css"
+    ],
+    "grammars": [
+      {
+        "path": "./syntaxes/injection.json",
+        "scopeName": "foam.wikilink.injection",
+        "injectTo": [
+          "text.html.markdown"
+        ]
+      }
+    ],
+    "colors": [
+      {
+        "id": "foam.placeholder",
+        "description": "Color of foam placeholders.",
+        "defaults": {
+          "dark": "editorWarning.foreground",
+          "light": "editorWarning.foreground",
+          "highContrast": "editorWarning.foreground"
+        }
+      }
+    ],
+    "views": {
+      "explorer": [
+        {
+          "id": "foam-vscode.backlinks",
+          "name": "Backlinks",
+          "icon": "$(references)",
+          "contextualTitle": "Backlinks"
+        },
+        {
+          "id": "foam-vscode.tags-explorer",
+          "name": "Tag Explorer",
+          "icon": "$(tag)",
+          "contextualTitle": "Tags Explorer"
+        },
+        {
+          "id": "foam-vscode.orphans",
+          "name": "Orphans",
+          "icon": "$(debug-gripper)",
+          "contextualTitle": "Orphans"
+        },
+        {
+          "id": "foam-vscode.placeholders",
+          "name": "Placeholders",
+          "icon": "$(debug-disconnect)",
+          "contextualTitle": "Placeholders"
+        }
+      ]
+    },
+    "viewsWelcome": [
+      {
+        "view": "foam-vscode.tags-explorer",
+        "contents": "No tags found. Notes that contain tags will show up here. You may add tags to a note with a hashtag (#tag) or by adding a tag list to the front matter (tags: tag1, tag2)."
+      },
+      {
+        "view": "foam-vscode.backlinks",
+        "contents": "No backlinks found for selected resource."
+      },
+      {
+        "view": "foam-vscode.orphans",
+        "contents": "No orphans found. Notes that have no backlinks nor links will show up here."
+      },
+      {
+        "view": "foam-vscode.placeholders",
+        "contents": "No placeholders found. Pending links and notes without content will show up here."
+      }
+    ],
+    "menus": {
+      "view/title": [
+        {
+          "command": "foam-vscode.group-orphans-by-folder",
+          "when": "view == foam-vscode.orphans && foam-vscode.orphans-grouped-by-folder == false",
+          "group": "navigation"
+        },
+        {
+          "command": "foam-vscode.group-orphans-off",
+          "when": "view == foam-vscode.orphans && foam-vscode.orphans-grouped-by-folder == true",
+          "group": "navigation"
+        },
+        {
+          "command": "foam-vscode.group-placeholders-by-folder",
+          "when": "view == foam-vscode.placeholders && foam-vscode.placeholders-grouped-by-folder == false",
+          "group": "navigation"
+        },
+        {
+          "command": "foam-vscode.group-placeholders-off",
+          "when": "view == foam-vscode.placeholders && foam-vscode.placeholders-grouped-by-folder == true",
+          "group": "navigation"
+        }
+      ],
+      "commandPalette": [
+        {
+          "command": "foam-vscode.create-note-from-default-template",
+          "when": "false"
+        },
+        {
+          "command": "foam-vscode.update-graph",
+          "when": "false"
+        },
+        {
+          "command": "foam-vscode.group-orphans-by-folder",
+          "when": "false"
+        },
+        {
+          "command": "foam-vscode.group-orphans-off",
+          "when": "false"
+        },
+        {
+          "command": "foam-vscode.group-placeholders-by-folder",
+          "when": "false"
+        },
+        {
+          "command": "foam-vscode.group-placeholders-off",
+          "when": "false"
+        },
+        {
+          "command": "foam-vscode.open-resource",
+          "when": "false"
+        },
+        {
+          "command": "foam-vscode.completion-move-cursor",
+          "when": "false"
+        }
+      ]
+    },
+    "commands": [
+      {
+        "command": "foam-vscode.create-note",
+        "title": "Foam: Create New Note"
+      },
+      {
+        "command": "foam-vscode.clear-cache",
+        "title": "Foam: Clear Cache"
+      },
+      {
+        "command": "foam-vscode.update-graph",
+        "title": "Foam: Update graph"
+      },
+      {
+        "command": "foam-vscode.set-log-level",
+        "title": "Foam: Set log level"
+      },
+      {
+        "command": "foam-vscode.show-graph",
+        "title": "Foam: Show graph"
+      },
+      {
+        "command": "foam-vscode.update-wikilinks",
+        "title": "Foam: Update Markdown Reference List"
+      },
+      {
+        "command": "foam-vscode.open-daily-note",
+        "title": "Foam: Open Today's Note"
+      },
+      {
+        "command": "foam-vscode.open-daily-note-for-date",
+        "title": "Foam: Open Daily Note"
+      },
+      {
+        "command": "foam-vscode.open-random-note",
+        "title": "Foam: Open Random Note"
+      },
+      {
+        "command": "foam-vscode.janitor",
+        "title": "Foam: Run Janitor (Experimental)"
+      },
+      {
+        "command": "foam-vscode.copy-without-brackets",
+        "title": "Foam: Copy To Clipboard Without Brackets"
+      },
+      {
+        "command": "foam-vscode.create-note-from-template",
+        "title": "Foam: Create New Note From Template"
+      },
+      {
+        "command": "foam-vscode.create-note-from-default-template",
+        "title": "Foam: Create New Note"
+      },
+      {
+        "command": "foam-vscode.open-resource",
+        "title": "Foam: Open Resource"
+      },
+      {
+        "command": "foam-vscode.group-orphans-by-folder",
+        "title": "Foam: Group Orphans By Folder",
+        "icon": "$(list-tree)"
+      },
+      {
+        "command": "foam-vscode.group-orphans-off",
+        "title": "Foam: Don't Group Orphans",
+        "icon": "$(list-flat)"
+      },
+      {
+        "command": "foam-vscode.group-placeholders-by-folder",
+        "title": "Foam: Group Placeholders By Folder",
+        "icon": "$(list-tree)"
+      },
+      {
+        "command": "foam-vscode.group-placeholders-off",
+        "title": "Foam: Don't Group Placeholders",
+        "icon": "$(list-flat)"
+      },
+      {
+        "command": "foam-vscode.create-new-template",
+        "title": "Foam: Create New Template"
+      },
+      {
+        "command": "foam-vscode.completion-move-cursor",
+        "title": "Foam: Move cursor after completion"
+      }
+    ],
+    "configuration": {
+      "title": "Foam",
+      "properties": {
+        "foam.completion.label": {
+          "type": "string",
+          "default": "path",
+          "description": "Describes what note property to use as a label for completion items",
+          "enum": [
+            "path",
+            "title",
+            "identifier"
+          ],
+          "enumDescriptions": [
+            "Use the path of the note",
+            "Use the title of the note",
+            "Use the identifier of the note"
+          ]
+        },
+        "foam.completion.useAlias": {
+          "type": "string",
+          "default": "never",
+          "description": "Specifies in which cases to use an alias when creating a wikilink",
+          "enum": [
+            "never",
+            "whenPathDiffersFromTitle"
+          ],
+          "enumDescriptions": [
+            "Never use aliases in completion items",
+            "Use alias if resource path is different from title"
+          ]
+        },
+        "foam.files.ignore": {
+          "type": [
+            "array"
+          ],
+          "default": [
+            "**/.vscode/**/*",
+            "**/_layouts/**/*",
+            "**/_site/**/*",
+            "**/node_modules/**/*"
+          ],
+          "description": "Specifies the list of globs that will be ignored by Foam (e.g. they will not be considered when creating the graph). To ignore the all the content of a given folder, use `<folderName>/**/*`"
+        },
+        "foam.files.attachmentExtensions": {
+          "type": "string",
+          "default": "pdf mp3 webm wav m4a mp4 avi mov rtf txt doc docx pages xls xlsx numbers ppt pptm pptx",
+          "description": "Space separated list of file extensions that will be considered attachments"
+        },
+        "foam.files.newNotePath": {
+          "type": "string",
+          "default": "root",
+          "description": "Specifies where to create a new note. It is overruled by the template or command arguments",
+          "enum": [
+            "root",
+            "currentDir"
+          ],
+          "enumDescriptions": [
+            "Use the root of the workspace",
+            "Use the directory of the file in the current editor"
+          ]
+        },
+        "foam.logging.level": {
+          "type": "string",
+          "default": "info",
+          "enum": [
+            "off",
+            "debug",
+            "info",
+            "warn",
+            "error"
+          ]
+        },
+        "foam.edit.linkReferenceDefinitions": {
+          "type": "string",
+          "default": "off",
+          "enum": [
+            "withExtensions",
+            "withoutExtensions",
+            "off"
+          ],
+          "enumDescriptions": [
+            "Include extension in wikilinks paths",
+            "Remove extension in wikilink paths",
+            "Disable wikilink definitions generation"
+          ]
+        },
+        "foam.links.sync.enable": {
+          "description": "Enable synching links when moving/renaming notes",
+          "type": "boolean",
+          "default": true
+        },
+        "foam.links.hover.enable": {
+          "description": "Enable displaying note content on hover links",
+          "type": "boolean",
+          "default": true
+        },
+        "foam.openDailyNote.onStartup": {
+          "type": "boolean",
+          "default": false
+        },
+        "foam.openDailyNote.fileExtension": {
+          "type": "string",
+          "default": "md"
+        },
+        "foam.openDailyNote.filenameFormat": {
+          "type": "string",
+          "default": "isoDate",
+          "markdownDescription": "Specifies how the daily note filename is formatted. See the [dateformat docs](https://www.npmjs.com/package/dateformat) for valid formats"
+        },
+        "foam.openDailyNote.titleFormat": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "markdownDescription": "Specifies how the daily note title is formatted. Will default to the filename format if set to null. See the [dateformat docs](https://www.npmjs.com/package/dateformat) for valid formats"
+        },
+        "foam.openDailyNote.directory": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "description": "The directory into which daily notes should be created. Defaults to the workspace root."
+        },
+        "foam.orphans.exclude": {
+          "type": [
+            "array"
+          ],
+          "default": [],
+          "markdownDescription": "Specifies the list of glob patterns that will be excluded from the orphans report. To ignore the all the content of a given folder, use `**<folderName>/**/*`"
+        },
+        "foam.orphans.groupBy": {
+          "type": [
+            "string"
+          ],
+          "enum": [
+            "off",
+            "folder"
+          ],
+          "enumDescriptions": [
+            "Disable grouping",
+            "Group by folder"
+          ],
+          "default": "folder",
+          "markdownDescription": "Group orphans report entries by."
+        },
+        "foam.placeholders.exclude": {
+          "type": [
+            "array"
+          ],
+          "default": [],
+          "markdownDescription": "Specifies the list of glob patterns that will be excluded from the placeholders report. To ignore the all the content of a given folder, use `**<folderName>/**/*`"
+        },
+        "foam.placeholders.groupBy": {
+          "type": [
+            "string"
+          ],
+          "enum": [
+            "off",
+            "folder"
+          ],
+          "enumDescriptions": [
+            "Disable grouping",
+            "Group by folder"
+          ],
+          "default": "folder",
+          "markdownDescription": "Group blank note report entries by."
+        },
+        "foam.dateSnippets.afterCompletion": {
+          "type": "string",
+          "default": "createNote",
+          "enum": [
+            "noop",
+            "createNote",
+            "navigateToNote"
+          ],
+          "enumDescriptions": [
+            "Nothing happens after selecting the completion item",
+            "The note is created following your daily note settings if it does not exist, but no navigation takes place",
+            "Navigates to the note, creating it following your daily note settings if it does not exist"
+          ],
+          "description": "Whether or not to navigate to the target daily note when a daily note snippet is selected."
+        },
+        "foam.preview.embedNoteInContainer": {
+          "type": "boolean",
+          "default": true,
+          "description": "Wrap embedded notes in a container when displayed in preview panel"
+        },
+        "foam.graph.titleMaxLength": {
+          "type": "number",
+          "default": 24,
+          "description": "The maximum title length before being abbreviated. Set to 0 or less to disable."
+        },
+        "foam.graph.style": {
+          "type": "object",
+          "description": "Custom graph styling settings. An example is present in the documentation.",
+          "default": {}
+        }
+      }
+    },
+    "keybindings": [
+      {
+        "command": "foam-vscode.open-daily-note",
+        "key": "alt+d"
+      },
+      {
+        "command": "foam-vscode.open-daily-note-for-date",
+        "key": "alt+h"
+      }
+    ]
+  },
+  "scripts": {
+    "build": "tsc -p ./",
+    "pretest": "yarn build",
+    "test": "node ./out/test/run-tests.js",
+    "pretest:unit": "yarn build",
+    "test:unit": "node ./out/test/run-tests.js --unit",
+    "pretest:e2e": "yarn build",
+    "test:e2e": "node ./out/test/run-tests.js --e2e",
+    "lint": "tsdx lint src",
+    "clean": "rimraf out",
+    "watch": "tsc --build ./tsconfig.json --watch",
+    "vscode:start-debugging": "yarn clean && yarn watch",
+    "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node",
+    "vscode:prepublish": "yarn run esbuild-base -- --minify",
+    "package-extension": "npx vsce package --yarn",
+    "install-extension": "code --install-extension ./foam-vscode-$npm_package_version.vsix",
+    "publish-extension-openvsx": "npx ovsx publish foam-vscode-$npm_package_version.vsix -p $OPENVSX_TOKEN",
+    "publish-extension-vscode": "npx vsce publish --packagePath foam-vscode-$npm_package_version.vsix",
+    "publish-extension": "yarn publish-extension-vscode && yarn publish-extension-openvsx"
+  },
+  "devDependencies": {
+    "@types/dateformat": "^3.0.1",
+    "@types/glob": "^7.1.1",
+    "@types/lodash": "^4.14.157",
+    "@types/markdown-it": "^12.0.1",
+    "@types/micromatch": "^4.0.1",
+    "@types/node": "^13.11.0",
+    "@types/picomatch": "^2.2.1",
+    "@types/remove-markdown": "^0.1.1",
+    "@types/vscode": "^1.47.1",
+    "@typescript-eslint/eslint-plugin": "^2.30.0",
+    "@typescript-eslint/parser": "^2.30.0",
+    "esbuild": "^0.14.45",
+    "eslint": "^6.8.0",
+    "eslint-import-resolver-typescript": "^2.5.0",
+    "eslint-plugin-import": "^2.24.2",
+    "eslint-plugin-jest": "^25.3.0",
+    "glob": "^7.1.6",
+    "husky": "^4.2.5",
+    "jest": "^26.2.2",
+    "jest-extended": "^0.11.5",
+    "markdown-it": "^12.0.4",
+    "micromatch": "^4.0.2",
+    "rimraf": "^3.0.2",
+    "ts-jest": "^26.4.4",
+    "tsdx": "^0.13.2",
+    "tslib": "^2.0.0",
+    "typescript": "^3.9.5",
+    "vscode-test": "^1.3.0",
+    "wait-for-expect": "^3.0.2"
+  },
+  "dependencies": {
+    "dateformat": "^3.0.3",
+    "detect-newline": "^3.1.0",
+    "github-slugger": "^1.4.0",
+    "gray-matter": "^4.0.2",
+    "lodash": "^4.17.21",
+    "lru-cache": "^7.12.0",
+    "markdown-it-regex": "^0.2.0",
+    "remark-frontmatter": "^2.0.0",
+    "remark-parse": "^8.0.2",
+    "remark-wiki-link": "^0.0.4",
+    "title-case": "^3.0.2",
+    "unified": "^9.0.0",
+    "unist-util-visit": "^2.0.2",
+    "yaml": "^1.10.0"
+  },
+  "__metadata": {
+    "id": "b85c6625-454b-4b61-8a22-c42f3d0f2e1e",
+    "publisherDisplayName": "Foam",
+    "publisherId": "34339645-24f0-4619-9917-12157fd92446",
+    "isPreReleaseVersion": false
+  }
 }

--- a/packages/foam-vscode/src/features/commands/create-note.spec.ts
+++ b/packages/foam-vscode/src/features/commands/create-note.spec.ts
@@ -167,21 +167,21 @@ describe('create-note command', () => {
     await closeEditors();
     await showInEditor(base.uri);
     await commands.executeCommand('foam-vscode.create-note', {
-      notePath: target.path,
+      notePath: target.getBasename(),
       text: 'test cancelling',
       onRelativeNotePath: 'cancel',
     });
     expectSameUri(window.activeTextEditor.document.uri, base.uri);
 
+    await closeEditors();
+    await showInEditor(base.uri);
     const spy = jest
       .spyOn(window, 'showInputBox')
       .mockImplementationOnce(jest.fn(() => Promise.resolve(undefined)));
-    await closeEditors();
-    await showInEditor(base.uri);
     await commands.executeCommand('foam-vscode.create-note', {
-      notePath: target.path,
+      notePath: target.getBasename(),
       text: 'test asking',
-      onRelativeNotePath: 'cancel',
+      onRelativeNotePath: 'ask',
     });
     expect(spy).toBeCalled();
 

--- a/packages/foam-vscode/src/features/commands/create-note.spec.ts
+++ b/packages/foam-vscode/src/features/commands/create-note.spec.ts
@@ -7,7 +7,9 @@ import {
   deleteFile,
   expectSameUri,
   getUriInWorkspace,
+  showInEditor,
 } from '../../test/test-utils-vscode';
+import { fromVsCodeUri } from '../../utils/vsc-utils';
 
 describe('create-note command', () => {
   afterEach(() => {
@@ -125,5 +127,64 @@ describe('create-note command', () => {
     expect(spy).toBeCalled();
 
     await deleteFile(target);
+  });
+
+  it('supports various options to deal with relative paths', async () => {
+    const base = await createFile('relative path tests base file', [
+      'create-note-tests',
+      'base-file.md',
+    ]);
+    await closeEditors();
+    await showInEditor(base.uri);
+
+    const target = getUriInWorkspace();
+    await commands.executeCommand('foam-vscode.create-note', {
+      notePath: target.getBasename(),
+      text: 'test resolving from root',
+      onRelativeNotePath: 'resolve-from-root',
+    });
+    expect(window.activeTextEditor.document.getText()).toEqual(
+      'test resolving from root'
+    );
+    expectSameUri(window.activeTextEditor.document.uri, target);
+
+    await closeEditors();
+    await showInEditor(base.uri);
+    await commands.executeCommand('foam-vscode.create-note', {
+      notePath: target.getBasename(),
+      text: 'test resolving from current dir',
+      onRelativeNotePath: 'resolve-from-current-dir',
+    });
+    expect(window.activeTextEditor.document.getText()).toEqual(
+      'test resolving from current dir'
+    );
+    expect(window.activeTextEditor.document.uri.path).toEqual(
+      fromVsCodeUri(window.activeTextEditor.document.uri)
+        .getDirectory()
+        .joinPath(target.getBasename()).path
+    );
+
+    await closeEditors();
+    await showInEditor(base.uri);
+    await commands.executeCommand('foam-vscode.create-note', {
+      notePath: target.path,
+      text: 'test cancelling',
+      onRelativeNotePath: 'cancel',
+    });
+    expectSameUri(window.activeTextEditor.document.uri, base.uri);
+
+    const spy = jest
+      .spyOn(window, 'showInputBox')
+      .mockImplementationOnce(jest.fn(() => Promise.resolve(undefined)));
+    await closeEditors();
+    await showInEditor(base.uri);
+    await commands.executeCommand('foam-vscode.create-note', {
+      notePath: target.path,
+      text: 'test asking',
+      onRelativeNotePath: 'cancel',
+    });
+    expect(spy).toBeCalled();
+
+    await deleteFile(base);
   });
 });

--- a/packages/foam-vscode/src/features/commands/create-note.spec.ts
+++ b/packages/foam-vscode/src/features/commands/create-note.spec.ts
@@ -158,7 +158,7 @@ describe('create-note command', () => {
     expect(window.activeTextEditor.document.getText()).toEqual(
       'test resolving from current dir'
     );
-    expect(fromVsCodeUri(window.activeTextEditor.document.uri)).toEqual(
+    expect(fromVsCodeUri(window.activeTextEditor.document.uri).path).toEqual(
       fromVsCodeUri(window.activeTextEditor.document.uri)
         .getDirectory()
         .joinPath(target.getBasename()).path

--- a/packages/foam-vscode/src/features/commands/create-note.spec.ts
+++ b/packages/foam-vscode/src/features/commands/create-note.spec.ts
@@ -158,7 +158,7 @@ describe('create-note command', () => {
     expect(window.activeTextEditor.document.getText()).toEqual(
       'test resolving from current dir'
     );
-    expect(window.activeTextEditor.document.uri.path).toEqual(
+    expect(fromVsCodeUri(window.activeTextEditor.document.uri)).toEqual(
       fromVsCodeUri(window.activeTextEditor.document.uri)
         .getDirectory()
         .joinPath(target.getBasename()).path

--- a/packages/foam-vscode/src/features/commands/create-note.ts
+++ b/packages/foam-vscode/src/features/commands/create-note.ts
@@ -43,6 +43,14 @@ interface CreateNoteArgs {
    * What to do in case the target file already exists
    */
   onFileExists?: 'overwrite' | 'open' | 'ask' | 'cancel';
+  /**
+   * What to do if the new note path is relative
+   */
+  onRelativeNotePath?:
+    | 'resolve-from-root'
+    | 'resolve-from-current-dir'
+    | 'ask'
+    | 'cancel';
 }
 
 const DEFAULT_NEW_NOTE_TEXT = `# \${FOAM_TITLE}
@@ -86,7 +94,8 @@ async function createNote(args: CreateNoteArgs) {
       noteUri ?? (await getPathFromTitle(resolver)),
       text,
       resolver,
-      args.onFileExists
+      args.onFileExists,
+      args.onRelativeNotePath
     );
   }
 }

--- a/packages/foam-vscode/src/features/commands/create-note.ts
+++ b/packages/foam-vscode/src/features/commands/create-note.ts
@@ -65,8 +65,7 @@ async function createNote(args: CreateNoteArgs) {
     date
   );
   const text = args.text ?? DEFAULT_NEW_NOTE_TEXT;
-  const noteUri =
-    args.notePath && asAbsoluteWorkspaceUri(URI.file(args.notePath));
+  const noteUri = args.notePath && URI.file(args.notePath);
   let templateUri: URI;
   if (args.askForTemplate) {
     const selectedTemplate = await askUserForTemplate();

--- a/packages/foam-vscode/src/services/editor.ts
+++ b/packages/foam-vscode/src/services/editor.ts
@@ -97,6 +97,19 @@ export function getCurrentEditorDirectory(): URI {
   throw new Error('A file must be open in editor, or workspace folder needed');
 }
 
+export function getRootDirectories(): URI[] {
+  return workspace.workspaceFolders.map(folder => {
+    return fromVsCodeUri(folder.uri);
+  });
+}
+
+export function getRootDirectory(): URI {
+  if (workspace.workspaceFolders.length === 0) {
+    throw new Error('No workspace or folder open');
+  }
+  return fromVsCodeUri(workspace.workspaceFolders[0].uri);
+}
+
 export async function fileExists(uri: URI): Promise<boolean> {
   try {
     const stat = await workspace.fs.stat(toVsCodeUri(uri));
@@ -175,8 +188,11 @@ export const createMatcherAndDataStore = async (
     return files.map(fromVsCodeUri);
   };
 
-  const readFile = async (uri: URI) =>
-    (await workspace.fs.readFile(toVsCodeUri(uri))).toString();
+  const decoder = new TextDecoder('utf-8');
+  const readFile = async (uri: URI) => {
+    const content = await workspace.fs.readFile(toVsCodeUri(uri));
+    return decoder.decode(content);
+  };
 
   const dataStore = new GenericDataStore(listFiles, readFile);
   const matcher = isEmpty(excludes)

--- a/packages/foam-vscode/src/services/editor.ts
+++ b/packages/foam-vscode/src/services/editor.ts
@@ -97,19 +97,6 @@ export function getCurrentEditorDirectory(): URI {
   throw new Error('A file must be open in editor, or workspace folder needed');
 }
 
-export function getRootDirectories(): URI[] {
-  return workspace.workspaceFolders.map(folder => {
-    return fromVsCodeUri(folder.uri);
-  });
-}
-
-export function getRootDirectory(): URI {
-  if (workspace.workspaceFolders.length === 0) {
-    throw new Error('No workspace or folder open');
-  }
-  return fromVsCodeUri(workspace.workspaceFolders[0].uri);
-}
-
 export async function fileExists(uri: URI): Promise<boolean> {
   try {
     const stat = await workspace.fs.stat(toVsCodeUri(uri));
@@ -128,9 +115,9 @@ export async function readFile(uri: URI): Promise<string | undefined> {
   return undefined;
 }
 
-export const deleteFile = (uri: URI) => {
+export function deleteFile(uri: URI) {
   return workspace.fs.delete(toVsCodeUri(uri), { recursive: true });
-};
+}
 
 /**
  * Turns a relative URI into an absolute URI for the given workspace.
@@ -148,13 +135,13 @@ export function asAbsoluteWorkspaceUri(uri: URI): URI {
   return res;
 }
 
-export const createMatcherAndDataStore = async (
+export async function createMatcherAndDataStore(
   excludes: string[]
 ): Promise<{
   matcher: IMatcher;
   dataStore: IDataStore;
   excludePatterns: Map<string, string[]>;
-}> => {
+}> {
   const excludePatterns = new Map<string, string[]>();
   workspace.workspaceFolders.forEach(f => excludePatterns.set(f.name, []));
 
@@ -200,4 +187,4 @@ export const createMatcherAndDataStore = async (
     : await FileListBasedMatcher.createFromListFn(listFiles);
 
   return { matcher, dataStore, excludePatterns };
-};
+}

--- a/packages/foam-vscode/src/services/templates.spec.ts
+++ b/packages/foam-vscode/src/services/templates.spec.ts
@@ -194,6 +194,7 @@ describe('NoteFactory.createNote', () => {
       'Hello ${FOAM_SELECTED_TEXT} ${FOAM_SELECTED_TEXT}', // eslint-disable-line no-template-curly-in-string
       new Resolver(new Map(), new Date()),
       undefined,
+      undefined,
       false
     );
     expect(window.activeTextEditor.document.getText()).toEqual(
@@ -215,6 +216,7 @@ describe('NoteFactory.createNote', () => {
       target,
       'Hello ${FOAM_SELECTED_TEXT} ${FOAM_SELECTED_TEXT}', // eslint-disable-line no-template-curly-in-string
       new Resolver(new Map(), new Date()),
+      undefined,
       undefined,
       true
     );

--- a/packages/foam-vscode/src/services/templates.spec.ts
+++ b/packages/foam-vscode/src/services/templates.spec.ts
@@ -37,7 +37,7 @@ describe('Create note from template', () => {
       );
       expect(spy).toBeCalledWith(
         expect.objectContaining({
-          prompt: `Enter the filename for the new note`,
+          prompt: `Enter the path for the new note`,
         })
       );
 

--- a/packages/foam-vscode/src/services/templates.ts
+++ b/packages/foam-vscode/src/services/templates.ts
@@ -230,7 +230,7 @@ const createFnForOnRelativePathStrategy = (
     case 'resolve-from-current-dir':
       return getCurrentEditorDirectory().joinPath(existingFile.path);
     case 'resolve-from-root':
-      return getRootDirectory().joinPath(existingFile.path);
+      return asAbsoluteWorkspaceUri(existingFile);
     case 'cancel':
       return undefined;
     case 'ask':

--- a/packages/foam-vscode/src/services/templates.ts
+++ b/packages/foam-vscode/src/services/templates.ts
@@ -19,8 +19,6 @@ import {
   fileExists,
   findSelectionContent,
   getCurrentEditorDirectory,
-  getRootDirectories,
-  getRootDirectory,
   readFile,
   replaceSelection,
 } from './editor';


### PR DESCRIPTION
Introduce a new setting that drives whether a new note will be created in the root dir or the current directory.

Also, add support for the same type of resolution for the `foam-vscode.create-note` command via argument.