### PR TITLE
Add support for link_label property

### DIFF
--- a/packages/foam-vscode/src/features/preview/wikilink-navigation.ts
+++ b/packages/foam-vscode/src/features/preview/wikilink-navigation.ts
@@ -34,7 +34,11 @@ export const markdownItWikilinkNavigation = (
           toVsCodeUri(resource.uri)
         )}${formattedSection}`;
         const title = `${resource.title}${formattedSection}`;
-        return `<a class='foam-note-link' title='${title}' href='/${link}' data-href='/${link}'>${label}</a>`;
+        const finalLabel =
+          isEmpty(alias) && !isEmpty(resource.properties.link_label)
+            ? `${resource.properties.link_label}${formattedSection}`
+            : label;
+        return `<a class='foam-note-link' title='${title}' href='/${link}' data-href='/${link}'>${finalLabel}</a>`;
       } catch (e) {
         Logger.error(
           `Error while creating link for [[${wikilink}]] in Preview panel`,


### PR DESCRIPTION
link_label provides the capability to set the canonical way of displaying a wikilink to the note instead of defaulting to the link name.

Implements #1149