### PR TITLE
Relax the TAG_REGEX to miss markdown headings

### DIFF
--- a/packages/foam-vscode/src/core/utils/hashtags.ts
+++ b/packages/foam-vscode/src/core/utils/hashtags.ts
@@ -1,5 +1,5 @@
 import { isSome } from './core';
-const HASHTAG_REGEX =
+export const HASHTAG_REGEX =
   /(?<=^|\s)#([0-9]*[\p{L}\p{Emoji_Presentation}/_-][\p{L}\p{Emoji_Presentation}\p{N}/_-]*)/gmu;
 const WORD_REGEX =
   /(?<=^|\s)([0-9]*[\p{L}\p{Emoji_Presentation}/_-][\p{L}\p{Emoji_Presentation}\p{N}/_-]*)/gmu;

--- a/packages/foam-vscode/src/features/tag-completion.spec.ts
+++ b/packages/foam-vscode/src/features/tag-completion.spec.ts
@@ -93,4 +93,18 @@ describe('Tag Completion', () => {
     expect(foamTags.tags.get('primary')).toBeTruthy();
     expect(tags).toBeNull();
   });
+
+  it('should not provide suggestions when inside a markdown heading #1182', async () => {
+    const { uri } = await createFile('# primary heading 1');
+    const { doc } = await showInEditor(uri);
+    const provider = new TagCompletionProvider(foamTags);
+
+    const tags = await provider.provideCompletionItems(
+      doc,
+      new vscode.Position(0, 7)
+    );
+
+    expect(foamTags.tags.get('primary')).toBeTruthy();
+    expect(tags).toBeNull();
+  });
 });

--- a/packages/foam-vscode/src/features/tag-completion.ts
+++ b/packages/foam-vscode/src/features/tag-completion.ts
@@ -1,11 +1,9 @@
 import * as vscode from 'vscode';
 import { Foam } from '../core/model/foam';
 import { FoamTags } from '../core/model/tags';
+import { HASHTAG_REGEX } from '../core/utils/hashtags';
 import { FoamFeature } from '../types';
 import { mdDocSelector } from '../utils';
-import { SECTION_REGEX } from './link-completion';
-
-export const TAG_REGEX = /#(.*)/;
 
 const feature: FoamFeature = {
   activate: async (
@@ -36,8 +34,7 @@ export class TagCompletionProvider
       .lineAt(position)
       .text.substr(0, position.character);
 
-    const requiresAutocomplete =
-      cursorPrefix.match(TAG_REGEX) && !cursorPrefix.match(SECTION_REGEX);
+    const requiresAutocomplete = cursorPrefix.match(HASHTAG_REGEX);
 
     if (!requiresAutocomplete) {
       return null;


### PR DESCRIPTION
Addresses #1182 

The `TAG_REGEX` was extremely greedy, and would include matches to markdown headings such as `## Heading 2` even though that could not be a tag.

Relax the regex to match on non-space characters only.