### PR TITLE
Add FOAM_TITLE_SAFE variable

### DIFF
--- a/docs/user/features/note-templates.md
+++ b/docs/user/features/note-templates.md
@@ -58,6 +58,7 @@ In addition, you can also use variables provided by Foam:
 | -------------------- | ------------ |
 | `FOAM_SELECTED_TEXT` | Foam will fill it with selected text when creating a new note, if any text is selected. Selected text will be replaced with a wikilink to the new     |
 | `FOAM_TITLE`         | The title of the note. If used, Foam will prompt you to enter a title for the note.        |
+| `FOAM_TITLE_SAFE`    | The title of the note in a file system safe format. If used, Foam will prompt you to enter a title for the note unless `FOAM_TITLE` has already caused the prompt.   |
 | `FOAM_SLUG`          | The sluggified title of the note (using the default github slug method). If used, Foam will prompt you to enter a title for the note unless `FOAM_TITLE` has already caused the prompt.   |
 | `FOAM_DATE_*`        | `FOAM_DATE_YEAR`, `FOAM_DATE_MONTH`, `FOAM_DATE_WEEK` etc. Foam-specific versions of [VS Code's datetime snippet variables](https://code.visualstudio.com/docs/editor/userdefinedsnippets#_variables). Prefer these versions over VS Code's. |
 

--- a/packages/foam-vscode/src/features/panels/notes-explorer.ts
+++ b/packages/foam-vscode/src/features/panels/notes-explorer.ts
@@ -160,6 +160,11 @@ export class NotesProvider extends FolderTreeProvider<
       });
       return backlinks;
     };
+    res.description =
+      value.uri.getName().toLocaleLowerCase() ===
+      value.title.toLocaleLowerCase()
+        ? undefined
+        : value.uri.getBasename();
     return res;
   }
 }

--- a/packages/foam-vscode/src/services/templates.ts
+++ b/packages/foam-vscode/src/services/templates.ts
@@ -475,30 +475,7 @@ async function askUserForFilepathConfirmation(
   });
 }
 
-/**
- * Common chars that is better to avoid in file names.
- * Inspired by:
- *   https://www.mtu.edu/umc/services/websites/writing/characters-avoid/
- *   https://stackoverflow.com/questions/1976007/what-characters-are-forbidden-in-windows-and-linux-directory-names
- * Even if some might be allowed in Win or Linux, to keep things more compatible and less error prone
- * we don't allow them
- * Also see https://github.com/foambubble/foam/issues/1042
- */
-const UNALLOWED_CHARS = '/\\#%&{}<>?*$!\'":@+`|=';
-
-/**
- * Uses the title to generate a file path.
- * It sanitizes the title to remove special characters and spaces.
- *
- * @param resolver the resolver to use
- * @returns the string path of the new note
- */
 export const getPathFromTitle = async (resolver: Resolver) => {
-  let defaultName = await resolver.resolveFromName('FOAM_TITLE');
-  UNALLOWED_CHARS.split('').forEach(char => {
-    defaultName = defaultName.split(char).join('');
-  });
-
-  const defaultFilepath = URI.file(`${defaultName}.md`);
-  return defaultFilepath;
+  const defaultName = await resolver.resolveFromName('FOAM_TITLE_SAFE');
+  return URI.file(`${defaultName}.md`);
 };

--- a/packages/foam-vscode/src/services/variable-resolver.spec.ts
+++ b/packages/foam-vscode/src/services/variable-resolver.spec.ts
@@ -102,6 +102,23 @@ describe('variable-resolver, variable resolution', () => {
     expect(await resolver.resolveAll(variables)).toEqual(expected);
   });
 
+  it('should resolve FOAM_TITLE_SAFE', async () => {
+    const foamTitle = 'My/note#title';
+    const variables = [
+      new Variable('FOAM_TITLE'),
+      new Variable('FOAM_TITLE_SAFE'),
+    ];
+
+    const expected = new Map<string, string>();
+    expected.set('FOAM_TITLE', foamTitle);
+    expected.set('FOAM_TITLE_SAFE', 'My-note-title');
+
+    const givenValues = new Map<string, string>();
+    givenValues.set('FOAM_TITLE', foamTitle);
+    const resolver = new Resolver(givenValues, new Date());
+    expect(await resolver.resolveAll(variables)).toEqual(expected);
+  });
+
   it('should resolve FOAM_DATE_* properties with current day by default', async () => {
     const variables = [
       new Variable('FOAM_DATE_YEAR'),


### PR DESCRIPTION
The `FOAM_TITLE_SAFE` variable is the `FOAM_TITLE` variable where all invalid FS characters have been replaced by `-`.
Compared to `FOAM_SLUG`, it's much less aggressive, keeps letter casing, and unless `FOAM_TITLE` has invalid FS characters it will match it.