### PR TITLE
[Fix][#1154]Create a new file from [[XX]] link and get wrong extension

### DIFF
--- a/packages/foam-vscode/src/core/utils/path.ts
+++ b/packages/foam-vscode/src/core/utils/path.ts
@@ -115,7 +115,7 @@ export function changeExtension(
   to: string
 ): string {
   const old = getExtension(path);
-  if ((from === '*' && old !== to) || old === from) {
+  if (((from === '*' || from === '') && old !== to) || old === from) {
     path = path.substring(0, path.length - old.length);
     return to ? path + to : path;
   }


### PR DESCRIPTION
Fix #1154 

Root cause: 
The folder path was treated as a file path, the last characters ".com" parsed as an extension, then changing from the folder's extension to ".md" terminated unexpectedly.

Solution:
Finish changing the extension to ".md".

Tested.