### PR TITLE
Allow for `#` alone to trigger tag completion

### DIFF
--- a/packages/foam-vscode/src/features/tag-completion.spec.ts
+++ b/packages/foam-vscode/src/features/tag-completion.spec.ts
@@ -66,6 +66,36 @@ describe('Tag Completion', () => {
     expect(tags).toBeNull();
   });
 
+  it('should provide multiple suggestions when typing #, issue #1189', async () => {
+    const { uri } = await createFile(`# Title
+
+#`);
+    const { doc } = await showInEditor(uri);
+    const provider = new TagCompletionProvider(foamTags);
+
+    const tags = await provider.provideCompletionItems(
+      doc,
+      new vscode.Position(2, 1)
+    );
+    expect(tags.items.length).toEqual(3);
+  });
+
+  it('should not provide a suggestion when typing `# `, issue #1189', async () => {
+    const { uri } = await createFile(`# Title
+
+# `);
+    const { doc } = await showInEditor(uri);
+    const provider = new TagCompletionProvider(foamTags);
+
+    const tags = await provider.provideCompletionItems(
+      doc,
+      new vscode.Position(2, 2)
+    );
+
+    expect(foamTags.tags.get('primary')).toBeTruthy();
+    expect(tags).toBeNull();
+  });
+
   it('should provide a suggestion when typing #prim', async () => {
     const { uri } = await createFile('#prim');
     const { doc } = await showInEditor(uri);
@@ -95,7 +125,7 @@ describe('Tag Completion', () => {
   });
 
   it('should not provide suggestions when inside a markdown heading #1182', async () => {
-    const { uri } = await createFile('# primary heading 1');
+    const { uri } = await createFile('# primary');
     const { doc } = await showInEditor(uri);
     const provider = new TagCompletionProvider(foamTags);
 

--- a/packages/foam-vscode/src/features/tag-completion.spec.ts
+++ b/packages/foam-vscode/src/features/tag-completion.spec.ts
@@ -66,36 +66,6 @@ describe('Tag Completion', () => {
     expect(tags).toBeNull();
   });
 
-  it('should provide multiple suggestions when typing #, issue #1189', async () => {
-    const { uri } = await createFile(`# Title
-
-#`);
-    const { doc } = await showInEditor(uri);
-    const provider = new TagCompletionProvider(foamTags);
-
-    const tags = await provider.provideCompletionItems(
-      doc,
-      new vscode.Position(2, 1)
-    );
-    expect(tags.items.length).toEqual(3);
-  });
-
-  it('should not provide a suggestion when typing `# `, issue #1189', async () => {
-    const { uri } = await createFile(`# Title
-
-# `);
-    const { doc } = await showInEditor(uri);
-    const provider = new TagCompletionProvider(foamTags);
-
-    const tags = await provider.provideCompletionItems(
-      doc,
-      new vscode.Position(2, 2)
-    );
-
-    expect(foamTags.tags.get('primary')).toBeTruthy();
-    expect(tags).toBeNull();
-  });
-
   it('should provide a suggestion when typing #prim', async () => {
     const { uri } = await createFile('#prim');
     const { doc } = await showInEditor(uri);
@@ -136,5 +106,85 @@ describe('Tag Completion', () => {
 
     expect(foamTags.tags.get('primary')).toBeTruthy();
     expect(tags).toBeNull();
+  });
+
+  describe('has robust triggering #1189', () => {
+    it('should provide multiple suggestions when typing #', async () => {
+      const { uri } = await createFile(`# Title
+
+#`);
+      const { doc } = await showInEditor(uri);
+      const provider = new TagCompletionProvider(foamTags);
+
+      const tags = await provider.provideCompletionItems(
+        doc,
+        new vscode.Position(2, 1)
+      );
+      expect(tags.items.length).toEqual(3);
+    });
+
+    it('should provide multiple suggestions when typing # at EOL', async () => {
+      const { uri } = await createFile(`# Title
+
+#
+more text
+`);
+      const { doc } = await showInEditor(uri);
+      const provider = new TagCompletionProvider(foamTags);
+
+      const tags = await provider.provideCompletionItems(
+        doc,
+        new vscode.Position(2, 1)
+      );
+      expect(tags.items.length).toEqual(3);
+    });
+
+    it('should not provide a suggestion when typing `# `', async () => {
+      const { uri } = await createFile(`# Title
+
+# `);
+      const { doc } = await showInEditor(uri);
+      const provider = new TagCompletionProvider(foamTags);
+
+      const tags = await provider.provideCompletionItems(
+        doc,
+        new vscode.Position(2, 2)
+      );
+
+      expect(foamTags.tags.get('primary')).toBeTruthy();
+      expect(tags).toBeNull();
+    });
+
+    it('should not provide a suggestion when typing `#{non-match}`', async () => {
+      const { uri } = await createFile(`# Title
+
+#$`);
+      const { doc } = await showInEditor(uri);
+      const provider = new TagCompletionProvider(foamTags);
+
+      const tags = await provider.provideCompletionItems(
+        doc,
+        new vscode.Position(2, 2)
+      );
+
+      expect(foamTags.tags.get('primary')).toBeTruthy();
+      expect(tags).toBeNull();
+    });
+
+    it('should not provide a suggestion when typing `##`', async () => {
+      const { uri } = await createFile(`# Title
+
+##`);
+      const { doc } = await showInEditor(uri);
+      const provider = new TagCompletionProvider(foamTags);
+
+      const tags = await provider.provideCompletionItems(
+        doc,
+        new vscode.Position(2, 2)
+      );
+
+      expect(foamTags.tags.get('primary')).toBeTruthy();
+      expect(tags).toBeNull();
+    });
   });
 });

--- a/packages/foam-vscode/src/features/tag-completion.spec.ts
+++ b/packages/foam-vscode/src/features/tag-completion.spec.ts
@@ -123,6 +123,18 @@ describe('Tag Completion', () => {
       expect(tags.items.length).toEqual(3);
     });
 
+    it('should provide multiple suggestions when typing # on line with match', async () => {
+      const { uri } = await createFile('Here is #my-tag and #');
+      const { doc } = await showInEditor(uri);
+      const provider = new TagCompletionProvider(foamTags);
+
+      const tags = await provider.provideCompletionItems(
+        doc,
+        new vscode.Position(0, 21)
+      );
+      expect(tags.items.length).toEqual(3);
+    });
+
     it('should provide multiple suggestions when typing # at EOL', async () => {
       const { uri } = await createFile(`# Title
 
@@ -181,6 +193,20 @@ more text
       const tags = await provider.provideCompletionItems(
         doc,
         new vscode.Position(2, 2)
+      );
+
+      expect(foamTags.tags.get('primary')).toBeTruthy();
+      expect(tags).toBeNull();
+    });
+
+    it('should not provide a suggestion when typing `# ` in a line that already matched', async () => {
+      const { uri } = await createFile('here is #primary and now # ');
+      const { doc } = await showInEditor(uri);
+      const provider = new TagCompletionProvider(foamTags);
+
+      const tags = await provider.provideCompletionItems(
+        doc,
+        new vscode.Position(0, 29)
       );
 
       expect(foamTags.tags.get('primary')).toBeTruthy();

--- a/packages/foam-vscode/src/features/tag-completion.ts
+++ b/packages/foam-vscode/src/features/tag-completion.ts
@@ -1,9 +1,13 @@
 import * as vscode from 'vscode';
 import { Foam } from '../core/model/foam';
 import { FoamTags } from '../core/model/tags';
-import { HASHTAG_REGEX } from '../core/utils/hashtags';
 import { FoamFeature } from '../types';
 import { mdDocSelector } from '../utils';
+
+// this regex is different from HASHTAG_REGEX in that it does not look for a
+// #+character. It uses a negative look-ahead for `# `
+const TAG_REGEX =
+  /(?<=^|\s)#(?!(\s+))([0-9]*[\p{L}\p{Emoji_Presentation}\p{N}/_-]*)/gmu;
 
 const feature: FoamFeature = {
   activate: async (
@@ -34,7 +38,7 @@ export class TagCompletionProvider
       .lineAt(position)
       .text.substr(0, position.character);
 
-    const requiresAutocomplete = cursorPrefix.match(HASHTAG_REGEX);
+    const requiresAutocomplete = cursorPrefix.match(TAG_REGEX);
 
     if (!requiresAutocomplete) {
       return null;

--- a/packages/foam-vscode/src/features/tag-completion.ts
+++ b/packages/foam-vscode/src/features/tag-completion.ts
@@ -7,7 +7,7 @@ import { mdDocSelector } from '../utils';
 // this regex is different from HASHTAG_REGEX in that it does not look for a
 // #+character. It uses a negative look-ahead for `# `
 const TAG_REGEX =
-  /(?<=^|\s)#(?![ \t#])([0-9]*[\p{L}\p{Emoji_Presentation}\p{N}/_-]*)/gu;
+  /(?<=^|\s)#(?![ \t#])([0-9]*[\p{L}\p{Emoji_Presentation}\p{N}/_-]*)/dgu;
 
 const feature: FoamFeature = {
   activate: async (
@@ -39,21 +39,19 @@ export class TagCompletionProvider
       .text.substr(0, position.character);
 
     const requiresAutocomplete = cursorPrefix.match(TAG_REGEX);
-
     if (!requiresAutocomplete) {
       return null;
     }
 
     // check the match group length.
-    // if the match is only '#', the character to the left of cursor should
-    // also be `#`. If it isn't, we didn't match the
-    // `[0-9]*[\p{L}\p{Emoji_Presentation}\p{N}/_-]` group
-    // This excludes things like `#&`
-    const matchText = requiresAutocomplete[requiresAutocomplete.length - 1];
-    if (
-      matchText === '#' &&
-      cursorPrefix.charAt(position.character - 1) !== '#'
-    ) {
+    // find the last match group, and ensure the end of that group is
+    // at the cursor position.
+    // This excludes both `#%` and also `here is #my-app1 and now # ` with
+    // trailing space
+    const matches = Array.from(cursorPrefix.matchAll(TAG_REGEX));
+    const lastMatch = matches[matches.length - 1];
+    const lastMatchEndIndex = lastMatch[0].length + lastMatch.index;
+    if (lastMatchEndIndex !== position.character) {
       return null;
     }
 

--- a/packages/foam-vscode/src/features/tag-completion.ts
+++ b/packages/foam-vscode/src/features/tag-completion.ts
@@ -7,7 +7,7 @@ import { mdDocSelector } from '../utils';
 // this regex is different from HASHTAG_REGEX in that it does not look for a
 // #+character. It uses a negative look-ahead for `# `
 const TAG_REGEX =
-  /(?<=^|\s)#(?!(\s+))([0-9]*[\p{L}\p{Emoji_Presentation}\p{N}/_-]*)/gmu;
+  /(?<=^|\s)#(?![ \t#])([0-9]*[\p{L}\p{Emoji_Presentation}\p{N}/_-]*)/gu;
 
 const feature: FoamFeature = {
   activate: async (
@@ -41,6 +41,19 @@ export class TagCompletionProvider
     const requiresAutocomplete = cursorPrefix.match(TAG_REGEX);
 
     if (!requiresAutocomplete) {
+      return null;
+    }
+
+    // check the match group length.
+    // if the match is only '#', the character to the left of cursor should
+    // also be `#`. If it isn't, we didn't match the
+    // `[0-9]*[\p{L}\p{Emoji_Presentation}\p{N}/_-]` group
+    // This excludes things like `#&`
+    const matchText = requiresAutocomplete[requiresAutocomplete.length - 1];
+    if (
+      matchText === '#' &&
+      cursorPrefix.charAt(position.character - 1) !== '#'
+    ) {
       return null;
     }
 


### PR DESCRIPTION
Closes #1189 

In #1183, I reused [HASHTAG_REGEX](https://github.com/foambubble/foam/blob/83a90177b921064c16e754a053f445ce79d6e9af/packages/foam-vscode/src/core/utils/hashtags.ts#L2-L3) to validate the tag line when the `CompletionProvider` was triggered.

I wanted to prevent this:

```markdown
# This is a Markdown header
```

but using the `HASHTAG_REGEX` had the side effect of requiring an _additional_ character to trigger the completion provider.

```markdown

1. #p <-- triggers completion
2. #  <-- does not trigger
3. #_ (space) <-- does not trigger
```
both 1. and 2. should have triggered.

To fix, I use a slightly different regex that uses a negative lookahead to ensure that the `#` is not followed by a space. I also added spec cases to cover this situation.