### PR TITLE
Open tag completion on the `tags:` line

### DIFF
--- a/packages/foam-vscode/src/features/tag-completion.spec.ts
+++ b/packages/foam-vscode/src/features/tag-completion.spec.ts
@@ -107,4 +107,39 @@ describe('Tag Completion', () => {
     expect(foamTags.tags.get('primary')).toBeTruthy();
     expect(tags).toBeNull();
   });
+
+  it('should provide suggestions when inside the `tags:` front-matter #1184', async () => {
+    const { uri } = await createFile(`---
+created: 2023-01-01
+tags: prim`);
+    const { doc } = await showInEditor(uri);
+    const provider = new TagCompletionProvider(foamTags);
+
+    const tags = await provider.provideCompletionItems(
+      doc,
+      new vscode.Position(2, 10)
+    );
+
+    expect(foamTags.tags.get('primary')).toBeTruthy();
+    expect(tags.items.length).toEqual(3);
+  });
+
+  it('should not provide suggestions when outside the `tags:` front-matter #1184', async () => {
+    const { uri } = await createFile(`---
+created: 2023-01-01
+tags: prim
+---
+content
+tags: prim`);
+    const { doc } = await showInEditor(uri);
+    const provider = new TagCompletionProvider(foamTags);
+
+    const tags = await provider.provideCompletionItems(
+      doc,
+      new vscode.Position(5, 10)
+    );
+
+    expect(foamTags.tags.get('primary')).toBeTruthy();
+    expect(tags).toBeNull();
+  });
 });

--- a/packages/foam-vscode/src/features/tag-completion.ts
+++ b/packages/foam-vscode/src/features/tag-completion.ts
@@ -1,4 +1,6 @@
+import { EOL } from 'os';
 import * as vscode from 'vscode';
+import matter from 'gray-matter';
 import { Foam } from '../core/model/foam';
 import { FoamTags } from '../core/model/tags';
 import { HASHTAG_REGEX } from '../core/utils/hashtags';
@@ -34,7 +36,9 @@ export class TagCompletionProvider
       .lineAt(position)
       .text.substr(0, position.character);
 
-    const requiresAutocomplete = cursorPrefix.match(HASHTAG_REGEX);
+    const requiresAutocomplete =
+      cursorPrefix.match(HASHTAG_REGEX) ||
+      this.isInTagsFrontMatter(document, position);
 
     if (!requiresAutocomplete) {
       return null;
@@ -54,6 +58,30 @@ export class TagCompletionProvider
     });
 
     return new vscode.CompletionList(completionTags);
+  }
+
+  isInTagsFrontMatter(
+    document: vscode.TextDocument,
+    position: vscode.Position
+  ): Boolean {
+    const FRONT_MATTER_TAG_REGEX =
+      /^\s*tags:\s+.*?\s{0,1}?([0-9]*[\p{L}\p{Emoji_Presentation}/_-][\p{L}\p{Emoji_Presentation}\p{N}/_-]*)$/gmu;
+
+    const fm = matter(document.getText());
+    if ('tags' in fm.data) {
+      const cursorPrefix = document
+        .lineAt(position)
+        .text.substr(0, position.character);
+
+      // need to ensure that the position is within the front matter
+      const contentStartLine = fm.matter.split(EOL).length;
+      if (position.line >= contentStartLine) {
+        return false;
+      }
+
+      return cursorPrefix.match(FRONT_MATTER_TAG_REGEX) != null;
+    }
+    return false;
   }
 }
 


### PR DESCRIPTION
Open the tag completion on the `tags:` line in the front matter.

Do this by inspecting via `graymatter` that we are in the frontmatter, and then matching on `tags: ` via a regex. Trying to push it all into one regex with `HASHTAG_REGEX` was overly complicated.

closes #1184