### PR TITLE
Fix 1168 - relative path in embed

### DIFF
--- a/packages/foam-vscode/src/core/model/note.ts
+++ b/packages/foam-vscode/src/core/model/note.ts
@@ -5,6 +5,7 @@ export interface ResourceLink {
   type: 'wikilink' | 'link';
   rawText: string;
   range: Range;
+  isEmbed: boolean;
 }
 
 export interface NoteLinkDefinition {

--- a/packages/foam-vscode/src/core/services/markdown-link.test.ts
+++ b/packages/foam-vscode/src/core/services/markdown-link.test.ts
@@ -107,6 +107,7 @@ describe('MarkdownLink', () => {
         type: 'link',
         rawText: '[link](#section)',
         range: Range.create(0, 0),
+        isEmbed: false,
       };
       const parsed = MarkdownLink.analyzeLink(link);
       expect(parsed.target).toEqual('');

--- a/packages/foam-vscode/src/core/services/markdown-link.ts
+++ b/packages/foam-vscode/src/core/services/markdown-link.ts
@@ -46,15 +46,16 @@ export abstract class MarkdownLink {
     const newAlias = delta.alias ?? alias ?? '';
     const sectionDivider = newSection ? '#' : '';
     const aliasDivider = newAlias ? '|' : '';
+    const embed = link.isEmbed ? '!' : '';
     if (link.type === 'wikilink') {
       return {
-        newText: `[[${newTarget}${sectionDivider}${newSection}${aliasDivider}${newAlias}]]`,
+        newText: `${embed}[[${newTarget}${sectionDivider}${newSection}${aliasDivider}${newAlias}]]`,
         selection: link.range,
       };
     }
     if (link.type === 'link') {
       return {
-        newText: `[${newAlias}](${newTarget}${sectionDivider}${newSection})`,
+        newText: `${embed}[${newAlias}](${newTarget}${sectionDivider}${newSection})`,
         selection: link.range,
       };
     }

--- a/packages/foam-vscode/src/core/services/markdown-parser.test.ts
+++ b/packages/foam-vscode/src/core/services/markdown-parser.test.ts
@@ -39,6 +39,7 @@ describe('Markdown parsing', () => {
       const link = note.links[0];
       expect(link.type).toEqual('link');
       expect(link.rawText).toEqual('[link to page b](../doc/page-b.md)');
+      expect(link.isEmbed).toBeFalsy();
     });
 
     it('should detect links that have formatting in label', () => {
@@ -48,6 +49,15 @@ describe('Markdown parsing', () => {
       expect(note.links.length).toEqual(1);
       const link = note.links[0];
       expect(link.type).toEqual('link');
+      expect(link.isEmbed).toBeFalsy();
+    });
+
+    it('should detect embed links', () => {
+      const note = createNoteFromMarkdown('this is ![link](../doc/page-b.md)');
+      expect(note.links.length).toEqual(1);
+      const link = note.links[0];
+      expect(link.type).toEqual('link');
+      expect(link.isEmbed).toBeTruthy();
     });
 
     it('should detect wikilinks', () => {
@@ -61,6 +71,16 @@ describe('Markdown parsing', () => {
       link = note.links[1];
       expect(link.type).toEqual('wikilink');
       expect(link.rawText).toEqual('[[a file]]');
+      expect(link.isEmbed).toBeFalsy();
+    });
+
+    it('should detect wikilink embeds', () => {
+      const note = createNoteFromMarkdown('Some content and ![[an embed]]');
+      expect(note.links.length).toEqual(1);
+      const link = note.links[0];
+      expect(link.type).toEqual('wikilink');
+      expect(link.rawText).toEqual('![[an embed]]');
+      expect(link.isEmbed).toBeTruthy();
     });
 
     it('should detect wikilinks that have aliases', () => {
@@ -74,6 +94,7 @@ describe('Markdown parsing', () => {
       link = note.links[1];
       expect(link.type).toEqual('wikilink');
       expect(link.rawText).toEqual('[[other link | spaced]]');
+      expect(link.isEmbed).toBeFalsy();
     });
 
     it('should skip wikilinks in codeblocks', () => {

--- a/packages/foam-vscode/src/features/preview/index.ts
+++ b/packages/foam-vscode/src/features/preview/index.ts
@@ -22,7 +22,11 @@ const feature: FoamFeature = {
           markdownItFoamTags,
           markdownItWikilinkNavigation,
           markdownItRemoveLinkReferences,
-        ].reduce((acc, extension) => extension(acc, foam.workspace), md);
+        ].reduce(
+          (acc, extension) =>
+            extension(acc, foam.workspace, foam.services.parser),
+          md
+        );
       },
     };
   },

--- a/packages/foam-vscode/src/features/preview/wikilink-embed.spec.ts
+++ b/packages/foam-vscode/src/features/preview/wikilink-embed.spec.ts
@@ -163,7 +163,7 @@ This is the third section of note E
 
     expect(res).toContain('This is the text of note B which includes');
     expect(res).toContain('This is the text of note A which includes');
-    expect(res).toContain('Cyclic link detected for wikilink: note-a');
+    expect(res).toContain('Cyclic link detected for wikilink');
 
     deleteFile(noteA);
     deleteFile(noteB);

--- a/packages/foam-vscode/src/features/preview/wikilink-embed.spec.ts
+++ b/packages/foam-vscode/src/features/preview/wikilink-embed.spec.ts
@@ -24,7 +24,7 @@ describe('Displaying included notes in preview', () => {
       CONFIG_EMBED_NOTE_IN_CONTAINER,
       false,
       () => {
-        const md = markdownItWikilinkEmbed(MarkdownIt(), ws);
+        const md = markdownItWikilinkEmbed(MarkdownIt(), ws, parser);
 
         expect(
           md.render(`This is the root node. 
@@ -51,7 +51,7 @@ describe('Displaying included notes in preview', () => {
       CONFIG_EMBED_NOTE_IN_CONTAINER,
       true,
       () => {
-        const md = markdownItWikilinkEmbed(MarkdownIt(), ws);
+        const md = markdownItWikilinkEmbed(MarkdownIt(), ws, parser);
 
         const res = md.render(`This is the root node. ![[note-a]]`);
         expect(res).toContain('This is the root node');
@@ -80,7 +80,7 @@ This is the third section of note E
     );
     const parser = createMarkdownParser([]);
     const ws = new FoamWorkspace().set(parser.parse(note.uri, note.content));
-    const md = markdownItWikilinkEmbed(MarkdownIt(), ws);
+    const md = markdownItWikilinkEmbed(MarkdownIt(), ws, parser);
 
     await withModifiedFoamConfiguration(
       CONFIG_EMBED_NOTE_IN_CONTAINER,
@@ -123,7 +123,7 @@ This is the third section of note E
       CONFIG_EMBED_NOTE_IN_CONTAINER,
       true,
       () => {
-        const md = markdownItWikilinkEmbed(MarkdownIt(), ws);
+        const md = markdownItWikilinkEmbed(MarkdownIt(), ws, parser);
 
         const res = md.render(
           `This is the root node. ![[note-e-container#Section 3]]`
@@ -139,7 +139,11 @@ This is the third section of note E
   });
 
   it('should fallback to the bare text when the note is not found', () => {
-    const md = markdownItWikilinkEmbed(MarkdownIt(), new FoamWorkspace());
+    const md = markdownItWikilinkEmbed(
+      MarkdownIt(),
+      new FoamWorkspace(),
+      parser
+    );
 
     expect(md.render(`This is the root node. ![[non-existing-note]]`)).toMatch(
       `<p>This is the root node. ![[non-existing-note]]</p>`
@@ -158,7 +162,7 @@ This is the third section of note E
     const ws = new FoamWorkspace()
       .set(parser.parse(noteA.uri, noteA.content))
       .set(parser.parse(noteB.uri, noteB.content));
-    const md = markdownItWikilinkEmbed(MarkdownIt(), ws);
+    const md = markdownItWikilinkEmbed(MarkdownIt(), ws, parser);
     const res = md.render(noteBText);
 
     expect(res).toContain('This is the text of note B which includes');

--- a/packages/foam-vscode/src/features/preview/wikilink-embed.ts
+++ b/packages/foam-vscode/src/features/preview/wikilink-embed.ts
@@ -5,7 +5,7 @@ import markdownItRegex from 'markdown-it-regex';
 import { isSome } from '../../utils';
 import { FoamWorkspace } from '../../core/model/workspace';
 import { Logger } from '../../core/utils/log';
-import { Resource } from '../../core/model/note';
+import { Resource, ResourceParser } from '../../core/model/note';
 import { applyTextEdit } from '../../core/janitor/apply-text-edit';
 import { getFoamVsCodeConfig } from '../../services/config';
 // eslint-disable-next-line no-restricted-imports
@@ -20,7 +20,8 @@ const refsStack: string[] = [];
 
 export const markdownItWikilinkEmbed = (
   md: markdownit,
-  workspace: FoamWorkspace
+  workspace: FoamWorkspace,
+  parser: ResourceParser
 ) => {
   return md.use(markdownItRegex, {
     name: 'embed-wikilinks',
@@ -58,7 +59,11 @@ export const markdownItWikilinkEmbed = (
                 .slice(section.range.start.line, section.range.end.line)
                 .join('\n');
             }
-            noteText = withLinksRelativeToWorkspaceRoot(noteText, workspace);
+            noteText = withLinksRelativeToWorkspaceRoot(
+              noteText,
+              parser,
+              workspace
+            );
             content = getFoamVsCodeConfig(CONFIG_EMBED_NOTE_IN_CONTAINER)
               ? `<div class="embed-container-note">${md.render(noteText)}</div>`
               : noteText;
@@ -91,9 +96,9 @@ Embed for attachments is not supported
   });
 };
 
-const parser = createMarkdownParser();
 function withLinksRelativeToWorkspaceRoot(
   noteText: string,
+  parser: ResourceParser,
   workspace: FoamWorkspace
 ) {
   const note = parser.parse(

--- a/packages/foam-vscode/src/features/preview/wikilink-navigation.ts
+++ b/packages/foam-vscode/src/features/preview/wikilink-navigation.ts
@@ -23,6 +23,7 @@ export const markdownItWikilinkNavigation = (
           rawText: '[[' + wikilink + ']]',
           type: 'wikilink',
           range: Range.create(0, 0),
+          isEmbed: false,
         });
         const formattedSection = section ? `#${section}` : '';
         const label = isEmpty(alias) ? `${target}${formattedSection}` : alias;

--- a/packages/foam-vscode/src/test/test-utils.ts
+++ b/packages/foam-vscode/src/test/test-utils.ts
@@ -89,11 +89,13 @@ export const createTestNote = (params: {
                 type: 'wikilink',
                 range: range,
                 rawText: `[[${link.slug}]]`,
+                isEmbed: false,
               }
             : {
                 type: 'link',
                 range: range,
                 rawText: `[link text](${link.to})`,
+                isEmbed: false,
               };
         })
       : [],


### PR DESCRIPTION
This was a bit more complicated than anticipated, because of 2 main issues:

1. In the preview I have not figured out yet how to access the file being rendered. The solution eventually was to make all paths relative to the workspace root, which makes VS Code preview happy and works regardless of the file being displayed.

2. the way links were being extracted from the file excluded images `![img](link)`. I added a `isEmbed` flag to the link (which can be helpful in the future as well), and ported both regular and wiki links to it. This made identifying and fixing the links trivial in the preview renderer

Fixes #1168 