### PR TITLE
Use filter in `open-resource` command

### DIFF
--- a/docs/user/features/commands.md
+++ b/docs/user/features/commands.md
@@ -9,16 +9,19 @@ In particular, some commands can be very customizible and can help with custom w
 This command creates a note.
 Although it works fine on its own, it can be customized to achieve various use cases.
 Here are the settings available for the command:
--  notePath: The path of the note to create. If relative it will be resolved against the workspace root.
+
+- notePath: The path of the note to create. If relative it will be resolved against the workspace root.
 - templatePath: The path of the template to use. If relative it will be resolved against the workspace root.
+- title: The title of the note (that is, the `FOAM_TITLE` variable)
 - text: The text to use for the note. If also a template is provided, the template has precedence
-- variables: Variables to use in the text or template (e.g. `FOAM_TITLE`)
-- date: The date used to resolve the FOAM_DATE_* variables. in `YYYY-MM-DD` format
+- variables: Variables to use in the text or template
+- date: The date used to resolve the FOAM*DATE*\* variables. in `YYYY-MM-DD` format
 - onFileExists?: 'overwrite' | 'open' | 'ask' | 'cancel': What to do in case the target file already exists
 
 To customize a command and associate a key binding to it, open the key binding settings and add the appropriate configuration, here are some examples:
 
 - Create a note called `test note.md` with some text. If the note already exists, ask for a new name
+
 ```
 {
   "key": "alt+f",
@@ -32,6 +35,7 @@ To customize a command and associate a key binding to it, open the key binding s
 ```
 
 - Create a note following the `weekly-note.md` template. If the note already exists, open it
+
 ```
 {
   "key": "alt+g",
@@ -43,3 +47,27 @@ To customize a command and associate a key binding to it, open the key binding s
 }
 ```
 
+## foam-vscode.open-resource command
+
+This command opens a resource.
+
+Normally it receives a `URI`, which identifies the resource to open.
+
+It is also possible to pass in a filter, which will be run against the workspace resources to find one or more matches.
+
+- If there is one match, it will be opened
+- If there is more than one match, a quick pick will show up allowing the user to select the desired resource
+
+Examples:
+
+```
+{
+  "key": "alt+f",
+  "command": "foam-vscode.open-resource",
+  "args": {
+    "filter": {
+      "title": "Weekly Note*"
+    }
+  }
+}
+```

--- a/packages/foam-vscode/src/core/model/workspace.test.ts
+++ b/packages/foam-vscode/src/core/model/workspace.test.ts
@@ -87,6 +87,13 @@ describe('Workspace resources', () => {
     const res = ws.find('test-file#my-section');
     expect(res.uri.fragment).toEqual('my-section');
   });
+
+  it('should find absolute files even when no basedir is provided', () => {
+    const noteA = createTestNote({ uri: '/a/path/to/file.md' });
+    const ws = createTestWorkspace().set(noteA);
+
+    expect(ws.find('/a/path/to/file.md').uri.path).toEqual(noteA.uri.path);
+  });
 });
 
 describe('Identifier computation', () => {

--- a/packages/foam-vscode/src/core/model/workspace.ts
+++ b/packages/foam-vscode/src/core/model/workspace.ts
@@ -121,14 +121,16 @@ export class FoamWorkspace implements IDisposable {
     if (FoamWorkspace.isIdentifier(path)) {
       resource = this.listByIdentifier(path)[0];
     } else {
-      if (isAbsolute(path) || isSome(baseUri)) {
-        if (getExtension(path) !== '.md') {
-          const uri = baseUri.resolve(path + '.md');
-          resource = uri ? this._resources.get(normalize(uri.path)) : null;
-        }
-        if (!resource) {
-          const uri = baseUri.resolve(path);
-          resource = uri ? this._resources.get(normalize(uri.path)) : null;
+      const candidates = [path, path + '.md'];
+      for (const candidate of candidates) {
+        const searchKey = isAbsolute(candidate)
+          ? candidate
+          : isSome(baseUri)
+          ? baseUri.resolve(candidate).path
+          : null;
+        resource = this._resources.get(normalize(searchKey));
+        if (resource) {
+          break;
         }
       }
     }

--- a/packages/foam-vscode/src/features/commands/create-note.ts
+++ b/packages/foam-vscode/src/features/commands/create-note.ts
@@ -11,6 +11,7 @@ import { Foam } from '../../core/model/foam';
 import { Resolver } from '../../services/variable-resolver';
 import { asAbsoluteWorkspaceUri, fileExists } from '../../services/editor';
 import { isSome } from '../../core/utils';
+import { CommandDescriptor } from '../../utils/commands';
 
 interface CreateNoteArgs {
   /**
@@ -108,12 +109,20 @@ async function createNote(args: CreateNoteArgs) {
 
 export const CREATE_NOTE_COMMAND = {
   command: 'foam-vscode.create-note',
-  title: 'Foam: Create Note',
 
-  asURI: (args: CreateNoteArgs) =>
-    vscode.Uri.parse(`command:${CREATE_NOTE_COMMAND.command}`).with({
-      query: encodeURIComponent(JSON.stringify(args)),
-    }),
+  forPlaceholder: (
+    placeholder: string,
+    extra: Partial<CreateNoteArgs> = {}
+  ): CommandDescriptor<CreateNoteArgs> => {
+    return {
+      name: CREATE_NOTE_COMMAND.command,
+      params: {
+        title: placeholder,
+        notePath: placeholder,
+        ...extra,
+      },
+    };
+  },
 };
 
 const feature: FoamFeature = {

--- a/packages/foam-vscode/src/features/commands/create-note.ts
+++ b/packages/foam-vscode/src/features/commands/create-note.ts
@@ -34,11 +34,15 @@ interface CreateNoteArgs {
   /**
    * Variables to use in the text or template
    */
-  variables?: Map<string, string>;
+  variables?: { [key: string]: string };
   /**
    * The date used to resolve the FOAM_DATE_* variables. in YYYY-MM-DD format
    */
   date?: string;
+  /**
+   * The title of the note (translates into the FOAM_TITLE variable)
+   */
+  title?: string;
   /**
    * What to do in case the target file already exists
    */
@@ -64,6 +68,9 @@ async function createNote(args: CreateNoteArgs) {
     new Map(Object.entries(args.variables ?? {})),
     date
   );
+  if (args.title) {
+    resolver.define('FOAM_TITLE', args.title);
+  }
   const text = args.text ?? DEFAULT_NEW_NOTE_TEXT;
   const noteUri = args.notePath && URI.file(args.notePath);
   let templateUri: URI;

--- a/packages/foam-vscode/src/features/commands/open-resource.spec.ts
+++ b/packages/foam-vscode/src/features/commands/open-resource.spec.ts
@@ -1,0 +1,100 @@
+import dateFormat from 'dateformat';
+import { commands, window } from 'vscode';
+import { CommandDescriptor } from '../../utils/commands';
+import { OpenResourceArgs, OPEN_COMMAND } from './open-resource';
+import * as filter from '../../core/services/resource-filter';
+import { URI } from '../../core/model/uri';
+import { closeEditors, createFile } from '../../test/test-utils-vscode';
+import { deleteFile } from '../../services/editor';
+import waitForExpect from 'wait-for-expect';
+
+describe('open-resource command', () => {
+  beforeEach(async () => {
+    await jest.resetAllMocks();
+    await closeEditors();
+  });
+
+  it('URI param has precedence over filter', async () => {
+    const spy = jest.spyOn(filter, 'createFilter');
+    const noteA = await createFile('Note A for open command');
+
+    const command: CommandDescriptor<OpenResourceArgs> = {
+      name: OPEN_COMMAND.command,
+      params: {
+        uri: noteA.uri,
+        filter: { title: 'note 1' },
+      },
+    };
+    await commands.executeCommand(command.name, command.params);
+
+    waitForExpect(() => {
+      expect(window.activeTextEditor.document.uri.path).toEqual(noteA.uri.path);
+    });
+    expect(spy).not.toHaveBeenCalled();
+
+    await deleteFile(noteA.uri);
+  });
+
+  it('URI param accept URI object, or path', async () => {
+    const noteA = await createFile('Note A for open command');
+
+    const uriCommand: CommandDescriptor<OpenResourceArgs> = {
+      name: OPEN_COMMAND.command,
+      params: {
+        uri: URI.file('path/to/file.md'),
+      },
+    };
+    await commands.executeCommand(uriCommand.name, uriCommand.params);
+    waitForExpect(() => {
+      expect(window.activeTextEditor.document.uri.path).toEqual(noteA.uri.path);
+    });
+
+    await closeEditors();
+
+    const pathCommand: CommandDescriptor<OpenResourceArgs> = {
+      name: OPEN_COMMAND.command,
+      params: {
+        uri: URI.file('path/to/file.md'),
+      },
+    };
+    await commands.executeCommand(pathCommand.name, pathCommand.params);
+    waitForExpect(() => {
+      expect(window.activeTextEditor.document.uri.path).toEqual(noteA.uri.path);
+    });
+    await deleteFile(noteA.uri);
+  });
+
+  it('User is notified if no resource is found', async () => {
+    const spy = jest.spyOn(window, 'showInformationMessage');
+
+    const command: CommandDescriptor<OpenResourceArgs> = {
+      name: OPEN_COMMAND.command,
+      params: {
+        filter: { title: 'note 1 with no existing title' },
+      },
+    };
+    await commands.executeCommand(command.name, command.params);
+
+    waitForExpect(() => {
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  it('filter with multiple results will show a quick pick', async () => {
+    const spy = jest
+      .spyOn(window, 'showQuickPick')
+      .mockImplementationOnce(jest.fn(() => Promise.resolve(undefined)));
+
+    const command: CommandDescriptor<OpenResourceArgs> = {
+      name: OPEN_COMMAND.command,
+      params: {
+        filter: { title: '.*' },
+      },
+    };
+    await commands.executeCommand(command.name, command.params);
+
+    waitForExpect(() => {
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/foam-vscode/src/features/commands/open-resource.ts
+++ b/packages/foam-vscode/src/features/commands/open-resource.ts
@@ -13,12 +13,12 @@ import { Resource } from '../../core/model/note';
 import { isSome, isNone } from '../../core/utils';
 import { Logger } from '../../core/utils/log';
 
-interface OpenResourceArgs {
+export interface OpenResourceArgs {
   /**
    * The URI of the resource to open.
    * If present the `filter` param is ignored
    */
-  uri?: URI;
+  uri?: URI | string | vscode.Uri;
 
   /**
    * The filter object that describes which notes to consider
@@ -47,7 +47,8 @@ async function openResource(workspace: FoamWorkspace, args?: OpenResourceArgs) {
   let item: { uri: URI } | null = null;
 
   if (args.uri) {
-    item = workspace.find(args.uri.path);
+    const path = typeof args.uri === 'string' ? args.uri : args.uri.path;
+    item = workspace.find(path);
   }
 
   if (isNone(item) && args.filter) {

--- a/packages/foam-vscode/src/features/commands/open-resource.ts
+++ b/packages/foam-vscode/src/features/commands/open-resource.ts
@@ -3,40 +3,113 @@ import { FoamFeature } from '../../types';
 import { URI } from '../../core/model/uri';
 import { toVsCodeUri } from '../../utils/vsc-utils';
 import { Foam } from '../../core/model/foam';
+import {
+  createFilter,
+  FilterDescriptor,
+} from '../../core/services/resource-filter';
+import { CommandDescriptor } from '../../utils/commands';
+import { FoamWorkspace } from '../../core/model/workspace';
+import { Resource } from '../../core/model/note';
+
+interface OpenResourceArgs {
+  filter: FilterDescriptor;
+}
 
 export const OPEN_COMMAND = {
   command: 'foam-vscode.open-resource',
   title: 'Foam: Open Resource',
 
-  asURI: (uri: URI) =>
-    vscode.Uri.parse(`command:${OPEN_COMMAND.command}`).with({
-      query: encodeURIComponent(JSON.stringify({ uri })),
-    }),
+  forURI: (uri: URI): CommandDescriptor<OpenResourceArgs> => {
+    return {
+      name: OPEN_COMMAND.command,
+      params: {
+        filter: {
+          uri: uri,
+        },
+      },
+    };
+  },
+};
+
+async function openResource(workspace: FoamWorkspace, args?: OpenResourceArgs) {
+  args = args ?? { filter: {} };
+
+  const resources = workspace.list();
+
+  const candidates = resources.filter(createFilter(args.filter));
+
+  if (candidates.length === 0) {
+    vscode.window.showInformationMessage(
+      'Foam: No note matches given filters.'
+    );
+    return;
+  }
+
+  const item =
+    candidates.length === 1
+      ? candidates[0]
+      : await vscode.window.showQuickPick(
+          candidates.map(createQuickPickItemForResource)
+        );
+
+  if (item) {
+    const targetUri =
+      item.uri.path === vscode.window.activeTextEditor?.document.uri.path
+        ? vscode.window.activeTextEditor?.document.uri
+        : toVsCodeUri(item.uri.asPlain());
+    return vscode.commands.executeCommand('vscode.open', targetUri);
+  }
+}
+
+interface ResourceItem extends vscode.QuickPickItem {
+  label: string;
+  description: string;
+  uri: URI;
+  detail?: string;
+}
+
+const createQuickPickItemForResource = (resource: Resource): ResourceItem => {
+  const icon = 'file';
+  const sections = resource.sections
+    .map(s => s.label)
+    .filter(l => l !== resource.title);
+  const detail = sections.length > 0 ? 'Sections: ' + sections.join(', ') : '';
+  return {
+    label: `$(${icon}) ${resource.title}`,
+    description: vscode.workspace.asRelativePath(resource.uri.toFsPath()),
+    uri: resource.uri,
+    detail: detail,
+  };
 };
 
 const feature: FoamFeature = {
-  activate: (context: vscode.ExtensionContext, foamPromise: Promise<Foam>) => {
+  activate: async (
+    context: vscode.ExtensionContext,
+    foamPromise: Promise<Foam>
+  ) => {
+    const foam = await foamPromise;
     context.subscriptions.push(
-      vscode.commands.registerCommand(
-        OPEN_COMMAND.command,
-        async (params: { uri: URI }) => {
-          const uri = new URI(params.uri);
-          switch (uri.scheme) {
-            case 'file': {
-              const targetUri =
-                uri.path === vscode.window.activeTextEditor?.document.uri.path
-                  ? vscode.window.activeTextEditor?.document.uri
-                  : toVsCodeUri(uri.asPlain());
-              return vscode.commands.executeCommand('vscode.open', targetUri);
-            }
-            case 'placeholder': {
-              vscode.window.showErrorMessage(
-                "Foam: Can't open placeholder. Use create-note command instead."
-              );
-            }
-          }
-        }
-      )
+      vscode.commands.registerCommand(OPEN_COMMAND.command, args => {
+        return openResource(foam.workspace, args);
+      })
+      //   async (params: { uri: URI }) => {
+      //     const uri = new URI(params.uri);
+      //     switch (uri.scheme) {
+      //       case 'file': {
+      //         const targetUri =
+      //           uri.path === vscode.window.activeTextEditor?.document.uri.path
+      //             ? vscode.window.activeTextEditor?.document.uri
+      //             : toVsCodeUri(uri.asPlain());
+      //         return vscode.commands.executeCommand('vscode.open', targetUri);
+      //       }
+      //       case 'placeholder': {
+      //         vscode.window.showErrorMessage(
+      //           "Foam: Can't open placeholder. Use create-note command instead."
+      //         );
+      //       }
+      //     }
+      //   }
+      // )
     );
   },
 };

--- a/packages/foam-vscode/src/features/commands/open-resource.ts
+++ b/packages/foam-vscode/src/features/commands/open-resource.ts
@@ -36,7 +36,9 @@ async function openResource(workspace: FoamWorkspace, args?: OpenResourceArgs) {
 
   const resources = workspace.list();
 
-  const candidates = resources.filter(createFilter(args.filter));
+  const candidates = resources.filter(
+    createFilter(args.filter, vscode.workspace.isTrusted)
+  );
 
   if (candidates.length === 0) {
     vscode.window.showInformationMessage(

--- a/packages/foam-vscode/src/features/commands/open-resource.ts
+++ b/packages/foam-vscode/src/features/commands/open-resource.ts
@@ -1,8 +1,7 @@
 import * as vscode from 'vscode';
 import { FoamFeature } from '../../types';
 import { URI } from '../../core/model/uri';
-import { fromVsCodeUri, toVsCodeUri } from '../../utils/vsc-utils';
-import { NoteFactory } from '../../services/templates';
+import { toVsCodeUri } from '../../utils/vsc-utils';
 import { Foam } from '../../core/model/foam';
 
 export const OPEN_COMMAND = {
@@ -28,35 +27,12 @@ const feature: FoamFeature = {
                 uri.path === vscode.window.activeTextEditor?.document.uri.path
                   ? vscode.window.activeTextEditor?.document.uri
                   : toVsCodeUri(uri.asPlain());
-              // if the doc is already open, reuse the same colunm
-              const targetEditor = vscode.window.visibleTextEditors.find(
-                ed => targetUri.path === ed.document.uri.path
-              );
-              const column = targetEditor?.viewColumn;
               return vscode.commands.executeCommand('vscode.open', targetUri);
             }
             case 'placeholder': {
-              const title = uri.getName();
-              if (uri.isAbsolute()) {
-                return NoteFactory.createForPlaceholderWikilink(
-                  title,
-                  URI.file(uri.path)
-                );
-              }
-              const basedir =
-                vscode.workspace.workspaceFolders.length > 0
-                  ? vscode.workspace.workspaceFolders[0].uri
-                  : vscode.window.activeTextEditor?.document.uri
-                  ? vscode.window.activeTextEditor!.document.uri
-                  : undefined;
-              if (basedir === undefined) {
-                return;
-              }
-              const target = fromVsCodeUri(basedir)
-                .resolve(uri, true)
-                .changeExtension('', '.md');
-              await NoteFactory.createForPlaceholderWikilink(title, target);
-              return;
+              vscode.window.showErrorMessage(
+                "Foam: Can't open placeholder. Use create-note command instead."
+              );
             }
           }
         }

--- a/packages/foam-vscode/src/features/hover-provider.ts
+++ b/packages/foam-vscode/src/features/hover-provider.ts
@@ -87,7 +87,7 @@ export class HoverProvider implements vscode.HoverProvider {
     );
 
     const links = sources.slice(0, 10).map(ref => {
-      const command = OPEN_COMMAND.asURI(ref);
+      const command = commandAsURI(OPEN_COMMAND.forURI(ref));
       return `- [${this.workspace.get(ref).title}](${command.toString()})`;
     });
 
@@ -116,7 +116,7 @@ export class HoverProvider implements vscode.HoverProvider {
     const newNoteFromTemplate = new vscode.MarkdownString(
       `[Create note from template for '${targetUri.getName()}'](${commandAsURI(
         command
-      )})`
+      ).toString()})`
     );
     newNoteFromTemplate.isTrusted = true;
 

--- a/packages/foam-vscode/src/features/hover-provider.ts
+++ b/packages/foam-vscode/src/features/hover-provider.ts
@@ -14,6 +14,7 @@ import { Range } from '../core/model/range';
 import { FoamGraph } from '../core/model/graph';
 import { OPEN_COMMAND } from './commands/open-resource';
 import { CREATE_NOTE_COMMAND } from './commands/create-note';
+import { commandAsURI } from '../utils/commands';
 
 export const CONFIG_KEY = 'links.hover.enable';
 
@@ -108,27 +109,14 @@ export class HoverProvider implements vscode.HoverProvider {
         : this.workspace.get(targetUri).title;
     }
 
-    // If placeholder, offer to create a new note from template (compared to default link provider - not from template)
-    const basedir =
-      vscode.workspace.workspaceFolders.length > 0
-        ? vscode.workspace.workspaceFolders[0].uri
-        : vscode.window.activeTextEditor?.document.uri
-        ? vscode.window.activeTextEditor!.document.uri
-        : undefined;
-    if (basedir === undefined) {
-      return;
-    }
-    const target = fromVsCodeUri(basedir)
-      .resolve(targetUri, true)
-      .changeExtension('', '.md');
-    const args = {
-      text: target.getName(),
-      notePath: target.path,
+    const command = CREATE_NOTE_COMMAND.forPlaceholder(targetUri.path, {
       askForTemplate: true,
-    };
-    const command = CREATE_NOTE_COMMAND.asURI(args);
+      onFileExists: 'open',
+    });
     const newNoteFromTemplate = new vscode.MarkdownString(
-      `[Create note from template for '${targetUri.getName()}'](${command})`
+      `[Create note from template for '${targetUri.getName()}'](${commandAsURI(
+        command
+      )})`
     );
     newNoteFromTemplate.isTrusted = true;
 

--- a/packages/foam-vscode/src/features/navigation-provider.spec.ts
+++ b/packages/foam-vscode/src/features/navigation-provider.spec.ts
@@ -12,6 +12,7 @@ import { OPEN_COMMAND } from './commands/open-resource';
 import { toVsCodeUri } from '../utils/vsc-utils';
 import { createMarkdownParser } from '../core/services/markdown-parser';
 import { FoamGraph } from '../core/model/graph';
+import { commandAsURI } from '../utils/commands';
 
 describe('Document navigation', () => {
   const parser = createMarkdownParser([]);
@@ -82,7 +83,7 @@ describe('Document navigation', () => {
 
       expect(links.length).toEqual(1);
       expect(links[0].target).toEqual(
-        OPEN_COMMAND.asURI(URI.placeholder('a placeholder'))
+        commandAsURI(OPEN_COMMAND.forURI(URI.placeholder('a placeholder')))
       );
       expect(links[0].range).toEqual(new vscode.Range(0, 20, 0, 33));
     });

--- a/packages/foam-vscode/src/features/navigation-provider.spec.ts
+++ b/packages/foam-vscode/src/features/navigation-provider.spec.ts
@@ -13,6 +13,7 @@ import { toVsCodeUri } from '../utils/vsc-utils';
 import { createMarkdownParser } from '../core/services/markdown-parser';
 import { FoamGraph } from '../core/model/graph';
 import { commandAsURI } from '../utils/commands';
+import { CREATE_NOTE_COMMAND } from './commands/create-note';
 
 describe('Document navigation', () => {
   const parser = createMarkdownParser([]);
@@ -83,7 +84,11 @@ describe('Document navigation', () => {
 
       expect(links.length).toEqual(1);
       expect(links[0].target).toEqual(
-        commandAsURI(OPEN_COMMAND.forURI(URI.placeholder('a placeholder')))
+        commandAsURI(
+          CREATE_NOTE_COMMAND.forPlaceholder('a placeholder', {
+            onFileExists: 'open',
+          })
+        )
       );
       expect(links[0].range).toEqual(new vscode.Range(0, 20, 0, 33));
     });

--- a/packages/foam-vscode/src/features/navigation-provider.ts
+++ b/packages/foam-vscode/src/features/navigation-provider.ts
@@ -2,7 +2,6 @@ import * as vscode from 'vscode';
 import { FoamFeature } from '../types';
 import { mdDocSelector } from '../utils';
 import { toVsCodeRange, toVsCodeUri, fromVsCodeUri } from '../utils/vsc-utils';
-import { OPEN_COMMAND } from './commands/open-resource';
 import { Foam } from '../core/model/foam';
 import { FoamWorkspace } from '../core/model/workspace';
 import { Resource, ResourceLink, ResourceParser } from '../core/model/note';
@@ -10,6 +9,8 @@ import { URI } from '../core/model/uri';
 import { Range } from '../core/model/range';
 import { FoamGraph } from '../core/model/graph';
 import { Position } from '../core/model/position';
+import { CREATE_NOTE_COMMAND } from './commands/create-note';
+import { commandAsURI } from '../utils/commands';
 
 const feature: FoamFeature = {
   activate: async (
@@ -163,7 +164,9 @@ export class NavigationProvider
     return targets
       .filter(o => o.target.isPlaceholder()) // links to resources are managed by the definition provider
       .map(o => {
-        const command = OPEN_COMMAND.asURI(o.target);
+        const command = CREATE_NOTE_COMMAND.forPlaceholder(o.target.path, {
+          onFileExists: 'open',
+        });
 
         const documentLink = new vscode.DocumentLink(
           new vscode.Range(
@@ -172,7 +175,7 @@ export class NavigationProvider
             o.link.range.end.line,
             o.link.range.end.character - 2
           ),
-          command
+          commandAsURI(command)
         );
         documentLink.tooltip = `Create note for '${o.target.path}'`;
         return documentLink;

--- a/packages/foam-vscode/src/utils/commands.ts
+++ b/packages/foam-vscode/src/utils/commands.ts
@@ -1,0 +1,20 @@
+import { Uri } from 'vscode';
+import { merge } from 'lodash';
+
+export interface CommandDescriptor<T> {
+  name: string;
+  params: T;
+}
+
+export function describeCommand<T>(
+  base: CommandDescriptor<T>,
+  ...extra: Partial<T>[]
+) {
+  return merge(base, ...extra.map(e => ({ params: e })));
+}
+
+export function commandAsURI<T>(command: CommandDescriptor<T>) {
+  return Uri.parse(`command:${command.name}`).with({
+    query: encodeURIComponent(JSON.stringify(command.params)),
+  });
+}


### PR DESCRIPTION
Currently the `open-resource` command takes a URI and opens it.

With this change, it's now possible to also pass a filter to the command.
The filter is run against the workspace resources.
- if it results in a singe resource, the resource will be opened
- if it results in more than a resource, a quickpick will allow the user to pick the one they care about

Also starting to consolidate how Foam commands and their params are structured.