### PR TITLE
Fixed #1193 and added tests

### DIFF
--- a/packages/foam-vscode/src/services/templates.ts
+++ b/packages/foam-vscode/src/services/templates.ts
@@ -351,13 +351,14 @@ export const NoteFactory = {
 
       let newFilePath = template.metadata.has('filepath')
         ? URI.file(template.metadata.get('filepath'))
-        : isSome(filepathFallbackURI)
-        ? filepathFallbackURI
-        : await getPathFromTitle(resolver);
+        : filepathFallbackURI;
 
-      if (!newFilePath.path.startsWith('./')) {
+      if (isNone(newFilePath)) {
+        newFilePath = await getPathFromTitle(resolver);
+      } else if (!newFilePath.path.startsWith('./')) {
         newFilePath = asAbsoluteWorkspaceUri(newFilePath);
       }
+
       return NoteFactory.createNote(
         newFilePath,
         template.text,


### PR DESCRIPTION
When no path is provided while creating a note from a template, we should default to the configuration for the creation of new notes. This fix ensures that is the case.