### PR TITLE
Various improvements

### DIFF
--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -102,23 +102,23 @@
     "menus": {
       "view/title": [
         {
-          "command": "foam-vscode.group-orphans-by-folder",
-          "when": "view == foam-vscode.orphans && foam-vscode.orphans-grouped-by-folder == false",
+          "command": "foam-vscode.views.orphans.group-by-folder",
+          "when": "view == foam-vscode.orphans && foam-vscode.views.orphans.grouped-by-folder == false",
           "group": "navigation"
         },
         {
-          "command": "foam-vscode.group-orphans-off",
-          "when": "view == foam-vscode.orphans && foam-vscode.orphans-grouped-by-folder == true",
+          "command": "foam-vscode.views.orphans.group-off",
+          "when": "view == foam-vscode.orphans && foam-vscode.views.orphans.grouped-by-folder == true",
           "group": "navigation"
         },
         {
-          "command": "foam-vscode.group-placeholders-by-folder",
-          "when": "view == foam-vscode.placeholders && foam-vscode.placeholders-grouped-by-folder == false",
+          "command": "foam-vscode.views.placeholders.group-by-folder",
+          "when": "view == foam-vscode.placeholders && foam-vscode.views.placeholders.grouped-by-folder == false",
           "group": "navigation"
         },
         {
-          "command": "foam-vscode.group-placeholders-off",
-          "when": "view == foam-vscode.placeholders && foam-vscode.placeholders-grouped-by-folder == true",
+          "command": "foam-vscode.views.placeholders.group-off",
+          "when": "view == foam-vscode.placeholders && foam-vscode.views.placeholders.grouped-by-folder == true",
           "group": "navigation"
         }
       ],
@@ -132,19 +132,19 @@
           "when": "false"
         },
         {
-          "command": "foam-vscode.group-orphans-by-folder",
+          "command": "foam-vscode.views.orphans.group-by-folder",
           "when": "false"
         },
         {
-          "command": "foam-vscode.group-orphans-off",
+          "command": "foam-vscode.views.orphans.group-off",
           "when": "false"
         },
         {
-          "command": "foam-vscode.group-placeholders-by-folder",
+          "command": "foam-vscode.views.placeholders.group-by-folder",
           "when": "false"
         },
         {
-          "command": "foam-vscode.group-placeholders-off",
+          "command": "foam-vscode.views.placeholders.group-off",
           "when": "false"
         },
         {
@@ -215,22 +215,22 @@
         "title": "Foam: Open Resource"
       },
       {
-        "command": "foam-vscode.group-orphans-by-folder",
+        "command": "foam-vscode.views.orphans.group-by-folder",
         "title": "Foam: Group Orphans By Folder",
         "icon": "$(list-tree)"
       },
       {
-        "command": "foam-vscode.group-orphans-off",
+        "command": "foam-vscode.views.orphans.group-off",
         "title": "Foam: Don't Group Orphans",
         "icon": "$(list-flat)"
       },
       {
-        "command": "foam-vscode.group-placeholders-by-folder",
+        "command": "foam-vscode.views.placeholders.group-by-folder",
         "title": "Foam: Group Placeholders By Folder",
         "icon": "$(list-tree)"
       },
       {
-        "command": "foam-vscode.group-placeholders-off",
+        "command": "foam-vscode.views.placeholders.group-off",
         "title": "Foam: Don't Group Placeholders",
         "icon": "$(list-flat)"
       },

--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -96,7 +96,7 @@
       },
       {
         "view": "foam-vscode.placeholders",
-        "contents": "No placeholders found. Pending links and notes without content will show up here."
+        "contents": "No placeholders found for selected resource or workspace."
       }
     ],
     "menus": {

--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -102,23 +102,33 @@
     "menus": {
       "view/title": [
         {
-          "command": "foam-vscode.views.orphans.group-by-folder",
-          "when": "view == foam-vscode.orphans && foam-vscode.views.orphans.grouped-by-folder == false",
+          "command": "foam-vscode.views.orphans.group-by:folder",
+          "when": "view == foam-vscode.orphans && foam-vscode.views.orphans.group-by == 'off'",
           "group": "navigation"
         },
         {
-          "command": "foam-vscode.views.orphans.group-off",
-          "when": "view == foam-vscode.orphans && foam-vscode.views.orphans.grouped-by-folder == true",
+          "command": "foam-vscode.views.orphans.group-by:off",
+          "when": "view == foam-vscode.orphans && foam-vscode.views.orphans.group-by == 'folder'",
           "group": "navigation"
         },
         {
-          "command": "foam-vscode.views.placeholders.group-by-folder",
-          "when": "view == foam-vscode.placeholders && foam-vscode.views.placeholders.grouped-by-folder == false",
+          "command": "foam-vscode.views.placeholders.show:for-current-file",
+          "when": "view == foam-vscode.placeholders && foam-vscode.views.placeholders.show == 'all'",
           "group": "navigation"
         },
         {
-          "command": "foam-vscode.views.placeholders.group-off",
-          "when": "view == foam-vscode.placeholders && foam-vscode.views.placeholders.grouped-by-folder == true",
+          "command": "foam-vscode.views.placeholders.show:all",
+          "when": "view == foam-vscode.placeholders && foam-vscode.views.placeholders.show == 'for-current-file'",
+          "group": "navigation"
+        },
+        {
+          "command": "foam-vscode.views.placeholders.group-by:folder",
+          "when": "view == foam-vscode.placeholders && foam-vscode.views.placeholders.group-by == 'off'",
+          "group": "navigation"
+        },
+        {
+          "command": "foam-vscode.views.placeholders.group-by:off",
+          "when": "view == foam-vscode.placeholders && foam-vscode.views.placeholders.group-by == 'folder'",
           "group": "navigation"
         }
       ],
@@ -132,19 +142,27 @@
           "when": "false"
         },
         {
-          "command": "foam-vscode.views.orphans.group-by-folder",
+          "command": "foam-vscode.views.orphans.group-by:folder",
           "when": "false"
         },
         {
-          "command": "foam-vscode.views.orphans.group-off",
+          "command": "foam-vscode.views.orphans.group-by:off",
           "when": "false"
         },
         {
-          "command": "foam-vscode.views.placeholders.group-by-folder",
+          "command": "foam-vscode.views.placeholders.show:for-current-file",
           "when": "false"
         },
         {
-          "command": "foam-vscode.views.placeholders.group-off",
+          "command": "foam-vscode.views.placeholders.show:all",
+          "when": "false"
+        },
+        {
+          "command": "foam-vscode.views.placeholders.group-by:folder",
+          "when": "false"
+        },
+        {
+          "command": "foam-vscode.views.placeholders.group-by:off",
           "when": "false"
         },
         {
@@ -215,23 +233,33 @@
         "title": "Foam: Open Resource"
       },
       {
-        "command": "foam-vscode.views.orphans.group-by-folder",
-        "title": "Foam: Group Orphans By Folder",
+        "command": "foam-vscode.views.orphans.group-by:folder",
+        "title": "Group By Folder",
         "icon": "$(list-tree)"
       },
       {
-        "command": "foam-vscode.views.orphans.group-off",
-        "title": "Foam: Don't Group Orphans",
+        "command": "foam-vscode.views.orphans.group-by:off",
+        "title": "Flat list",
         "icon": "$(list-flat)"
       },
       {
-        "command": "foam-vscode.views.placeholders.group-by-folder",
-        "title": "Foam: Group Placeholders By Folder",
+        "command": "foam-vscode.views.placeholders.show:for-current-file",
+        "title": "Show placeholders in current file",
+        "icon": "$(file)"
+      },
+      {
+        "command": "foam-vscode.views.placeholders.show:all",
+        "title": "Show placeholders in workspace",
+        "icon": "$(files)"
+      },
+      {
+        "command": "foam-vscode.views.placeholders.group-by:folder",
+        "title": "Group By Folder",
         "icon": "$(list-tree)"
       },
       {
-        "command": "foam-vscode.views.placeholders.group-off",
-        "title": "Foam: Don't Group Placeholders",
+        "command": "foam-vscode.views.placeholders.group-by:off",
+        "title": "Flat list",
         "icon": "$(list-flat)"
       },
       {
@@ -375,42 +403,12 @@
           "default": [],
           "markdownDescription": "Specifies the list of glob patterns that will be excluded from the orphans report. To ignore the all the content of a given folder, use `**<folderName>/**/*`"
         },
-        "foam.orphans.groupBy": {
-          "type": [
-            "string"
-          ],
-          "enum": [
-            "off",
-            "folder"
-          ],
-          "enumDescriptions": [
-            "Disable grouping",
-            "Group by folder"
-          ],
-          "default": "folder",
-          "markdownDescription": "Group orphans report entries by."
-        },
         "foam.placeholders.exclude": {
           "type": [
             "array"
           ],
           "default": [],
           "markdownDescription": "Specifies the list of glob patterns that will be excluded from the placeholders report. To ignore the all the content of a given folder, use `**<folderName>/**/*`"
-        },
-        "foam.placeholders.groupBy": {
-          "type": [
-            "string"
-          ],
-          "enum": [
-            "off",
-            "folder"
-          ],
-          "enumDescriptions": [
-            "Disable grouping",
-            "Group by folder"
-          ],
-          "default": "folder",
-          "markdownDescription": "Group blank note report entries by."
         },
         "foam.dateSnippets.afterCompletion": {
           "type": "string",

--- a/packages/foam-vscode/src/core/services/markdown-parser.test.ts
+++ b/packages/foam-vscode/src/core/services/markdown-parser.test.ts
@@ -479,27 +479,32 @@ this is another simple line
   `;
 
   it('can detect block', () => {
-    expect(getBlockFor(md, 1)).toEqual('- this is block 1');
+    const { block } = getBlockFor(md, 1);
+    expect(block).toEqual('- this is block 1');
   });
 
   it('supports nested blocks 1', () => {
-    expect(getBlockFor(md, 2)).toEqual(`- this is [[block]] 2
+    const { block } = getBlockFor(md, 2);
+    expect(block).toEqual(`- this is [[block]] 2
   - this is block 2.1`);
   });
 
   it('supports nested blocks 2', () => {
-    expect(getBlockFor(md, 5)).toEqual(`  - this is block 3.1
+    const { block } = getBlockFor(md, 5);
+    expect(block).toEqual(`  - this is block 3.1
     - this is block 3.1.1`);
   });
 
   it('returns the line if no block is detected', () => {
-    expect(getBlockFor(md, 9)).toEqual(`this is a simple line`);
+    const { block } = getBlockFor(md, 9);
+    expect(block).toEqual(`this is a simple line`);
   });
 
   it('is compatible with Range object', () => {
     const note = parser.parse(URI.file('/path/to/a'), md);
     const { start } = note.links[0].range;
-    expect(getBlockFor(md, start)).toEqual(`- this is [[block]] 2
+    const { block } = getBlockFor(md, start);
+    expect(block).toEqual(`- this is [[block]] 2
   - this is block 2.1`);
   });
 });

--- a/packages/foam-vscode/src/core/services/markdown-parser.ts
+++ b/packages/foam-vscode/src/core/services/markdown-parser.ts
@@ -424,3 +424,28 @@ const astPositionToFoamRange = (pos: AstPosition): Range =>
     pos.end.line - 1,
     pos.end.column - 1
   );
+
+export const getBlockFor = (
+  markdown: string,
+  line: number | Position
+): { block: string; nLines: number } => {
+  const searchLine = typeof line === 'number' ? line : line.line;
+  const parser = unified().use(markdownParse, { gfm: true });
+  const tree = parser.parse(markdown);
+  let block = null;
+  let nLines = 0;
+  const lines = markdown.split('\n');
+  visit(tree, ['listItem'], (node: any) => {
+    if (node.position.start.line === searchLine + 1) {
+      block = lines
+        .slice(node.position.start.line - 1, node.position.end.line)
+        .join('\n');
+      nLines = node.position.end.line - node.position.start.line;
+      return visit.EXIT;
+    }
+  });
+  if (block == null) {
+    block = lines[searchLine];
+  }
+  return { block, nLines };
+};

--- a/packages/foam-vscode/src/features/panels/orphans.ts
+++ b/packages/foam-vscode/src/features/panels/orphans.ts
@@ -20,6 +20,7 @@ const feature: FoamFeature = {
     const provider = new GroupedResourcesTreeDataProvider(
       'orphans',
       'orphan',
+      context.globalState,
       () =>
         foam.graph
           .getAllNodes()
@@ -35,18 +36,18 @@ const feature: FoamFeature = {
       },
       matcher
     );
-    provider.setGroupBy(getOrphansConfig().groupBy);
 
     const treeView = vscode.window.createTreeView('foam-vscode.orphans', {
       treeDataProvider: provider,
       showCollapseAll: true,
     });
+    provider.refresh();
     const baseTitle = treeView.title;
     treeView.title = baseTitle + ` (${provider.numElements})`;
 
     context.subscriptions.push(
       vscode.window.registerTreeDataProvider('foam-vscode.orphans', provider),
-      ...provider.commands,
+      provider,
       foam.graph.onDidUpdate(() => {
         provider.refresh();
         treeView.title = baseTitle + ` (${provider.numElements})`;

--- a/packages/foam-vscode/src/features/panels/orphans.ts
+++ b/packages/foam-vscode/src/features/panels/orphans.ts
@@ -21,6 +21,7 @@ const feature: FoamFeature = {
       'orphans',
       'orphan',
       context.globalState,
+      matcher,
       () =>
         foam.graph
           .getAllNodes()
@@ -33,8 +34,7 @@ const feature: FoamFeature = {
         return uri.isPlaceholder()
           ? new UriTreeItem(uri)
           : new ResourceTreeItem(foam.workspace.find(uri), foam.workspace);
-      },
-      matcher
+      }
     );
 
     const treeView = vscode.window.createTreeView('foam-vscode.orphans', {

--- a/packages/foam-vscode/src/features/panels/placeholders.ts
+++ b/packages/foam-vscode/src/features/panels/placeholders.ts
@@ -9,6 +9,10 @@ import {
   UriTreeItem,
   groupRangesByResource,
 } from '../../utils/tree-view-utils';
+import { IMatcher } from '../../core/services/datastore';
+import { ContextMemento, fromVsCodeUri } from '../../utils/vsc-utils';
+import { FoamGraph } from '../../core/model/graph';
+import { URI } from '../../core/model/uri';
 
 const feature: FoamFeature = {
   activate: async (
@@ -19,10 +23,49 @@ const feature: FoamFeature = {
     const { matcher } = await createMatcherAndDataStore(
       getPlaceholdersConfig().exclude
     );
-    const provider = new GroupedResourcesTreeDataProvider(
+    const provider = new PlaceholderTreeView(
+      context.globalState,
+      foam,
+      matcher
+    );
+
+    const treeView = vscode.window.createTreeView('foam-vscode.placeholders', {
+      treeDataProvider: provider,
+      showCollapseAll: true,
+    });
+    const baseTitle = treeView.title;
+    treeView.title = baseTitle + ` (${provider.numElements})`;
+    provider.refresh();
+
+    context.subscriptions.push(
+      treeView,
+      provider,
+      foam.graph.onDidUpdate(() => {
+        provider.refresh();
+      }),
+      provider.onDidChangeTreeData(() => {
+        treeView.title = baseTitle + ` (${provider.numElements})`;
+      })
+    );
+  },
+};
+
+export class PlaceholderTreeView extends GroupedResourcesTreeDataProvider {
+  private graph: FoamGraph;
+  public show = new ContextMemento<'all' | 'for-current-file'>(
+    this.state,
+    `foam-vscode.views.${this.providerId}.show`,
+    'all'
+  );
+
+  public constructor(state: vscode.Memento, foam: Foam, matcher: IMatcher) {
+    super(
       'placeholders',
       'placeholder',
-      () => foam.graph.getAllNodes().filter(uri => uri.isPlaceholder()),
+      state,
+      () => {
+        return foam.graph.getAllNodes().filter(uri => uri.isPlaceholder()); // TODO
+      },
       uri => {
         return new UriTreeItem(uri, {
           icon: 'link',
@@ -42,24 +85,37 @@ const feature: FoamFeature = {
       },
       matcher
     );
-    provider.setGroupBy(getPlaceholdersConfig().groupBy);
-
-    const treeView = vscode.window.createTreeView('foam-vscode.placeholders', {
-      treeDataProvider: provider,
-      showCollapseAll: true,
-    });
-    const baseTitle = treeView.title;
-    treeView.title = baseTitle + ` (${provider.numElements})`;
-
-    context.subscriptions.push(
-      treeView,
-      ...provider.commands,
-      foam.graph.onDidUpdate(() => {
-        provider.refresh();
-        treeView.title = baseTitle + ` (${provider.numElements})`;
-      })
+    this.graph = foam.graph;
+    this.disposables.push(
+      vscode.commands.registerCommand(
+        `foam-vscode.views.${this.providerId}.show:all`,
+        () => {
+          this.show.update('all');
+          this.refresh();
+        }
+      ),
+      vscode.commands.registerCommand(
+        `foam-vscode.views.${this.providerId}.show:for-current-file`,
+        () => {
+          this.show.update('for-current-file');
+          this.refresh();
+        }
+      )
     );
-  },
-};
+  }
+
+  computeResources = (): URI[] => {
+    if (this.show.get() === 'for-current-file') {
+      const currentFile = vscode.window.activeTextEditor?.document.uri;
+      return currentFile
+        ? this.graph
+            .getLinks(fromVsCodeUri(currentFile))
+            .map(link => link.target)
+            .filter(uri => uri.isPlaceholder())
+        : [];
+    }
+    return this.graph.getAllNodes().filter(uri => uri.isPlaceholder());
+  };
+}
 
 export default feature;

--- a/packages/foam-vscode/src/features/panels/placeholders.ts
+++ b/packages/foam-vscode/src/features/panels/placeholders.ts
@@ -45,6 +45,11 @@ const feature: FoamFeature = {
       }),
       provider.onDidChangeTreeData(() => {
         treeView.title = baseTitle + ` (${provider.numElements})`;
+      }),
+      vscode.window.onDidChangeActiveTextEditor(() => {
+        if (provider.show.get() === 'for-current-file') {
+          provider.refresh();
+        }
       })
     );
   },

--- a/packages/foam-vscode/src/features/panels/placeholders.ts
+++ b/packages/foam-vscode/src/features/panels/placeholders.ts
@@ -68,8 +68,10 @@ export class PlaceholderTreeView extends GroupedResourcesTreeDataProvider {
       'placeholders',
       'placeholder',
       state,
+      matcher,
       () => {
-        return foam.graph.getAllNodes().filter(uri => uri.isPlaceholder()); // TODO
+        // we override computeResources below (as we can't use "this" here)
+        throw new Error('Not implemented');
       },
       uri => {
         return new UriTreeItem(uri, {
@@ -87,8 +89,7 @@ export class PlaceholderTreeView extends GroupedResourcesTreeDataProvider {
             );
           },
         });
-      },
-      matcher
+      }
     );
     this.graph = foam.graph;
     this.disposables.push(

--- a/packages/foam-vscode/src/features/panels/tags-explorer.spec.ts
+++ b/packages/foam-vscode/src/features/panels/tags-explorer.spec.ts
@@ -1,8 +1,9 @@
 import { createTestNote } from '../../test/test-utils';
 import { cleanWorkspace, closeEditors } from '../../test/test-utils-vscode';
-import { TagItem, TagReference, TagsProvider } from './tags-explorer';
+import { TagItem, TagsProvider } from './tags-explorer';
 import { FoamTags } from '../../core/model/tags';
 import { FoamWorkspace } from '../../core/model/workspace';
+import { ResourceTreeItem } from '../../utils/tree-view-utils';
 
 describe('Tags tree panel', () => {
   beforeAll(async () => {
@@ -122,9 +123,9 @@ describe('Tags tree panel', () => {
     )) as TagItem[];
 
     childTreeItems
-      .filter(item => item instanceof TagReference)
+      .filter(item => item instanceof ResourceTreeItem)
       .forEach(item => {
-        expect(item.title).toEqual('Test note');
+        expect(item.label).toEqual('Test note');
       });
 
     childTreeItems

--- a/packages/foam-vscode/src/settings.ts
+++ b/packages/foam-vscode/src/settings.ts
@@ -19,6 +19,7 @@ export function getWikilinkDefinitionSetting(): LinkReferenceDefinitionsSetting 
 /** Retrieve the list of file ignoring globs. */
 export function getIgnoredFilesSetting(): GlobPattern[] {
   return [
+    '**/.foam/**',
     ...workspace.getConfiguration().get('foam.files.ignore', []),
     ...Object.keys(workspace.getConfiguration().get('files.exclude', {})),
   ];

--- a/packages/foam-vscode/src/settings.ts
+++ b/packages/foam-vscode/src/settings.ts
@@ -43,24 +43,16 @@ export function getFoamLoggerLevel(): LogLevel {
 export function getOrphansConfig(): GroupedResourcesConfig {
   const orphansConfig = workspace.getConfiguration('foam.orphans');
   const exclude: string[] = orphansConfig.get('exclude');
-  const groupBy: GroupedResoucesConfigGroupBy = orphansConfig.get('groupBy');
-  return { exclude, groupBy };
+  return { exclude };
 }
 
 /** Retrieve the placeholders configuration */
 export function getPlaceholdersConfig(): GroupedResourcesConfig {
   const placeholderCfg = workspace.getConfiguration('foam.placeholders');
   const exclude: string[] = placeholderCfg.get('exclude');
-  const groupBy: GroupedResoucesConfigGroupBy = placeholderCfg.get('groupBy');
-  return { exclude, groupBy };
+  return { exclude };
 }
 
 export interface GroupedResourcesConfig {
   exclude: string[];
-  groupBy: GroupedResoucesConfigGroupBy;
-}
-
-export enum GroupedResoucesConfigGroupBy {
-  Folder = 'folder',
-  Off = 'off',
 }

--- a/packages/foam-vscode/src/utils/grouped-resources-tree-data-provider.spec.ts
+++ b/packages/foam-vscode/src/utils/grouped-resources-tree-data-provider.spec.ts
@@ -1,35 +1,18 @@
-import { Memento } from 'vscode';
 import { FoamWorkspace } from '../core/model/workspace';
 import {
   AlwaysIncludeMatcher,
   SubstringExcludeMatcher,
 } from '../core/services/datastore';
-import { createTestNote, getRandomURI } from '../test/test-utils';
+import { createTestNote } from '../test/test-utils';
 import {
   DirectoryTreeItem,
   GroupedResourcesTreeDataProvider,
 } from './grouped-resources-tree-data-provider';
 import { ResourceTreeItem, UriTreeItem } from './tree-view-utils';
 import { randomString } from '../test/test-utils';
+import { MapBasedMemento } from './vsc-utils';
 
 const testMatcher = new SubstringExcludeMatcher('path-exclude');
-
-// implementation of the Memento interface that uses a Map as backend
-class TestMemento implements Memento {
-  get<T>(key: string): T;
-  get<T>(key: string, defaultValue: T): T;
-  get<T>(key: unknown, defaultValue?: unknown): T | T {
-    return (this.map.get(key as string) as T) || (defaultValue as T);
-  }
-  private map: Map<string, string> = new Map();
-  keys(): readonly string[] {
-    return Array.from(this.map.keys());
-  }
-  update(key: string, value: any): Thenable<void> {
-    this.map.set(key, value);
-    return Promise.resolve();
-  }
-}
 
 describe('GroupedResourcesTreeDataProvider', () => {
   const matchingNote1 = createTestNote({ uri: '/path/ABC.md', title: 'ABC' });
@@ -56,7 +39,7 @@ describe('GroupedResourcesTreeDataProvider', () => {
     const provider = new GroupedResourcesTreeDataProvider(
       randomString(),
       'note',
-      new TestMemento(),
+      new MapBasedMemento(),
       testMatcher,
       () =>
         workspace
@@ -88,7 +71,7 @@ describe('GroupedResourcesTreeDataProvider', () => {
     const provider = new GroupedResourcesTreeDataProvider(
       randomString(),
       'note',
-      new TestMemento(),
+      new MapBasedMemento(),
       testMatcher,
       () =>
         workspace
@@ -120,7 +103,7 @@ describe('GroupedResourcesTreeDataProvider', () => {
     const provider = new GroupedResourcesTreeDataProvider(
       randomString(),
       'note',
-      new TestMemento(),
+      new MapBasedMemento(),
       testMatcher,
       () =>
         workspace
@@ -153,7 +136,7 @@ describe('GroupedResourcesTreeDataProvider', () => {
     const provider = new GroupedResourcesTreeDataProvider(
       randomString(),
       'note',
-      new TestMemento(),
+      new MapBasedMemento(),
       new AlwaysIncludeMatcher(),
       () =>
         workspace
@@ -183,7 +166,7 @@ describe('GroupedResourcesTreeDataProvider', () => {
     const provider = new GroupedResourcesTreeDataProvider(
       randomString(),
       description,
-      new TestMemento(),
+      new MapBasedMemento(),
       testMatcher,
       () =>
         workspace

--- a/packages/foam-vscode/src/utils/grouped-resources-tree-data-provider.spec.ts
+++ b/packages/foam-vscode/src/utils/grouped-resources-tree-data-provider.spec.ts
@@ -4,12 +4,13 @@ import {
   AlwaysIncludeMatcher,
   SubstringExcludeMatcher,
 } from '../core/services/datastore';
-import { createTestNote } from '../test/test-utils';
+import { createTestNote, getRandomURI } from '../test/test-utils';
 import {
   DirectoryTreeItem,
   GroupedResourcesTreeDataProvider,
 } from './grouped-resources-tree-data-provider';
 import { ResourceTreeItem, UriTreeItem } from './tree-view-utils';
+import { randomString } from '../test/test-utils';
 
 const testMatcher = new SubstringExcludeMatcher('path-exclude');
 
@@ -53,18 +54,19 @@ describe('GroupedResourcesTreeDataProvider', () => {
 
   it('should return the grouped resources as a folder tree', async () => {
     const provider = new GroupedResourcesTreeDataProvider(
-      'length3',
+      randomString(),
       'note',
       new TestMemento(),
+      testMatcher,
       () =>
         workspace
           .list()
           .filter(r => r.title.length === 3)
           .map(r => r.uri),
-      uri => new UriTreeItem(uri),
-      testMatcher
+      uri => new UriTreeItem(uri)
     );
     provider.groupBy.update('folder');
+    provider.refresh();
     const result = await provider.getChildren();
     expect(result).toMatchObject([
       {
@@ -84,18 +86,19 @@ describe('GroupedResourcesTreeDataProvider', () => {
 
   it('should return the grouped resources in a directory', async () => {
     const provider = new GroupedResourcesTreeDataProvider(
-      'length3',
+      randomString(),
       'note',
       new TestMemento(),
+      testMatcher,
       () =>
         workspace
           .list()
           .filter(r => r.title.length === 3)
           .map(r => r.uri),
-      uri => new ResourceTreeItem(workspace.get(uri), workspace),
-      testMatcher
+      uri => new ResourceTreeItem(workspace.get(uri), workspace)
     );
     provider.groupBy.update('folder');
+    provider.refresh();
 
     const directory = new DirectoryTreeItem(
       '/path',
@@ -115,18 +118,19 @@ describe('GroupedResourcesTreeDataProvider', () => {
 
   it('should return the flattened resources', async () => {
     const provider = new GroupedResourcesTreeDataProvider(
-      'length3',
+      randomString(),
       'note',
       new TestMemento(),
+      testMatcher,
       () =>
         workspace
           .list()
           .filter(r => r.title.length === 3)
           .map(r => r.uri),
-      uri => new ResourceTreeItem(workspace.get(uri), workspace),
-      testMatcher
+      uri => new ResourceTreeItem(workspace.get(uri), workspace)
     );
     provider.groupBy.update('off');
+    provider.refresh();
 
     const result = await provider.getChildren();
     expect(result).toMatchObject([
@@ -147,18 +151,19 @@ describe('GroupedResourcesTreeDataProvider', () => {
 
   it('should return the grouped resources without exclusion', async () => {
     const provider = new GroupedResourcesTreeDataProvider(
-      'length3',
+      randomString(),
       'note',
       new TestMemento(),
+      new AlwaysIncludeMatcher(),
       () =>
         workspace
           .list()
           .filter(r => r.title.length === 3)
           .map(r => r.uri),
-      uri => new UriTreeItem(uri),
-      new AlwaysIncludeMatcher()
+      uri => new UriTreeItem(uri)
     );
     provider.groupBy.update('folder');
+    provider.refresh();
 
     const result = await provider.getChildren();
     expect(result).toMatchObject([
@@ -176,18 +181,19 @@ describe('GroupedResourcesTreeDataProvider', () => {
   it('should dynamically set the description', async () => {
     const description = 'test description';
     const provider = new GroupedResourcesTreeDataProvider(
-      'length3',
+      randomString(),
       description,
       new TestMemento(),
+      testMatcher,
       () =>
         workspace
           .list()
           .filter(r => r.title.length === 3)
           .map(r => r.uri),
-      uri => new UriTreeItem(uri),
-      testMatcher
+      uri => new UriTreeItem(uri)
     );
     provider.groupBy.update('folder');
+    provider.refresh();
     const result = await provider.getChildren();
     expect(result).toMatchObject([
       {

--- a/packages/foam-vscode/src/utils/grouped-resources-tree-data-provider.ts
+++ b/packages/foam-vscode/src/utils/grouped-resources-tree-data-provider.ts
@@ -13,8 +13,8 @@ import { UriTreeItem } from './tree-view-utils';
  *
  * **NOTE**: In order for this provider to correctly function, you must define the following command in the package.json file:
    * ```
-   * foam-vscode.group-${providerId}-by-folder
-   * foam-vscode.group-${providerId}-off
+   * foam-vscode.views.${providerId}.group-by-folder
+   * foam-vscode.views.${providerId}.group-off
    * ```
    * Where `providerId` is the same string provided to the constructor. You must also register the commands in your context subscriptions as follows:
    * ```
@@ -88,11 +88,11 @@ export class GroupedResourcesTreeDataProvider
   public get commands() {
     return [
       vscode.commands.registerCommand(
-        `foam-vscode.group-${this.providerId}-by-folder`,
+        `foam-vscode.views.${this.providerId}.group-by-folder`,
         () => this.setGroupBy(GroupedResoucesConfigGroupBy.Folder)
       ),
       vscode.commands.registerCommand(
-        `foam-vscode.group-${this.providerId}-off`,
+        `foam-vscode.views.${this.providerId}.group-off`,
         () => this.setGroupBy(GroupedResoucesConfigGroupBy.Off)
       ),
     ];
@@ -111,7 +111,7 @@ export class GroupedResourcesTreeDataProvider
   private setContext(): void {
     vscode.commands.executeCommand(
       'setContext',
-      `foam-vscode.${this.providerId}-grouped-by-folder`,
+      `foam-vscode.views.${this.providerId}.grouped-by-folder`,
       this.groupBy === GroupedResoucesConfigGroupBy.Folder
     );
   }

--- a/packages/foam-vscode/src/utils/grouped-resources-tree-data-provider.ts
+++ b/packages/foam-vscode/src/utils/grouped-resources-tree-data-provider.ts
@@ -1,10 +1,10 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { GroupedResoucesConfigGroupBy } from '../settings';
 import { getContainsTooltip, isSome } from '../utils';
 import { URI } from '../core/model/uri';
 import { IMatcher } from '../core/services/datastore';
 import { UriTreeItem } from './tree-view-utils';
+import { ContextMemento } from './vsc-utils';
 
 /**
  * Provides the ability to expose a TreeDataExplorerView in VSCode. This class will
@@ -34,24 +34,29 @@ import { UriTreeItem } from './tree-view-utils';
  * @implements {vscode.TreeDataProvider<GroupedResourceTreeItem>}
  */
 export class GroupedResourcesTreeDataProvider
-  implements vscode.TreeDataProvider<GroupedResourceTreeItem>
+  implements
+    vscode.TreeDataProvider<GroupedResourceTreeItem>,
+    vscode.Disposable
 {
   // prettier-ignore
   private _onDidChangeTreeData: vscode.EventEmitter<GroupedResourceTreeItem | undefined | void> = new vscode.EventEmitter<GroupedResourceTreeItem | undefined | void>();
   // prettier-ignore
   readonly onDidChangeTreeData: vscode.Event<GroupedResourceTreeItem | undefined | void> = this._onDidChangeTreeData.event;
-  // prettier-ignore
-  private groupBy: GroupedResoucesConfigGroupBy = GroupedResoucesConfigGroupBy.Folder;
-  private exclude: string[] = [];
   private flatUris: Array<URI> = [];
   private root = vscode.workspace.workspaceFolders[0].uri.path;
+  public groupBy = new ContextMemento<'off' | 'folder'>(
+    this.state,
+    `foam-vscode.views.${this.providerId}.group-by`,
+    'folder'
+  );
+  protected disposables: vscode.Disposable[] = [];
 
   /**
    * Creates an instance of GroupedResourcesTreeDataProvider.
    * **NOTE**: In order for this provider to correctly function, you must define the following command in the package.json file:
    * ```
-   * foam-vscode.group-${providerId}-by-folder
-   * foam-vscode.group-${providerId}-off
+   * foam-vscode.views.${this.providerId}.group-by-folder
+   * foam-vscode.views.${this.providerId}.group-by-off
    * ```
    * Where `providerId` is the same string provided to this constructor. You must also register the commands in your context subscriptions as follows:
    * ```
@@ -75,45 +80,37 @@ export class GroupedResourcesTreeDataProvider
    * @memberof GroupedResourcesTreeDataProvider
    */
   constructor(
-    private providerId: string,
+    protected providerId: string,
     private resourceName: string,
-    private computeResources: () => Array<URI>,
+    protected state: vscode.Memento,
+    protected computeResources: () => Array<URI>,
     private createTreeItem: (item: URI) => GroupedResourceTreeItem,
     private matcher: IMatcher
   ) {
-    this.setContext();
-    this.doComputeResources();
+    this.disposables.push(
+      vscode.commands.registerCommand(
+        `foam-vscode.views.${this.providerId}.group-by:folder`,
+        () => {
+          this.groupBy.update('folder');
+          this.refresh();
+        }
+      ),
+      vscode.commands.registerCommand(
+        `foam-vscode.views.${this.providerId}.group-by:off`,
+        () => {
+          this.groupBy.update('off');
+          this.refresh();
+        }
+      )
+    );
   }
 
-  public get commands() {
-    return [
-      vscode.commands.registerCommand(
-        `foam-vscode.views.${this.providerId}.group-by-folder`,
-        () => this.setGroupBy(GroupedResoucesConfigGroupBy.Folder)
-      ),
-      vscode.commands.registerCommand(
-        `foam-vscode.views.${this.providerId}.group-off`,
-        () => this.setGroupBy(GroupedResoucesConfigGroupBy.Off)
-      ),
-    ];
+  dispose() {
+    this.disposables.forEach(d => d.dispose());
   }
 
   public get numElements() {
     return this.flatUris.length;
-  }
-
-  setGroupBy(groupBy: GroupedResoucesConfigGroupBy): void {
-    this.groupBy = groupBy;
-    this.setContext();
-    this.refresh();
-  }
-
-  private setContext(): void {
-    vscode.commands.executeCommand(
-      'setContext',
-      `foam-vscode.views.${this.providerId}.grouped-by-folder`,
-      this.groupBy === GroupedResoucesConfigGroupBy.Folder
-    );
   }
 
   refresh(): void {
@@ -132,7 +129,7 @@ export class GroupedResourcesTreeDataProvider
       const children = await (item as any).getChildren();
       return children.sort(sortByTreeItemLabel);
     }
-    if (this.groupBy === GroupedResoucesConfigGroupBy.Folder) {
+    if (this.groupBy.get() === 'folder') {
       const directories = Object.entries(this.getUrisByDirectory())
         .sort(([dir1], [dir2]) => sortByString(dir1, dir2))
         .map(

--- a/packages/foam-vscode/src/utils/grouped-resources-tree-data-provider.ts
+++ b/packages/foam-vscode/src/utils/grouped-resources-tree-data-provider.ts
@@ -83,9 +83,9 @@ export class GroupedResourcesTreeDataProvider
     protected providerId: string,
     private resourceName: string,
     protected state: vscode.Memento,
+    private matcher: IMatcher,
     protected computeResources: () => Array<URI>,
-    private createTreeItem: (item: URI) => GroupedResourceTreeItem,
-    private matcher: IMatcher
+    private createTreeItem: (item: URI) => GroupedResourceTreeItem
   ) {
     this.disposables.push(
       vscode.commands.registerCommand(
@@ -126,8 +126,7 @@ export class GroupedResourcesTreeDataProvider
     item?: GroupedResourceTreeItem
   ): Promise<GroupedResourceTreeItem[]> {
     if ((item as any)?.getChildren) {
-      const children = await (item as any).getChildren();
-      return children.sort(sortByTreeItemLabel);
+      return (item as any).getChildren();
     }
     if (this.groupBy.get() === 'folder') {
       const directories = Object.entries(this.getUrisByDirectory())

--- a/packages/foam-vscode/src/utils/vsc-utils.ts
+++ b/packages/foam-vscode/src/utils/vsc-utils.ts
@@ -1,4 +1,4 @@
-import { Position, Range, Uri } from 'vscode';
+import { Memento, Position, Range, Uri, commands } from 'vscode';
 import { Position as FoamPosition } from '../core/model/position';
 import { Range as FoamRange } from '../core/model/range';
 import { URI as FoamURI } from '../core/model/uri';
@@ -12,3 +12,20 @@ export const toVsCodeRange = (r: FoamRange): Range =>
 export const toVsCodeUri = (u: FoamURI): Uri => Uri.parse(u.toString());
 
 export const fromVsCodeUri = (u: Uri): FoamURI => FoamURI.parse(u.toString());
+
+/**
+ * A class that wraps context value, syncs it via setContext, and provides a typed interface to it.
+ */
+export class ContextMemento<T> {
+  constructor(private data: Memento, private key: string, defaultValue: T) {
+    const value = data.get(key) ?? defaultValue;
+    commands.executeCommand('setContext', this.key, value);
+  }
+  public get(): T {
+    return this.data.get(this.key);
+  }
+  public update(value: T): Thenable<void> {
+    this.data.update(this.key, value);
+    return commands.executeCommand('setContext', this.key, value);
+  }
+}

--- a/packages/foam-vscode/src/utils/vsc-utils.ts
+++ b/packages/foam-vscode/src/utils/vsc-utils.ts
@@ -24,8 +24,27 @@ export class ContextMemento<T> {
   public get(): T {
     return this.data.get(this.key);
   }
-  public update(value: T): Thenable<void> {
+  public async update(value: T): Promise<void> {
     this.data.update(this.key, value);
-    return commands.executeCommand('setContext', this.key, value);
+    await commands.executeCommand('setContext', this.key, value);
+  }
+}
+
+/**
+ * Implementation of the Memento interface that uses a Map as backend
+ */
+export class MapBasedMemento implements Memento {
+  get<T>(key: string): T;
+  get<T>(key: string, defaultValue: T): T;
+  get<T>(key: unknown, defaultValue?: unknown): T | T {
+    return (this.map.get(key as string) as T) || (defaultValue as T);
+  }
+  private map: Map<string, string> = new Map();
+  keys(): readonly string[] {
+    return Array.from(this.map.keys());
+  }
+  update(key: string, value: any): Promise<void> {
+    this.map.set(key, value);
+    return Promise.resolve();
   }
 }

--- a/packages/foam-vscode/src/utils/vsc-utils.ts
+++ b/packages/foam-vscode/src/utils/vsc-utils.ts
@@ -34,9 +34,7 @@ export class ContextMemento<T> {
  * Implementation of the Memento interface that uses a Map as backend
  */
 export class MapBasedMemento implements Memento {
-  get<T>(key: string): T;
-  get<T>(key: string, defaultValue: T): T;
-  get<T>(key: unknown, defaultValue?: unknown): T | T {
+  get<T>(key: unknown, defaultValue?: unknown | T): T | T {
     return (this.map.get(key as string) as T) || (defaultValue as T);
   }
   private map: Map<string, string> = new Map();


### PR DESCRIPTION
Unfortunately a couple of features ended up here:
1. various improvements to the tree panels
  - added filter in placeholder view to only see placeholders in current file (addresses part of #988)
  - refactored GroupedResourcesTreeDataProvider
2. show full block when previewing a range item on hover in the tree panels (closes #800)
3. ignore `.foam` directory (related to #1200)