### PR TITLE
Resource tree items improvements

### DIFF
--- a/packages/foam-vscode/src/core/model/range.ts
+++ b/packages/foam-vscode/src/core/model/range.ts
@@ -69,4 +69,8 @@ export abstract class Range {
   static isBefore(a: Range, b: Range): number {
     return a.start.line - b.start.line || a.start.character - b.start.character;
   }
+
+  static toString(range: Range): string {
+    return `${range.start.line}:${range.start.character} - ${range.end.line}:${range.end.character}`;
+  }
 }

--- a/packages/foam-vscode/src/features/panels/backlinks.spec.ts
+++ b/packages/foam-vscode/src/features/panels/backlinks.spec.ts
@@ -6,12 +6,15 @@ import {
   createNote,
   getUriInWorkspace,
 } from '../../test/test-utils-vscode';
-import { BacklinksTreeDataProvider, BacklinkTreeItem } from './backlinks';
+import { BacklinksTreeDataProvider } from './backlinks';
 import { OPEN_COMMAND } from '../commands/open-resource';
 import { toVsCodeUri } from '../../utils/vsc-utils';
 import { FoamGraph } from '../../core/model/graph';
 import { URI } from '../../core/model/uri';
-import { ResourceTreeItem } from '../../utils/tree-view-utils';
+import {
+  ResourceRangeTreeItem,
+  ResourceTreeItem,
+} from '../../utils/tree-view-utils';
 
 describe('Backlinks panel', () => {
   beforeAll(async () => {
@@ -84,11 +87,11 @@ describe('Backlinks panel', () => {
     const notes = (await provider.getChildren()) as ResourceTreeItem[];
     const linksFromB = (await provider.getChildren(
       notes[0]
-    )) as BacklinkTreeItem[];
-    expect(linksFromB.map(l => l.link)).toEqual(
-      noteB.links.sort(
-        (a, b) => a.range.start.character - b.range.start.character
-      )
+    )) as ResourceRangeTreeItem[];
+    expect(linksFromB.map(l => l.range)).toEqual(
+      noteB.links
+        .map(l => l.range)
+        .sort((a, b) => a.start.character - b.start.character)
     );
   });
   it('navigates to the document if clicking on note', async () => {
@@ -104,7 +107,7 @@ describe('Backlinks panel', () => {
     const notes = (await provider.getChildren()) as ResourceTreeItem[];
     const linksFromB = (await provider.getChildren(
       notes[0]
-    )) as BacklinkTreeItem[];
+    )) as ResourceRangeTreeItem[];
     expect(linksFromB[0].command).toMatchObject({
       command: 'vscode.open',
       arguments: [

--- a/packages/foam-vscode/src/features/panels/backlinks.spec.ts
+++ b/packages/foam-vscode/src/features/panels/backlinks.spec.ts
@@ -7,11 +7,11 @@ import {
   getUriInWorkspace,
 } from '../../test/test-utils-vscode';
 import { BacklinksTreeDataProvider, BacklinkTreeItem } from './backlinks';
-import { ResourceTreeItem } from '../../utils/grouped-resources-tree-data-provider';
 import { OPEN_COMMAND } from '../commands/open-resource';
 import { toVsCodeUri } from '../../utils/vsc-utils';
 import { FoamGraph } from '../../core/model/graph';
 import { URI } from '../../core/model/uri';
+import { ResourceTreeItem } from '../../utils/tree-view-utils';
 
 describe('Backlinks panel', () => {
   beforeAll(async () => {

--- a/packages/foam-vscode/src/features/panels/backlinks.spec.ts
+++ b/packages/foam-vscode/src/features/panels/backlinks.spec.ts
@@ -98,8 +98,8 @@ describe('Backlinks panel', () => {
     provider.target = noteA.uri;
     const notes = (await provider.getChildren()) as ResourceTreeItem[];
     expect(notes[0].command).toMatchObject({
-      command: OPEN_COMMAND.command,
-      arguments: [expect.objectContaining({ uri: noteB.uri })],
+      command: 'vscode.open',
+      arguments: [expect.objectContaining({ path: noteB.uri.path })],
     });
   });
   it('navigates to document with link selection if clicking on backlink', async () => {
@@ -111,7 +111,7 @@ describe('Backlinks panel', () => {
     expect(linksFromB[0].command).toMatchObject({
       command: 'vscode.open',
       arguments: [
-        noteB.uri,
+        expect.objectContaining({ path: noteB.uri.path }),
         {
           selection: expect.arrayContaining([]),
         },

--- a/packages/foam-vscode/src/features/panels/backlinks.ts
+++ b/packages/foam-vscode/src/features/panels/backlinks.ts
@@ -1,16 +1,17 @@
 import * as vscode from 'vscode';
-import { groupBy } from 'lodash';
 import { URI } from '../../core/model/uri';
 
-import { getNoteTooltip, isNone } from '../../utils';
+import { isNone } from '../../utils';
 import { FoamFeature } from '../../types';
 import { Foam } from '../../core/model/foam';
 import { FoamWorkspace } from '../../core/model/workspace';
 import { FoamGraph } from '../../core/model/graph';
-import { Resource, ResourceLink } from '../../core/model/note';
-import { Range } from '../../core/model/range';
-import { fromVsCodeUri, toVsCodeUri } from '../../utils/vsc-utils';
-import { ResourceTreeItem } from '../../utils/tree-view-utils';
+import { fromVsCodeUri } from '../../utils/vsc-utils';
+import {
+  ResourceRangeTreeItem,
+  ResourceTreeItem,
+  groupRangesByResource,
+} from '../../utils/tree-view-utils';
 
 const feature: FoamFeature = {
   activate: async (
@@ -37,7 +38,7 @@ const feature: FoamFeature = {
 export default feature;
 
 export class BacklinksTreeDataProvider
-  implements vscode.TreeDataProvider<BacklinkPanelTreeItem>
+  implements vscode.TreeDataProvider<vscode.TreeItem>
 {
   public target?: URI = undefined;
   // prettier-ignore
@@ -54,65 +55,32 @@ export class BacklinksTreeDataProvider
     return item;
   }
 
-  getChildren(item?: ResourceTreeItem): Promise<BacklinkPanelTreeItem[]> {
+  getChildren(item?: BacklinkPanelTreeItem): Promise<vscode.TreeItem[]> {
     const uri = this.target;
-    if (item) {
-      const resource = item.resource;
-
-      const backlinkRefs = Promise.all(
-        resource.links
-          .filter(link =>
-            this.workspace.resolveLink(resource, link).asPlain().isEqual(uri)
-          )
-          .map(async link => {
-            const item = new BacklinkTreeItem(resource, link);
-            const lines = (
-              (await this.workspace.readAsMarkdown(resource.uri)) ?? ''
-            ).split('\n');
-            if (link.range.start.line < lines.length) {
-              const line = lines[link.range.start.line];
-              const start = Math.max(0, link.range.start.character - 15);
-              const ellipsis = start === 0 ? '' : '...';
-
-              item.label = `${link.range.start.line}: ${ellipsis}${line.substr(
-                start,
-                300
-              )}`;
-              item.tooltip = getNoteTooltip(line);
-            }
-            return item;
-          })
-      );
-
-      return backlinkRefs;
+    if (item && item instanceof ResourceTreeItem) {
+      return item.getChildren();
     }
 
     if (isNone(uri) || isNone(this.workspace.find(uri))) {
       return Promise.resolve([]);
     }
 
-    const backlinksByResourcePath = groupBy(
-      this.graph
-        .getConnections(uri)
-        .filter(c => c.target.asPlain().isEqual(uri)),
-      b => b.source.path
-    );
+    const connections = this.graph
+      .getConnections(uri)
+      .filter(c => c.target.asPlain().isEqual(uri));
 
-    const resources = Object.keys(backlinksByResourcePath)
-      .map(res => backlinksByResourcePath[res][0].source)
-      .map(uri => this.workspace.get(uri))
-      .sort(Resource.sortByTitle)
-      .map(note => {
-        const connections = backlinksByResourcePath[note.uri.path].sort(
-          (a, b) => Range.isBefore(a.link.range, b.link.range)
-        );
-        const item = new ResourceTreeItem(note, this.workspace, {
-          collapsibleState: vscode.TreeItemCollapsibleState.Expanded,
-        });
-        item.description = `(${connections.length}) ${item.description}`;
-        return item;
-      });
-    return Promise.resolve(resources);
+    const backlinkItems = connections.map(c =>
+      ResourceRangeTreeItem.createStandardItem(
+        this.workspace,
+        this.workspace.get(c.source),
+        c.link.range
+      )
+    );
+    return groupRangesByResource(
+      this.workspace,
+      backlinkItems,
+      vscode.TreeItemCollapsibleState.Expanded
+    );
   }
 
   resolveTreeItem(item: BacklinkPanelTreeItem): Promise<BacklinkPanelTreeItem> {
@@ -120,33 +88,4 @@ export class BacklinksTreeDataProvider
   }
 }
 
-export class ResourceRangeTreeItem extends vscode.TreeItem {
-  constructor(
-    public label: string,
-    public readonly resource: Resource,
-    public readonly range: Range
-  ) {
-    super(label, vscode.TreeItemCollapsibleState.None);
-    this.label = `${range.start.line}: ${this.label}`;
-    this.command = {
-      command: 'vscode.open',
-      arguments: [toVsCodeUri(resource.uri), { selection: range }],
-      title: 'Go to location',
-    };
-  }
-}
-
-export class BacklinkTreeItem extends ResourceRangeTreeItem {
-  constructor(
-    public readonly resource: Resource,
-    public readonly link: ResourceLink
-  ) {
-    super(link.rawText, resource, link.range);
-  }
-
-  resolveTreeItem(): Promise<BacklinkTreeItem> {
-    return Promise.resolve(this);
-  }
-}
-
-type BacklinkPanelTreeItem = ResourceTreeItem | BacklinkTreeItem;
+type BacklinkPanelTreeItem = ResourceTreeItem | ResourceRangeTreeItem;

--- a/packages/foam-vscode/src/features/panels/backlinks.ts
+++ b/packages/foam-vscode/src/features/panels/backlinks.ts
@@ -4,13 +4,13 @@ import { URI } from '../../core/model/uri';
 
 import { getNoteTooltip, isNone } from '../../utils';
 import { FoamFeature } from '../../types';
-import { ResourceTreeItem } from '../../utils/grouped-resources-tree-data-provider';
 import { Foam } from '../../core/model/foam';
 import { FoamWorkspace } from '../../core/model/workspace';
 import { FoamGraph } from '../../core/model/graph';
 import { Resource, ResourceLink } from '../../core/model/note';
 import { Range } from '../../core/model/range';
 import { fromVsCodeUri, toVsCodeUri } from '../../utils/vsc-utils';
+import { ResourceTreeItem } from '../../utils/tree-view-utils';
 
 const feature: FoamFeature = {
   activate: async (
@@ -106,11 +106,9 @@ export class BacklinksTreeDataProvider
         const connections = backlinksByResourcePath[note.uri.path].sort(
           (a, b) => Range.isBefore(a.link.range, b.link.range)
         );
-        const item = new ResourceTreeItem(
-          note,
-          this.workspace,
-          vscode.TreeItemCollapsibleState.Expanded
-        );
+        const item = new ResourceTreeItem(note, this.workspace, {
+          collapsibleState: vscode.TreeItemCollapsibleState.Expanded,
+        });
         item.description = `(${connections.length}) ${item.description}`;
         return item;
       });

--- a/packages/foam-vscode/src/features/panels/backlinks.ts
+++ b/packages/foam-vscode/src/features/panels/backlinks.ts
@@ -122,18 +122,28 @@ export class BacklinksTreeDataProvider
   }
 }
 
-export class BacklinkTreeItem extends vscode.TreeItem {
+export class ResourceRangeTreeItem extends vscode.TreeItem {
+  constructor(
+    public label: string,
+    public readonly resource: Resource,
+    public readonly range: Range
+  ) {
+    super(label, vscode.TreeItemCollapsibleState.None);
+    this.label = `${range.start.line}: ${this.label}`;
+    this.command = {
+      command: 'vscode.open',
+      arguments: [toVsCodeUri(resource.uri), { selection: range }],
+      title: 'Go to location',
+    };
+  }
+}
+
+export class BacklinkTreeItem extends ResourceRangeTreeItem {
   constructor(
     public readonly resource: Resource,
     public readonly link: ResourceLink
   ) {
-    super(link.rawText, vscode.TreeItemCollapsibleState.None);
-    this.label = `${link.range.start.line}: ${this.label}`;
-    this.command = {
-      command: 'vscode.open',
-      arguments: [toVsCodeUri(resource.uri), { selection: link.range }],
-      title: 'Go to link',
-    };
+    super(link.rawText, resource, link.range);
   }
 
   resolveTreeItem(): Promise<BacklinkTreeItem> {

--- a/packages/foam-vscode/src/features/panels/orphans.ts
+++ b/packages/foam-vscode/src/features/panels/orphans.ts
@@ -3,11 +3,8 @@ import { Foam } from '../../core/model/foam';
 import { createMatcherAndDataStore } from '../../services/editor';
 import { getOrphansConfig } from '../../settings';
 import { FoamFeature } from '../../types';
-import {
-  GroupedResourcesTreeDataProvider,
-  ResourceTreeItem,
-  UriTreeItem,
-} from '../../utils/grouped-resources-tree-data-provider';
+import { GroupedResourcesTreeDataProvider } from '../../utils/grouped-resources-tree-data-provider';
+import { ResourceTreeItem, UriTreeItem } from '../../utils/tree-view-utils';
 
 const EXCLUDE_TYPES = ['image', 'attachment'];
 const feature: FoamFeature = {

--- a/packages/foam-vscode/src/features/panels/placeholders.ts
+++ b/packages/foam-vscode/src/features/panels/placeholders.ts
@@ -28,6 +28,7 @@ const feature: FoamFeature = {
           icon: 'link',
           getChildren: async () => {
             return groupRangesByResource(
+              foam.workspace,
               foam.graph.getBacklinks(uri).map(link => {
                 return ResourceRangeTreeItem.createStandardItem(
                   foam.workspace,

--- a/packages/foam-vscode/src/utils/grouped-resources-tree-data-provider.spec.ts
+++ b/packages/foam-vscode/src/utils/grouped-resources-tree-data-provider.spec.ts
@@ -10,7 +10,7 @@ import {
   DirectoryTreeItem,
   GroupedResourcesTreeDataProvider,
 } from './grouped-resources-tree-data-provider';
-import { UriTreeItem } from './tree-view-utils';
+import { ResourceTreeItem, UriTreeItem } from './tree-view-utils';
 
 const testMatcher = new SubstringExcludeMatcher('path-exclude');
 
@@ -74,14 +74,14 @@ describe('GroupedResourcesTreeDataProvider', () => {
           .list()
           .filter(r => r.title.length === 3)
           .map(r => r.uri),
-      uri => new UriTreeItem(uri),
+      uri => new ResourceTreeItem(workspace.get(uri), workspace),
       testMatcher
     );
     provider.setGroupBy(GroupedResoucesConfigGroupBy.Folder);
 
     const directory = new DirectoryTreeItem(
       '/path',
-      [new UriTreeItem(matchingNote1.uri)],
+      [new ResourceTreeItem(matchingNote1, workspace)],
       'note'
     );
     const result = await provider.getChildren(directory);
@@ -90,7 +90,7 @@ describe('GroupedResourcesTreeDataProvider', () => {
         collapsibleState: 0,
         label: 'ABC',
         description: '/path/ABC.md',
-        command: { command: OPEN_COMMAND.command },
+        command: { command: 'vscode.open' },
       },
     ]);
   });
@@ -104,7 +104,7 @@ describe('GroupedResourcesTreeDataProvider', () => {
           .list()
           .filter(r => r.title.length === 3)
           .map(r => r.uri),
-      uri => new UriTreeItem(uri),
+      uri => new ResourceTreeItem(workspace.get(uri), workspace),
       testMatcher
     );
     provider.setGroupBy(GroupedResoucesConfigGroupBy.Off);
@@ -115,13 +115,13 @@ describe('GroupedResourcesTreeDataProvider', () => {
         collapsibleState: 0,
         label: matchingNote1.title,
         description: '/path/ABC.md',
-        command: { command: OPEN_COMMAND.command },
+        command: { command: 'vscode.open' },
       },
       {
         collapsibleState: 0,
         label: matchingNote2.title,
         description: '/path-bis/XYZ.md',
-        command: { command: OPEN_COMMAND.command },
+        command: { command: 'vscode.open' },
       },
     ]);
   });

--- a/packages/foam-vscode/src/utils/grouped-resources-tree-data-provider.spec.ts
+++ b/packages/foam-vscode/src/utils/grouped-resources-tree-data-provider.spec.ts
@@ -9,8 +9,8 @@ import { createTestNote } from '../test/test-utils';
 import {
   DirectoryTreeItem,
   GroupedResourcesTreeDataProvider,
-  UriTreeItem,
 } from './grouped-resources-tree-data-provider';
+import { UriTreeItem } from './tree-view-utils';
 
 const testMatcher = new SubstringExcludeMatcher('path-exclude');
 

--- a/packages/foam-vscode/src/utils/tree-view-utils.ts
+++ b/packages/foam-vscode/src/utils/tree-view-utils.ts
@@ -116,11 +116,10 @@ export class ResourceRangeTreeItem extends vscode.TreeItem {
     const start = Math.max(0, range.start.character - 15);
     const ellipsis = start === 0 ? '' : '...';
 
-    const label = `${range.start.line}: ${ellipsis}${line.slice(
-      start,
-      start + 300
-    )}`;
-    const tooltip = getNoteTooltip(line);
+    const label = line
+      ? `${range.start.line}: ${ellipsis}${line.slice(start, start + 300)}`
+      : Range.toString(range);
+    const tooltip = line && getNoteTooltip(line);
     const item = new ResourceRangeTreeItem(label, resource, range);
     item.tooltip = tooltip;
     return item;

--- a/packages/foam-vscode/src/utils/tree-view-utils.ts
+++ b/packages/foam-vscode/src/utils/tree-view-utils.ts
@@ -1,0 +1,149 @@
+import * as vscode from 'vscode';
+import { Resource } from '../core/model/note';
+import { toVsCodeUri } from './vsc-utils';
+import { Range } from '../core/model/range';
+import { OPEN_COMMAND } from '../features/commands/open-resource';
+import { URI } from '../core/model/uri';
+import { FoamWorkspace } from '../core/model/workspace';
+import { getNoteTooltip } from '../utils';
+import { isSome } from '../core/utils';
+import { groupBy } from 'lodash';
+
+export class UriTreeItem extends vscode.TreeItem {
+  private doGetChildren: () => Promise<vscode.TreeItem[]>;
+
+  constructor(
+    public readonly uri: URI,
+    options: {
+      collapsibleState?: vscode.TreeItemCollapsibleState;
+      icon?: string;
+      title?: string;
+      getChildren?: () => Promise<vscode.TreeItem[]>;
+    } = {}
+  ) {
+    super(
+      options?.title ?? uri.getName(),
+      options.collapsibleState ?? options.getChildren
+        ? vscode.TreeItemCollapsibleState.Collapsed
+        : vscode.TreeItemCollapsibleState.None
+    );
+    this.doGetChildren = options.getChildren;
+    this.description = uri.path.replace(
+      vscode.workspace.getWorkspaceFolder(toVsCodeUri(uri))?.uri.path,
+      ''
+    );
+    this.tooltip = undefined;
+    this.command = {
+      command: OPEN_COMMAND.command,
+      title: OPEN_COMMAND.title,
+      arguments: [
+        {
+          uri: uri,
+        },
+      ],
+    };
+    this.iconPath = new vscode.ThemeIcon(options.icon ?? 'new-file');
+  }
+
+  resolveTreeItem(): Promise<UriTreeItem> {
+    return Promise.resolve(this);
+  }
+
+  getChildren(): Promise<vscode.TreeItem[]> {
+    return isSome(this.doGetChildren)
+      ? this.doGetChildren()
+      : Promise.resolve([]);
+  }
+}
+
+export class ResourceTreeItem extends UriTreeItem {
+  constructor(
+    public readonly resource: Resource,
+    private readonly workspace: FoamWorkspace,
+    options: {
+      collapsibleState?: vscode.TreeItemCollapsibleState;
+      getChildren?: () => Promise<vscode.TreeItem[]>;
+    } = {}
+  ) {
+    super(resource.uri, {
+      title: resource.title,
+      icon: 'note',
+      collapsibleState: options.collapsibleState,
+      getChildren: options.getChildren,
+    });
+    this.contextValue = 'resource';
+  }
+
+  async resolveTreeItem(): Promise<ResourceTreeItem> {
+    if (this instanceof ResourceTreeItem) {
+      const content = await this.workspace.readAsMarkdown(this.resource.uri);
+      this.tooltip = isSome(content)
+        ? getNoteTooltip(content)
+        : this.resource.title;
+    }
+    return this;
+  }
+}
+
+export class ResourceRangeTreeItem extends vscode.TreeItem {
+  constructor(
+    public label: string,
+    public readonly resource: Resource,
+    public readonly range: Range
+  ) {
+    super(label, vscode.TreeItemCollapsibleState.None);
+    this.label = `${range.start.line}: ${this.label}`;
+    this.command = {
+      command: 'vscode.open',
+      arguments: [toVsCodeUri(resource.uri), { selection: range }],
+      title: 'Go to location',
+    };
+  }
+
+  static async createStandardItem(
+    workspace: FoamWorkspace,
+    resource: Resource,
+    range: Range
+  ): Promise<ResourceRangeTreeItem> {
+    const lines = ((await workspace.readAsMarkdown(resource.uri)) ?? '').split(
+      '\n'
+    );
+
+    const line = lines[range.start.line];
+    const start = Math.max(0, range.start.character - 15);
+    const ellipsis = start === 0 ? '' : '...';
+
+    const label = `${range.start.line}: ${ellipsis}${line.slice(
+      start,
+      start + 300
+    )}`;
+    const tooltip = getNoteTooltip(line);
+    const item = new ResourceRangeTreeItem(label, resource, range);
+    item.tooltip = tooltip;
+    return item;
+  }
+}
+
+export const groupRangesByResource = async (
+  items:
+    | ResourceRangeTreeItem[]
+    | Promise<ResourceRangeTreeItem[]>
+    | Promise<ResourceRangeTreeItem>[]
+) => {
+  let itemsArray = [] as ResourceRangeTreeItem[];
+  if (items instanceof Promise) {
+    itemsArray = await items;
+  }
+  if (items instanceof Array && items[0] instanceof Promise) {
+    itemsArray = await Promise.all(items);
+  }
+  const byResource = groupBy(itemsArray, item => item.resource.uri.path);
+  return Object.values(byResource).map(items => {
+    return new ResourceTreeItem(items[0].resource, null, {
+      collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+      getChildren: () => {
+        return Promise.resolve(items);
+      },
+    });
+  });
+};


### PR DESCRIPTION
A lot of TreeViews in Foam have a similar structure, they refer to resource or ranges within a resource.

In this PR the implementation of these differente views have been consolidated, to offer a consistent UX:
- resource items
  - use the title of the resource
  - hover will preview the resource
  - clicking will navigate to the resource
  - can be expanded when it has ranges within it
  - shows the number of ranges within the resource
- a range item (e.g. a backlink within a resource, a placeholder, ...) 
  - in the tree provides some context
  - on hover will show the full line
  - clicking on it takes the user to the range

I have also ported the Placeholder view to this new pattern, also inspired by the comments from #1145.