### PR TITLE
Notes explorer

### DIFF
--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -68,6 +68,12 @@
           "contextualTitle": "Tags Explorer"
         },
         {
+          "id": "foam-vscode.notes-explorer",
+          "name": "Notes",
+          "icon": "$(notebook)",
+          "contextualTitle": "Notes Explorer"
+        },
+        {
           "id": "foam-vscode.orphans",
           "name": "Orphans",
           "icon": "$(debug-gripper)",
@@ -130,6 +136,16 @@
           "command": "foam-vscode.views.placeholders.group-by:off",
           "when": "view == foam-vscode.placeholders && foam-vscode.views.placeholders.group-by == 'folder'",
           "group": "navigation"
+        },
+        {
+          "command": "foam-vscode.views.notes-explorer.show:notes",
+          "when": "view == foam-vscode.notes-explorer && foam-vscode.views.notes-explorer.show == 'all'",
+          "group": "navigation"
+        },
+        {
+          "command": "foam-vscode.views.notes-explorer.show:all",
+          "when": "view == foam-vscode.notes-explorer && foam-vscode.views.notes-explorer.show == 'notes-only'",
+          "group": "navigation"
         }
       ],
       "commandPalette": [
@@ -163,6 +179,14 @@
         },
         {
           "command": "foam-vscode.views.placeholders.group-by:off",
+          "when": "false"
+        },
+        {
+          "command": "foam-vscode.views.notes-explorer.show:all",
+          "when": "false"
+        },
+        {
+          "command": "foam-vscode.views.notes-explorer.show:notes",
           "when": "false"
         },
         {
@@ -261,6 +285,16 @@
         "command": "foam-vscode.views.placeholders.group-by:off",
         "title": "Flat list",
         "icon": "$(list-flat)"
+      },
+      {
+        "command": "foam-vscode.views.notes-explorer.show:all",
+        "title": "Show all resources",
+        "icon": "$(files)"
+      },
+      {
+        "command": "foam-vscode.views.notes-explorer.show:notes",
+        "title": "Show only notes",
+        "icon": "$(file)"
       },
       {
         "command": "foam-vscode.create-new-template",

--- a/packages/foam-vscode/src/features/panels/index.ts
+++ b/packages/foam-vscode/src/features/panels/index.ts
@@ -3,3 +3,4 @@ export { default as dataviz } from './dataviz';
 export { default as orphans } from './orphans';
 export { default as placeholders } from './placeholders';
 export { default as tags } from './tags-explorer';
+export { default as notes } from './notes-explorer';

--- a/packages/foam-vscode/src/features/panels/notes-explorer.ts
+++ b/packages/foam-vscode/src/features/panels/notes-explorer.ts
@@ -1,0 +1,312 @@
+import * as vscode from 'vscode';
+import { FoamFeature } from '../../types';
+import { Foam } from '../../core/model/foam';
+import { FoamWorkspace } from '../../core/model/workspace';
+import {
+  ResourceRangeTreeItem,
+  ResourceTreeItem,
+  createBacklinkItemsForResource as createBacklinkTreeItemsForResource,
+} from '../../utils/tree-view-utils';
+import { Resource } from '../../core/model/note';
+import { FoamGraph } from '../../core/model/graph';
+import { ContextMemento, toVsCodeUri } from '../../utils/vsc-utils';
+import { IDisposable } from '../../core/common/lifecycle';
+
+const feature: FoamFeature = {
+  activate: async (
+    context: vscode.ExtensionContext,
+    foamPromise: Promise<Foam>
+  ) => {
+    const foam = await foamPromise;
+    const provider = new NotesProvider(
+      foam.workspace,
+      foam.graph,
+      context.globalState
+    );
+    provider.refresh();
+    const treeView = vscode.window.createTreeView<NotesTreeItems>(
+      'foam-vscode.notes-explorer',
+      {
+        treeDataProvider: provider,
+        showCollapseAll: true,
+        canSelectMany: true,
+      }
+    );
+    context.subscriptions.push(
+      treeView,
+      provider,
+      foam.graph.onDidUpdate(() => {
+        provider.refresh();
+      }),
+      vscode.window.onDidChangeActiveTextEditor(async () => {
+        const target = vscode.window.activeTextEditor?.document.uri;
+        if (treeView.visible) {
+          if (target) {
+            const item = await provider.findTreeItem(target);
+            // Check if the item is already selected.
+            // This check is needed because always calling reveal() will
+            // cause the tree view to take the focus from the item when
+            // browsing the notes explorer
+            if (
+              !treeView.selection.find(
+                i => i.resourceUri.path === item.resourceUri.path
+              )
+            ) {
+              treeView.reveal(item);
+            }
+          }
+        }
+      }),
+      treeView.onDidChangeVisibility(async () => {
+        if (treeView.visible) {
+          const target = vscode.window.activeTextEditor?.document.uri;
+          if (target) {
+            const item = await provider.findTreeItem(target);
+            treeView.reveal(item);
+          }
+        }
+      })
+    );
+  },
+};
+
+export default feature;
+
+export class FolderTreeItem extends vscode.TreeItem {
+  collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
+  contextValue = 'folder';
+  iconPath = new vscode.ThemeIcon('folder');
+
+  constructor(
+    public parent: Directory,
+    public name: string,
+    public parentElement?: FolderTreeItem
+  ) {
+    super(name, vscode.TreeItemCollapsibleState.Collapsed);
+  }
+}
+
+export type NotesTreeItems =
+  | ResourceTreeItem
+  | FolderTreeItem
+  | ResourceRangeTreeItem;
+
+export class NotesProvider
+  implements vscode.TreeDataProvider<NotesTreeItems>, IDisposable
+{
+  // prettier-ignore
+  private _onDidChangeTreeData: vscode.EventEmitter<NotesTreeItems | undefined | void> = new vscode.EventEmitter<NotesTreeItems | undefined | void>();
+  // prettier-ignore
+  readonly onDidChangeTreeData: vscode.Event<NotesTreeItems | undefined | void> = this._onDidChangeTreeData.event;
+
+  public show = new ContextMemento<'all' | 'notes-only'>(
+    this.state,
+    `foam-vscode.views.notes-explorer.show`,
+    'all'
+  );
+
+  private root: Directory = {};
+  protected disposables: vscode.Disposable[] = [];
+
+  constructor(
+    private workspace: FoamWorkspace,
+    private graph: FoamGraph,
+    private state: vscode.Memento
+  ) {
+    this.disposables.push(
+      vscode.commands.registerCommand(
+        `foam-vscode.views.notes-explorer.show:all`,
+        () => {
+          this.show.update('all');
+          this.refresh();
+        }
+      ),
+      vscode.commands.registerCommand(
+        `foam-vscode.views.notes-explorer.show:notes`,
+        () => {
+          this.show.update('notes-only');
+          this.refresh();
+        }
+      )
+    );
+  }
+
+  refresh(): void {
+    this.root = createTreeStructure(
+      this.workspace,
+      this.show.get() === 'notes-only'
+        ? r => r.type !== 'image' && r.type !== 'attachment'
+        : () => true
+    );
+    this._onDidChangeTreeData.fire();
+  }
+
+  getTreeItem(item) {
+    return item;
+  }
+
+  getParent(element: NotesTreeItems): vscode.ProviderResult<NotesTreeItems> {
+    if (element instanceof ResourceTreeItem) {
+      return Promise.resolve(element.parent as NotesTreeItems);
+    }
+    if (element instanceof FolderTreeItem) {
+      return Promise.resolve(element.parentElement);
+    }
+  }
+
+  async getChildren(item?: NotesTreeItems): Promise<NotesTreeItems[]> {
+    if (item instanceof ResourceTreeItem) {
+      return item.getChildren() as Promise<NotesTreeItems[]>;
+    }
+    if (item instanceof ResourceRangeTreeItem) {
+      return [];
+    }
+
+    const parent = item?.parent ?? this.root;
+
+    const children = Object.keys(parent).map(name => {
+      const value = parent[name];
+      if ((value as Resource)?.uri) {
+        return this.createResourceTreeItem(value as Resource);
+      } else {
+        return new FolderTreeItem(value as Directory, name, item);
+      }
+    });
+
+    return children.sort(sortNotesExplorerItems);
+  }
+
+  private createResourceTreeItem(value: Resource, parent?: FolderTreeItem) {
+    const res = new ResourceTreeItem(value, this.workspace, {
+      parent,
+      collapsibleState:
+        this.graph.getBacklinks(value.uri).length > 0
+          ? vscode.TreeItemCollapsibleState.Collapsed
+          : vscode.TreeItemCollapsibleState.None,
+    });
+    res.getChildren = async () => {
+      const backlinks = await createBacklinkTreeItemsForResource(
+        this.workspace,
+        this.graph,
+        res.uri
+      );
+      return backlinks;
+    };
+    res.iconPath = vscode.ThemeIcon.File;
+    res.resourceUri = toVsCodeUri(res.uri);
+    return res;
+  }
+
+  async resolveTreeItem(item: NotesTreeItems): Promise<NotesTreeItems> {
+    if ((item as any)?.resolveTreeItem) {
+      return (item as any).resolveTreeItem();
+    }
+    return Promise.resolve(item);
+  }
+
+  getTreeItemsHierarchy(uri: vscode.Uri, root: Directory): vscode.TreeItem[] {
+    const path = vscode.workspace.asRelativePath(uri, true);
+    const parts = path.split('/').filter(p => p.length > 0);
+    const treeItemsHierarchy: vscode.TreeItem[] = [];
+    let currentNode: Directory | Resource = root;
+
+    for (const part of parts) {
+      if (currentNode[part] !== undefined) {
+        currentNode = currentNode[part] as Directory | Resource;
+        if ((currentNode as Resource).uri) {
+          treeItemsHierarchy.push(
+            this.createResourceTreeItem(
+              currentNode as Resource,
+              treeItemsHierarchy[
+                treeItemsHierarchy.length - 1
+              ] as FolderTreeItem
+            )
+          );
+        } else {
+          treeItemsHierarchy.push(
+            new FolderTreeItem(
+              currentNode as Directory,
+              part,
+              treeItemsHierarchy[
+                treeItemsHierarchy.length - 1
+              ] as FolderTreeItem
+            )
+          );
+        }
+      } else {
+        // If a part is not found in the tree structure, the given URI is not valid.
+        return [];
+      }
+    }
+
+    return treeItemsHierarchy;
+  }
+
+  findTreeItem(target: vscode.Uri): Promise<NotesTreeItems> {
+    const hierarchy = this.getTreeItemsHierarchy(target, this.root);
+    return hierarchy.length > 0
+      ? Promise.resolve(hierarchy.pop())
+      : Promise.resolve(null);
+  }
+
+  dispose(): void {
+    this.disposables.forEach(d => d.dispose());
+  }
+}
+
+function sortNotesExplorerItems(
+  a: ResourceTreeItem | FolderTreeItem,
+  b: ResourceTreeItem | FolderTreeItem
+): number {
+  // Both a and b are FolderTreeItem instances
+  if (a instanceof FolderTreeItem && b instanceof FolderTreeItem) {
+    return a.label.toString().localeCompare(b.label.toString());
+  }
+
+  // Only a is a FolderTreeItem instance
+  if (a instanceof FolderTreeItem) {
+    return -1;
+  }
+
+  // Only b is a FolderTreeItem instance
+  if (b instanceof FolderTreeItem) {
+    return 1;
+  }
+
+  return a.label.toString().localeCompare(b.label.toString());
+}
+
+interface Directory {
+  [key: string]: Directory | Resource;
+}
+
+function createTreeStructure(
+  workspace: FoamWorkspace,
+  filterFn: (r: Resource) => boolean
+): Directory {
+  const root: Directory = {};
+
+  for (const r of workspace.resources()) {
+    const path = vscode.workspace.asRelativePath(
+      r.uri.path,
+      vscode.workspace.workspaceFolders.length > 1
+    );
+    const parts = path.split('/');
+    let currentNode: Directory = root;
+
+    parts.forEach((part, index) => {
+      if (!currentNode[part]) {
+        if (index < parts.length - 1) {
+          currentNode[part] = {};
+        } else {
+          if (filterFn(r)) {
+            currentNode[part] = r;
+          }
+        }
+      }
+      currentNode = currentNode[part] as Directory;
+    });
+  }
+
+  return root;
+}

--- a/packages/foam-vscode/src/features/panels/notes-explorer.ts
+++ b/packages/foam-vscode/src/features/panels/notes-explorer.ts
@@ -3,7 +3,6 @@ import { FoamFeature } from '../../types';
 import { Foam } from '../../core/model/foam';
 import { FoamWorkspace } from '../../core/model/workspace';
 import {
-  BaseTreeItem,
   ResourceRangeTreeItem,
   ResourceTreeItem,
   createBacklinkItemsForResource as createBacklinkTreeItemsForResource,
@@ -11,8 +10,10 @@ import {
 import { Resource } from '../../core/model/note';
 import { FoamGraph } from '../../core/model/graph';
 import { ContextMemento } from '../../utils/vsc-utils';
-import { IDisposable } from '../../core/common/lifecycle';
-import { BaseTreeProvider } from './utils/base-tree-provider';
+import {
+  FolderTreeItem,
+  FolderTreeProvider,
+} from './utils/folder-tree-provider';
 
 const feature: FoamFeature = {
   activate: async (
@@ -20,19 +21,6 @@ const feature: FoamFeature = {
     foamPromise: Promise<Foam>
   ) => {
     const foam = await foamPromise;
-    // const folderTree = new FolderTree<Resource>(
-    //   value => (value as Resource)?.uri != null,
-    //   (value, parent) =>
-    //     createResourceTreeItem(value, foam.workspace, foam.graph, parent),
-    //   value => {
-    //     const path = vscode.workspace.asRelativePath(
-    //       value.uri.path,
-    //       vscode.workspace.workspaceFolders.length > 1
-    //     );
-    //     const parts = path.split('/');
-    //     return parts;
-    //   }
-    // );
     const provider = new NotesProvider(
       foam.workspace,
       foam.graph,
@@ -51,7 +39,7 @@ const feature: FoamFeature = {
       const target = vscode.window.activeTextEditor?.document.uri;
       if (treeView.visible) {
         if (target) {
-          const item = await provider.findTreeItem(target);
+          const item = await provider.findTreeItemByUri(target);
           // Check if the item is already selected.
           // This check is needed because always calling reveal() will
           // cause the tree view to take the focus from the item when
@@ -86,13 +74,15 @@ export type NotesTreeItems =
   | FolderTreeItem<Resource>
   | ResourceRangeTreeItem;
 
-export class NotesProvider extends BaseTreeProvider<NotesTreeItems> {
+export class NotesProvider extends FolderTreeProvider<
+  NotesTreeItems,
+  Resource
+> {
   public show = new ContextMemento<'all' | 'notes-only'>(
     this.state,
     `foam-vscode.views.notes-explorer.show`,
     'all'
   );
-  private root: Folder<Resource>;
 
   constructor(
     private workspace: FoamWorkspace,
@@ -118,115 +108,24 @@ export class NotesProvider extends BaseTreeProvider<NotesTreeItems> {
     );
   }
 
-  refresh(): void {
-    this.createFolders();
-    super.refresh();
-  }
-
-  getParent(element: NotesTreeItems): vscode.ProviderResult<NotesTreeItems> {
-    if (element instanceof ResourceTreeItem) {
-      return Promise.resolve(element.parent as NotesTreeItems);
-    }
-    if (element instanceof FolderTreeItem) {
-      return Promise.resolve(element.parentElement);
-    }
-  }
-
-  async getChildren(item?: NotesTreeItems): Promise<NotesTreeItems[]> {
-    if (item instanceof BaseTreeItem) {
-      return item.getChildren() as Promise<NotesTreeItems[]>;
-    }
-
-    const parent = item?.parent ?? this.root;
-
-    const children = Object.keys(parent).map(name => {
-      const value = parent[name];
-      if (this.isValueType(value as Resource)) {
-        return this.createLeafItem(value as Resource, undefined);
-      } else {
-        return new FolderTreeItem(value as Folder<Resource>, name, item);
-      }
-    });
-
-    return children.sort(sortFolderTreeItems);
-  }
-
-  createTree(
-    values: Resource[],
-    filterFn: (value: Resource) => boolean
-  ): Folder<Resource> {
-    const root: Folder<Resource> = {};
-
-    for (const r of values) {
-      const parts = this.valueToPath(r);
-      let currentNode: Folder<Resource> = root;
-
-      parts.forEach((part, index) => {
-        if (!currentNode[part]) {
-          if (index < parts.length - 1) {
-            currentNode[part] = {};
-          } else {
-            if (filterFn(r)) {
-              currentNode[part] = r;
-            }
-          }
-        }
-        currentNode = currentNode[part] as Folder<Resource>;
-      });
-    }
-
-    return root;
-  }
-
-  getTreeItemsHierarchy(
-    root: Folder<Resource>,
-    path: string[]
-  ): vscode.TreeItem[] {
-    const treeItemsHierarchy: vscode.TreeItem[] = [];
-    let currentNode: Folder<Resource> | Resource = root;
-
-    for (const part of path) {
-      if (currentNode[part] !== undefined) {
-        currentNode = currentNode[part] as Folder<Resource> | Resource;
-        if (this.isValueType(currentNode as Resource)) {
-          treeItemsHierarchy.push(
-            this.createLeafItem(
-              currentNode as Resource,
-              treeItemsHierarchy[
-                treeItemsHierarchy.length - 1
-              ] as FolderTreeItem<Resource>
-            )
-          );
-        } else {
-          treeItemsHierarchy.push(
-            new FolderTreeItem(
-              currentNode as Folder<Resource>,
-              part,
-              treeItemsHierarchy[
-                treeItemsHierarchy.length - 1
-              ] as FolderTreeItem<Resource>
-            )
-          );
-        }
-      } else {
-        // If a part is not found in the tree structure, the given URI is not valid.
-        return [];
-      }
-    }
-
-    return treeItemsHierarchy;
-  }
-
-  findTreeItem(uri: vscode.Uri): Promise<NotesTreeItems> {
+  findTreeItemByUri(target: vscode.Uri) {
     const path = vscode.workspace.asRelativePath(
-      uri,
+      target,
       vscode.workspace.workspaceFolders.length > 1
     );
-    const parts = path.split('/');
-    const hierarchy = this.getTreeItemsHierarchy(this.root, parts);
-    return hierarchy.length > 0
-      ? Promise.resolve(hierarchy.pop())
-      : Promise.resolve(null);
+    return this.findTreeItemByPath(path.split('/'));
+  }
+
+  // Implementation of abstract methods
+
+  getValues() {
+    return this.workspace.list();
+  }
+
+  getFilterFn() {
+    return this.show.get() === 'notes-only'
+      ? res => res.type !== 'image' && res.type !== 'attachment'
+      : () => true;
   }
 
   valueToPath(value: Resource) {
@@ -238,92 +137,29 @@ export class NotesProvider extends BaseTreeProvider<NotesTreeItems> {
     return parts;
   }
 
-  createFolders() {
-    this.root = this.createTree(
-      this.workspace.list(),
-      this.show.get() === 'notes-only'
-        ? res => res.type !== 'image' && res.type !== 'attachment'
-        : () => true
-    );
-  }
-
   isValueType(value: Resource): value is Resource {
     return (value as Resource)?.uri != null;
   }
 
-  createLeafItem(
+  createValueTreeItem(
     value: Resource,
     parent: FolderTreeItem<Resource>
   ): NotesTreeItems {
-    return createResourceTreeItem(
-      value as Resource,
-      this.workspace,
-      this.graph,
-      parent
-    );
-  }
-}
-
-function createResourceTreeItem(
-  value: Resource,
-  workspace: FoamWorkspace,
-  graph: FoamGraph,
-  parent?: FolderTreeItem<Resource>
-) {
-  const res = new ResourceTreeItem(value, workspace, {
-    parent,
-    collapsibleState:
-      graph.getBacklinks(value.uri).length > 0
-        ? vscode.TreeItemCollapsibleState.Collapsed
-        : vscode.TreeItemCollapsibleState.None,
-  });
-  res.getChildren = async () => {
-    const backlinks = await createBacklinkTreeItemsForResource(
-      workspace,
-      graph,
-      res.uri
-    );
-    return backlinks;
-  };
-  return res;
-}
-
-function sortFolderTreeItems<T>(
-  a: ResourceTreeItem | FolderTreeItem<T>,
-  b: ResourceTreeItem | FolderTreeItem<T>
-): number {
-  // Both a and b are FolderTreeItem instances
-  if (a instanceof FolderTreeItem && b instanceof FolderTreeItem) {
-    return a.label.toString().localeCompare(b.label.toString());
-  }
-
-  // Only a is a FolderTreeItem instance
-  if (a instanceof FolderTreeItem) {
-    return -1;
-  }
-
-  // Only b is a FolderTreeItem instance
-  if (b instanceof FolderTreeItem) {
-    return 1;
-  }
-
-  return a.label.toString().localeCompare(b.label.toString());
-}
-
-interface Folder<T> {
-  [basename: string]: Folder<T> | T;
-}
-
-export class FolderTreeItem<T> extends vscode.TreeItem {
-  collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
-  contextValue = 'folder';
-  iconPath = new vscode.ThemeIcon('folder');
-
-  constructor(
-    public parent: Folder<T>,
-    public name: string,
-    public parentElement?: FolderTreeItem<T>
-  ) {
-    super(name, vscode.TreeItemCollapsibleState.Collapsed);
+    const res = new ResourceTreeItem(value, this.workspace, {
+      parent,
+      collapsibleState:
+        this.graph.getBacklinks(value.uri).length > 0
+          ? vscode.TreeItemCollapsibleState.Collapsed
+          : vscode.TreeItemCollapsibleState.None,
+    });
+    res.getChildren = async () => {
+      const backlinks = await createBacklinkTreeItemsForResource(
+        this.workspace,
+        this.graph,
+        res.uri
+      );
+      return backlinks;
+    };
+    return res;
   }
 }

--- a/packages/foam-vscode/src/features/panels/notes-explorer.ts
+++ b/packages/foam-vscode/src/features/panels/notes-explorer.ts
@@ -39,14 +39,14 @@ const feature: FoamFeature = {
       const target = vscode.window.activeTextEditor?.document.uri;
       if (treeView.visible) {
         if (target) {
-          const item = await provider.findTreeItemByUri(target);
+          const item = await findTreeItemByUri(provider, target);
           // Check if the item is already selected.
           // This check is needed because always calling reveal() will
           // cause the tree view to take the focus from the item when
           // browsing the notes explorer
           if (
             !treeView.selection.find(
-              i => i.resourceUri.path === item.resourceUri.path
+              i => i.resourceUri?.path === item.resourceUri.path
             )
           ) {
             treeView.reveal(item);
@@ -68,6 +68,17 @@ const feature: FoamFeature = {
 };
 
 export default feature;
+
+export function findTreeItemByUri<I, T>(
+  provider: FolderTreeProvider<I, T>,
+  target: vscode.Uri
+) {
+  const path = vscode.workspace.asRelativePath(
+    target,
+    vscode.workspace.workspaceFolders.length > 1
+  );
+  return provider.findTreeItemByPath(path.split('/'));
+}
 
 export type NotesTreeItems =
   | ResourceTreeItem
@@ -108,16 +119,6 @@ export class NotesProvider extends FolderTreeProvider<
     );
   }
 
-  findTreeItemByUri(target: vscode.Uri) {
-    const path = vscode.workspace.asRelativePath(
-      target,
-      vscode.workspace.workspaceFolders.length > 1
-    );
-    return this.findTreeItemByPath(path.split('/'));
-  }
-
-  // Implementation of abstract methods
-
   getValues() {
     return this.workspace.list();
   }
@@ -138,7 +139,7 @@ export class NotesProvider extends FolderTreeProvider<
   }
 
   isValueType(value: Resource): value is Resource {
-    return (value as Resource)?.uri != null;
+    return value.uri != null;
   }
 
   createValueTreeItem(

--- a/packages/foam-vscode/src/features/panels/utils/base-tree-provider.ts
+++ b/packages/foam-vscode/src/features/panels/utils/base-tree-provider.ts
@@ -13,7 +13,7 @@ export abstract class BaseTreeProvider<T>
 
   abstract getChildren(element?: T): vscode.ProviderResult<T[]>;
 
-  getTreeItem(element: T): vscode.TreeItem | Thenable<vscode.TreeItem> {
+  getTreeItem(element: T) {
     return element;
   }
 

--- a/packages/foam-vscode/src/features/panels/utils/base-tree-provider.ts
+++ b/packages/foam-vscode/src/features/panels/utils/base-tree-provider.ts
@@ -1,0 +1,34 @@
+import * as vscode from 'vscode';
+import { IDisposable } from 'packages/foam-vscode/src/core/common/lifecycle';
+
+export abstract class BaseTreeProvider<T>
+  implements vscode.TreeDataProvider<T>, IDisposable
+{
+  protected disposables: vscode.Disposable[] = [];
+
+  // prettier-ignore
+  private _onDidChangeTreeData: vscode.EventEmitter<T | undefined | void> = new vscode.EventEmitter<T | undefined | void>();
+  // prettier-ignore
+  readonly onDidChangeTreeData: vscode.Event<T | undefined | void> = this._onDidChangeTreeData.event;
+
+  abstract getChildren(element?: T): vscode.ProviderResult<T[]>;
+
+  getTreeItem(element: T): vscode.TreeItem | Thenable<vscode.TreeItem> {
+    return element;
+  }
+
+  async resolveTreeItem(item: T): Promise<T> {
+    if ((item as any)?.resolveTreeItem) {
+      return (item as any).resolveTreeItem();
+    }
+    return Promise.resolve(item);
+  }
+
+  refresh(): void {
+    this._onDidChangeTreeData.fire();
+  }
+
+  dispose(): void {
+    this.disposables.forEach(d => d.dispose());
+  }
+}

--- a/packages/foam-vscode/src/features/panels/utils/folder-tree-provider.ts
+++ b/packages/foam-vscode/src/features/panels/utils/folder-tree-provider.ts
@@ -1,0 +1,159 @@
+import * as vscode from 'vscode';
+import { BaseTreeProvider } from './base-tree-provider';
+import { BaseTreeItem, ResourceTreeItem } from '../../../utils/tree-view-utils';
+
+export interface Folder<T> {
+  [basename: string]: Folder<T> | T;
+}
+
+export class FolderTreeItem<T> extends vscode.TreeItem {
+  collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
+  contextValue = 'folder';
+  iconPath = new vscode.ThemeIcon('folder');
+
+  constructor(
+    public parent: Folder<T>,
+    public name: string,
+    public parentElement?: FolderTreeItem<T>
+  ) {
+    super(name, vscode.TreeItemCollapsibleState.Collapsed);
+  }
+}
+
+export abstract class FolderTreeProvider<I, T> extends BaseTreeProvider<I> {
+  private root: Folder<T>;
+
+  refresh(): void {
+    this.createTree(this.getValues(), this.getFilterFn());
+    super.refresh();
+  }
+
+  getParent(element: I | FolderTreeItem<T>): vscode.ProviderResult<I> {
+    if (element instanceof ResourceTreeItem) {
+      return Promise.resolve(element.parent as I);
+    }
+    if (element instanceof FolderTreeItem) {
+      return Promise.resolve(element.parentElement as any);
+    }
+  }
+
+  async getChildren(item?: I): Promise<I[]> {
+    if (item instanceof BaseTreeItem) {
+      return item.getChildren() as Promise<I[]>;
+    }
+
+    const parent = (item as any)?.parent ?? this.root;
+
+    const children: vscode.TreeItem[] = Object.keys(parent).map(name => {
+      const value = parent[name];
+      if (this.isValueType(value)) {
+        return this.createValueTreeItem(value, undefined);
+      } else {
+        return new FolderTreeItem<T>(
+          value as Folder<T>,
+          name,
+          item as unknown as FolderTreeItem<T>
+        );
+      }
+    });
+
+    return children.sort((a, b) => sortFolderTreeItems(a, b)) as any;
+  }
+
+  createTree(values: T[], filterFn: (value: T) => boolean): Folder<T> {
+    const root: Folder<T> = {};
+
+    for (const r of values) {
+      const parts = this.valueToPath(r);
+      let currentNode: Folder<T> = root;
+
+      parts.forEach((part, index) => {
+        if (!currentNode[part]) {
+          if (index < parts.length - 1) {
+            currentNode[part] = {};
+          } else {
+            if (filterFn(r)) {
+              currentNode[part] = r;
+            }
+          }
+        }
+        currentNode = currentNode[part] as Folder<T>;
+      });
+    }
+
+    this.root = root;
+    return root;
+  }
+
+  getTreeItemsHierarchy(path: string[]): vscode.TreeItem[] {
+    const treeItemsHierarchy: vscode.TreeItem[] = [];
+    let currentNode: Folder<T> | T = this.root;
+
+    for (const part of path) {
+      if (currentNode[part] !== undefined) {
+        currentNode = currentNode[part] as Folder<T> | T;
+        if (this.isValueType(currentNode as T)) {
+          treeItemsHierarchy.push(
+            this.createValueTreeItem(
+              currentNode as T,
+              treeItemsHierarchy[
+                treeItemsHierarchy.length - 1
+              ] as FolderTreeItem<T>
+            )
+          );
+        } else {
+          treeItemsHierarchy.push(
+            new FolderTreeItem(
+              currentNode as Folder<T>,
+              part,
+              treeItemsHierarchy[
+                treeItemsHierarchy.length - 1
+              ] as FolderTreeItem<T>
+            )
+          );
+        }
+      } else {
+        // If a part is not found in the tree structure, the given URI is not valid.
+        return [];
+      }
+    }
+
+    return treeItemsHierarchy;
+  }
+
+  findTreeItemByPath(path: string[]): Promise<I> {
+    const hierarchy = this.getTreeItemsHierarchy(path);
+    return hierarchy.length > 0
+      ? Promise.resolve(hierarchy.pop())
+      : Promise.resolve(null);
+  }
+
+  abstract valueToPath(value: T);
+
+  abstract getValues(): T[];
+
+  abstract getFilterFn(): (value: T) => boolean;
+
+  abstract isValueType(value: T): value is T;
+
+  abstract createValueTreeItem(value: T, parent: FolderTreeItem<T>): I;
+}
+
+function sortFolderTreeItems(a: vscode.TreeItem, b: vscode.TreeItem): number {
+  // Both a and b are FolderTreeItem instances
+  if (a instanceof FolderTreeItem && b instanceof FolderTreeItem) {
+    return a.label.toString().localeCompare(b.label.toString());
+  }
+
+  // Only a is a FolderTreeItem instance
+  if (a instanceof FolderTreeItem) {
+    return -1;
+  }
+
+  // Only b is a FolderTreeItem instance
+  if (b instanceof FolderTreeItem) {
+    return 1;
+  }
+
+  return a.label.toString().localeCompare(b.label.toString());
+}

--- a/packages/foam-vscode/src/utils/tree-view-utils.ts
+++ b/packages/foam-vscode/src/utils/tree-view-utils.ts
@@ -76,7 +76,7 @@ export class ResourceTreeItem extends UriTreeItem {
   }
 }
 
-export class ResourceRangeTreeItem extends vscode.TreeItem {
+export class ResourceRangeTreeItem extends BaseTreeItem {
   constructor(
     public label: string,
     public readonly resource: Resource,

--- a/packages/foam-vscode/src/utils/tree-view-utils.ts
+++ b/packages/foam-vscode/src/utils/tree-view-utils.ts
@@ -84,7 +84,6 @@ export class ResourceRangeTreeItem extends vscode.TreeItem {
     public readonly workspace: FoamWorkspace
   ) {
     super(label, vscode.TreeItemCollapsibleState.None);
-    this.label = `${range.start.line}: ${this.label}`;
     this.command = {
       command: 'vscode.open',
       arguments: [toVsCodeUri(resource.uri), { selection: range }],
@@ -122,7 +121,7 @@ export class ResourceRangeTreeItem extends vscode.TreeItem {
     const ellipsis = start === 0 ? '' : '...';
 
     const label = line
-      ? `${range.start.line}: ${ellipsis}${line.slice(start, start + 300)}`
+      ? `${range.start.line + 1}: ${ellipsis}${line.slice(start, start + 300)}`
       : Range.toString(range);
 
     const item = new ResourceRangeTreeItem(label, resource, range, workspace);
@@ -176,13 +175,16 @@ export function createBacklinkItemsForResource(
     .getConnections(uri)
     .filter(c => c.target.asPlain().isEqual(uri));
 
-  const backlinkItems = connections.map(c =>
-    ResourceRangeTreeItem.createStandardItem(
+  const backlinkItems = connections.map(async c => {
+    const item = await ResourceRangeTreeItem.createStandardItem(
       workspace,
       workspace.get(c.source),
       c.link.range,
       'backlink'
-    )
-  );
+    );
+    item.description = item.label;
+    item.label = workspace.get(c.source).title;
+    return item;
+  });
   return Promise.all(backlinkItems);
 }


### PR DESCRIPTION
This PR introduces a new tree view, the notes explorer.

The notes explorer allows the user to see their notes in a tree structure, but centered around note info (e.g. instead of the file name it uses the note title).

It also allows to filter out attachments and images for a less cluttered space.

Finally, each resource tree item includes as children the backlinks to the resource.

Although this feature has been requested in the past, I want to credit to the [Wikilens extensions](https://github.com/lostintangent/wikilens/) for the high level inspiration (and I outright stole the design for the backlink tree item icon, as I find it just perfect)