### PR TITLE
Fix #1126 - daily note folder in multi folder workspace

### DIFF
--- a/packages/foam-vscode/src/dated-notes.ts
+++ b/packages/foam-vscode/src/dated-notes.ts
@@ -86,9 +86,7 @@ export async function createDailyNoteIfNotExists(targetDate: Date) {
 
   const templateFallbackText = `---
 foam_template:
-  filepath: "${workspace.asRelativePath(
-    toVsCodeUri(pathFromLegacyConfiguration)
-  )}"
+  filepath: "${pathFromLegacyConfiguration.toFsPath()}"
 ---
 # ${dateFormat(targetDate, titleFormat, false)}
 `;


### PR DESCRIPTION
This PR fixes #1126

The issue is that VS Code `asRelativePath` appends by default the name of the folder when in a workspace with multiple roots.

The solution here is to simply use the absolute path of the note, instead of converting it into a relative path from the root.
