### PR TITLE
Fix Previews of Embedded Sections

### DIFF
--- a/packages/foam-vscode/src/features/preview/wikilink-embed.spec.ts
+++ b/packages/foam-vscode/src/features/preview/wikilink-embed.spec.ts
@@ -125,10 +125,12 @@ This is the third section of note E
       () => {
         const md = markdownItWikilinkEmbed(MarkdownIt(), ws);
 
-        const res = md.render(`This is the root node. ![[note-e-container#Section 3]]`);
+        const res = md.render(
+          `This is the root node. ![[note-e-container#Section 3]]`
+        );
         expect(res).toContain('This is the root node');
         expect(res).toContain('embed-container-note');
-        expect(res).toContain('Section 3')
+        expect(res).toContain('Section 3');
         expect(res).toContain('This is the third section of note E');
       }
     );

--- a/packages/foam-vscode/src/features/preview/wikilink-embed.spec.ts
+++ b/packages/foam-vscode/src/features/preview/wikilink-embed.spec.ts
@@ -68,13 +68,13 @@ describe('Displaying included notes in preview', () => {
     const note = await createFile(
       `
 # Section 1
-This is the first section of note D
+This is the first section of note E
 
 # Section 2 
-This is the second section of note D
+This is the second section of note E
 
 # Section 3
-This is the third section of note D
+This is the third section of note E
     `,
       ['note-e.md']
     );
@@ -93,9 +93,43 @@ This is the third section of note D
         ).toMatch(
           `<p>This is the root node.</p>
 <p><h1>Section 2</h1>
-<p>This is the second section of note D</p>
+<p>This is the second section of note E</p>
 </p>`
         );
+      }
+    );
+
+    await deleteFile(note);
+  });
+
+  it('should render an included section in container mode', async () => {
+    const note = await createFile(
+      `
+# Section 1
+This is the first section of note E
+
+# Section 2 
+This is the second section of note E
+
+# Section 3
+This is the third section of note E
+    `,
+      ['note-e-container.md']
+    );
+    const parser = createMarkdownParser([]);
+    const ws = new FoamWorkspace().set(parser.parse(note.uri, note.content));
+
+    await withModifiedFoamConfiguration(
+      CONFIG_EMBED_NOTE_IN_CONTAINER,
+      true,
+      () => {
+        const md = markdownItWikilinkEmbed(MarkdownIt(), ws);
+
+        const res = md.render(`This is the root node. ![[note-e-container#Section 3]]`);
+        expect(res).toContain('This is the root node');
+        expect(res).toContain('embed-container-note');
+        expect(res).toContain('Section 3')
+        expect(res).toContain('This is the third section of note E');
       }
     );
 

--- a/packages/foam-vscode/src/features/preview/wikilink-embed.ts
+++ b/packages/foam-vscode/src/features/preview/wikilink-embed.ts
@@ -41,9 +41,7 @@ export const markdownItWikilinkEmbed = (
         let content = `Embed for [[${wikilink}]]`;
         switch (includedNote.type) {
           case 'note': {
-            let noteText = readFileSync(
-              includedNote.uri.toFsPath()
-            ).toString();
+            let noteText = readFileSync(includedNote.uri.toFsPath()).toString();
             const section = Resource.findSection(
               includedNote,
               includedNote.uri.fragment

--- a/packages/foam-vscode/src/features/preview/wikilink-embed.ts
+++ b/packages/foam-vscode/src/features/preview/wikilink-embed.ts
@@ -41,9 +41,19 @@ export const markdownItWikilinkEmbed = (
         let content = `Embed for [[${wikilink}]]`;
         switch (includedNote.type) {
           case 'note': {
-            const noteText = readFileSync(
+            let noteText = readFileSync(
               includedNote.uri.toFsPath()
             ).toString();
+            const section = Resource.findSection(
+              includedNote,
+              includedNote.uri.fragment
+            );
+            if (isSome(section)) {
+              const rows = noteText.split('\n');
+              noteText = rows
+                .slice(section.range.start.line, section.range.end.line)
+                .join('\n');
+            }
             content = getFoamVsCodeConfig(CONFIG_EMBED_NOTE_IN_CONTAINER)
               ? `<div class="embed-container-note">${md.render(noteText)}</div>`
               : noteText;
@@ -61,16 +71,6 @@ Embed for attachments is not supported
               `![](${md.normalizeLink(includedNote.uri.path)})`
             )}</div>`;
             break;
-        }
-        const section = Resource.findSection(
-          includedNote,
-          includedNote.uri.fragment
-        );
-        if (isSome(section)) {
-          const rows = content.split('\n');
-          content = rows
-            .slice(section.range.start.line, section.range.end.line)
-            .join('\n');
         }
         const html = md.render(content);
         refsStack.pop();


### PR DESCRIPTION
I've only recently started exploring Foam and when I was porting over some of my notes I noticed that when a note had a section of another note embedded in it the preview panel wouldn't behave as expected.

e.g.,
```md
# A Note

Here's a section from another note ![[another-note#My Section]]
```

I took a look around and it seems to be because when `foam.preview.embedNoteInContainer` is `true` (which is the default value), the embedding logic attempts to split the embedded note after it has already been rendered to HTML which breaks the mapping of the content to the section ranges.

It may be a naïve solution but I was able to fix it by moving the section-splitting before the HTML rendering for embedded notes. I'm still new to Foam and I've never done VS Code extension development before so I'm open to feedback!

| Broken section embedding |
| --- |
| ![foam-embed-section-broken](https://user-images.githubusercontent.com/15224439/218341350-898500d9-c442-429f-89db-71f16bad68b6.gif) |

| Fixed section embedding |
| --- |
| ![foam-embed-section-fixed](https://user-images.githubusercontent.com/15224439/218341373-fa4a705f-5846-4549-b098-e0ea2d788e09.gif) |