### PR TITLE
Support for multiple file extensions and default extension

### DIFF
--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -395,15 +395,15 @@
           "default": "pdf mp3 webm wav m4a mp4 avi mov rtf txt doc docx pages xls xlsx numbers ppt pptm pptx",
           "description": "Space separated list of file extensions that will be considered attachments"
         },
-        "foam.files.noteExtensions": {
+        "foam.files.notesExtensions": {
           "type": "string",
-          "default": "md",
-          "description": "Space separated list of file extensions that will be considered markdown notes"
+          "default": "",
+          "description": "Space separated list of file extensions that will be considered markdown notes (e.g. 'mdx md markdown')"
         },
         "foam.files.defaultNoteExtension": {
           "type": "string",
           "default": "md",
-          "description": "The default note extension"
+          "description": "The default extension for new notes"
         },
         "foam.files.newNotePath": {
           "type": "string",

--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -398,7 +398,7 @@
         "foam.files.noteExtensions": {
           "type": "string",
           "default": "md",
-          "description": "Space separated list of file extensions that will be considered markdown notes"
+          "description": "Space separated list of file extensions that will be considered markdown notes.\n *The first extension listed will be used as default for new notes and link resolution*"
         },
         "foam.files.newNotePath": {
           "type": "string",

--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -398,7 +398,12 @@
         "foam.files.noteExtensions": {
           "type": "string",
           "default": "md",
-          "description": "Space separated list of file extensions that will be considered markdown notes.\n *The first extension listed will be used as default for new notes and link resolution*"
+          "description": "Space separated list of file extensions that will be considered markdown notes"
+        },
+        "foam.files.defaultNoteExtension": {
+          "type": "string",
+          "default": "md",
+          "description": "The default note extension"
         },
         "foam.files.newNotePath": {
           "type": "string",

--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -395,6 +395,11 @@
           "default": "pdf mp3 webm wav m4a mp4 avi mov rtf txt doc docx pages xls xlsx numbers ppt pptm pptx",
           "description": "Space separated list of file extensions that will be considered attachments"
         },
+        "foam.files.noteExtensions": {
+          "type": "string",
+          "default": "md",
+          "description": "Space separated list of file extensions that will be considered markdown notes"
+        },
         "foam.files.newNotePath": {
           "type": "string",
           "default": "root",

--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -398,7 +398,7 @@
         "foam.files.notesExtensions": {
           "type": "string",
           "default": "",
-          "description": "Space separated list of file extensions that will be considered markdown notes (e.g. 'mdx md markdown')"
+          "description": "Space separated list of extra file extensions that will be considered text notes (e.g. 'mdx txt markdown')"
         },
         "foam.files.defaultNoteExtension": {
           "type": "string",

--- a/packages/foam-vscode/src/core/model/foam.ts
+++ b/packages/foam-vscode/src/core/model/foam.ts
@@ -25,13 +25,15 @@ export const bootstrap = async (
   watcher: IWatcher | undefined,
   dataStore: IDataStore,
   parser: ResourceParser,
-  initialProviders: ResourceProvider[]
+  initialProviders: ResourceProvider[],
+  defaultExtension: string = '.md'
 ) => {
   const tsStart = Date.now();
 
   const workspace = await FoamWorkspace.fromProviders(
     initialProviders,
-    dataStore
+    dataStore,
+    defaultExtension
   );
 
   const tsWsDone = Date.now();

--- a/packages/foam-vscode/src/core/model/note.ts
+++ b/packages/foam-vscode/src/core/model/note.ts
@@ -66,6 +66,10 @@ export abstract class Resource {
     return a.title.localeCompare(b.title);
   }
 
+  public static sortByPath(a: Resource, b: Resource) {
+    return a.uri.path.localeCompare(b.uri.path);
+  }
+
   public static isResource(thing: any): thing is Resource {
     if (!thing) {
       return false;

--- a/packages/foam-vscode/src/core/model/workspace.test.ts
+++ b/packages/foam-vscode/src/core/model/workspace.test.ts
@@ -107,7 +107,7 @@ describe('Identifier computation', () => {
     const third = createTestNote({
       uri: '/another/path/for/page-a.md',
     });
-    const ws = new FoamWorkspace().set(first).set(second).set(third);
+    const ws = new FoamWorkspace('.md').set(first).set(second).set(third);
 
     expect(ws.getIdentifier(first.uri)).toEqual('to/page-a');
     expect(ws.getIdentifier(second.uri)).toEqual('way/for/page-a');
@@ -124,7 +124,7 @@ describe('Identifier computation', () => {
     const third = createTestNote({
       uri: '/another/path/for/page-a.md',
     });
-    const ws = new FoamWorkspace().set(first).set(second).set(third);
+    const ws = new FoamWorkspace('.md').set(first).set(second).set(third);
 
     expect(ws.getIdentifier(first.uri.withFragment('section name'))).toEqual(
       'to/page-a#section name'
@@ -170,7 +170,7 @@ describe('Identifier computation', () => {
   });
 
   it('should ignore elements from the exclude list', () => {
-    const workspace = new FoamWorkspace();
+    const workspace = new FoamWorkspace('.md');
     const noteA = createTestNote({ uri: '/path/to/note-a.md' });
     const noteB = createTestNote({ uri: '/path/to/note-b.md' });
     const noteC = createTestNote({ uri: '/path/to/note-c.md' });

--- a/packages/foam-vscode/src/core/model/workspace.ts
+++ b/packages/foam-vscode/src/core/model/workspace.ts
@@ -6,10 +6,6 @@ import { Emitter } from '../common/event';
 import { ResourceProvider } from './provider';
 import { IDisposable } from '../common/lifecycle';
 import { IDataStore } from '../services/datastore';
-import { getFoamVsCodeConfig } from '../../services/config';
-
-const defaultExtension =
-  getFoamVsCodeConfig('files.noteExtensions', 'md').split(' ')?.[0] ?? 'md';
 
 export class FoamWorkspace implements IDisposable {
   private onDidAddEmitter = new Emitter<Resource>();
@@ -27,9 +23,9 @@ export class FoamWorkspace implements IDisposable {
   private _resources: Map<string, Resource> = new Map();
 
   /**
-   * The default extension for notes in this workspace (e.g. `.md`)
+   * @param defaultExtension: The default extension for notes in this workspace (e.g. `.md`)
    */
-  public defaultExtension: string = '.' + defaultExtension;
+  constructor(public defaultExtension: string = '.md') {}
 
   registerProvider(provider: ResourceProvider) {
     this.providers.push(provider);
@@ -247,9 +243,10 @@ export class FoamWorkspace implements IDisposable {
 
   static async fromProviders(
     providers: ResourceProvider[],
-    dataStore: IDataStore
+    dataStore: IDataStore,
+    defaultExtension: string = '.md'
   ): Promise<FoamWorkspace> {
-    const workspace = new FoamWorkspace();
+    const workspace = new FoamWorkspace(defaultExtension);
     await Promise.all(providers.map(p => workspace.registerProvider(p)));
     const files = await dataStore.list();
     await Promise.all(files.map(f => workspace.fetchAndSet(f)));

--- a/packages/foam-vscode/src/core/model/workspace.ts
+++ b/packages/foam-vscode/src/core/model/workspace.ts
@@ -75,6 +75,7 @@ export class FoamWorkspace implements IDisposable {
       }
     }
     return resources.sort((a, b) => a.uri.path.localeCompare(b.uri.path));
+    return resources.sort(Resource.sortByPath);
   }
 
   /**

--- a/packages/foam-vscode/src/core/services/attachment-provider.ts
+++ b/packages/foam-vscode/src/core/services/attachment-provider.ts
@@ -3,17 +3,8 @@ import { URI } from '../model/uri';
 import { FoamWorkspace } from '../model/workspace';
 import { IDisposable } from '../common/lifecycle';
 import { ResourceProvider } from '../model/provider';
-import { getFoamVsCodeConfig } from '../../services/config';
-
-const attachmentExtConfig = getFoamVsCodeConfig(
-  'files.attachmentExtensions',
-  ''
-)
-  .split(' ')
-  .map(ext => '.' + ext.trim());
 
 const imageExtensions = ['.png', '.jpg', '.jpeg', '.gif', '.svg', '.webp'];
-const attachmentExtensions = [...attachmentExtConfig, ...imageExtensions];
 
 const asResource = (uri: URI): Resource => {
   const type = imageExtensions.includes(uri.getExtension())
@@ -34,9 +25,14 @@ const asResource = (uri: URI): Resource => {
 
 export class AttachmentResourceProvider implements ResourceProvider {
   private disposables: IDisposable[] = [];
+  public readonly attachmentExtensions: string[];
+
+  constructor(attachmentExtensions: string[] = []) {
+    this.attachmentExtensions = [...imageExtensions, ...attachmentExtensions];
+  }
 
   supports(uri: URI) {
-    return attachmentExtensions.includes(
+    return this.attachmentExtensions.includes(
       uri.getExtension().toLocaleLowerCase()
     );
   }

--- a/packages/foam-vscode/src/core/services/markdown-provider.ts
+++ b/packages/foam-vscode/src/core/services/markdown-provider.ts
@@ -137,7 +137,10 @@ export function createMarkdownReferences(
       }
 
       let relativeUri = target.uri.relativeTo(resource.uri.getDirectory());
-      if (!includeExtension && relativeUri.path.endsWith('.md')) {
+      if (
+        !includeExtension &&
+        relativeUri.path.endsWith(workspace.defaultExtension)
+      ) {
         relativeUri = relativeUri.changeExtension('*', '');
       }
 

--- a/packages/foam-vscode/src/core/services/markdown-provider.ts
+++ b/packages/foam-vscode/src/core/services/markdown-provider.ts
@@ -13,6 +13,14 @@ import { ResourceProvider } from '../model/provider';
 import { MarkdownLink } from './markdown-link';
 import { IDataStore } from './datastore';
 import { uniqBy } from 'lodash';
+import { getFoamVsCodeConfig } from '../../services/config';
+
+const notesExtensions = getFoamVsCodeConfig(
+  'files.noteExtensions',
+  'md markdown'
+)
+  .split(' ')
+  .map(ext => '.' + ext.trim());
 
 export class MarkdownResourceProvider implements ResourceProvider {
   private disposables: IDisposable[] = [];
@@ -23,7 +31,7 @@ export class MarkdownResourceProvider implements ResourceProvider {
   ) {}
 
   supports(uri: URI) {
-    return uri.isMarkdown();
+    return notesExtensions.includes(uri.getExtension());
   }
 
   async readAsMarkdown(uri: URI): Promise<string | null> {

--- a/packages/foam-vscode/src/core/services/markdown-provider.ts
+++ b/packages/foam-vscode/src/core/services/markdown-provider.ts
@@ -13,25 +13,18 @@ import { ResourceProvider } from '../model/provider';
 import { MarkdownLink } from './markdown-link';
 import { IDataStore } from './datastore';
 import { uniqBy } from 'lodash';
-import { getFoamVsCodeConfig } from '../../services/config';
-
-const notesExtensions = getFoamVsCodeConfig(
-  'files.noteExtensions',
-  'md markdown'
-)
-  .split(' ')
-  .map(ext => '.' + ext.trim());
 
 export class MarkdownResourceProvider implements ResourceProvider {
   private disposables: IDisposable[] = [];
 
   constructor(
     private readonly dataStore: IDataStore,
-    private readonly parser: ResourceParser
+    private readonly parser: ResourceParser,
+    public readonly noteExtensions: string[] = ['.md']
   ) {}
 
   supports(uri: URI) {
-    return notesExtensions.includes(uri.getExtension());
+    return this.noteExtensions.includes(uri.getExtension());
   }
 
   async readAsMarkdown(uri: URI): Promise<string | null> {

--- a/packages/foam-vscode/src/extension.ts
+++ b/packages/foam-vscode/src/extension.ts
@@ -7,7 +7,11 @@ import { Logger } from './core/utils/log';
 
 import { features } from './features';
 import { VsCodeOutputLogger, exposeLogger } from './services/logging';
-import { getIgnoredFilesSetting, getNotesExtensions } from './settings';
+import {
+  getAttachmentsExtensions,
+  getIgnoredFilesSetting,
+  getNotesExtensions,
+} from './settings';
 import { AttachmentResourceProvider } from './core/services/attachment-provider';
 import { VsCodeWatcher } from './services/watcher';
 import { createMarkdownParser } from './core/services/markdown-parser';
@@ -54,12 +58,7 @@ export async function activate(context: ExtensionContext) {
       notesExtensions
     );
 
-    const attachmentExtConfig = getFoamVsCodeConfig(
-      'files.attachmentExtensions',
-      ''
-    )
-      .split(' ')
-      .map(ext => '.' + ext.trim());
+    const attachmentExtConfig = getAttachmentsExtensions();
     const attachmentProvider = new AttachmentResourceProvider(
       attachmentExtConfig
     );

--- a/packages/foam-vscode/src/extension.ts
+++ b/packages/foam-vscode/src/extension.ts
@@ -59,7 +59,16 @@ export async function activate(context: ExtensionContext) {
       parser,
       notesExtensions
     );
-    const attachmentProvider = new AttachmentResourceProvider();
+
+    const attachmentExtConfig = getFoamVsCodeConfig(
+      'files.attachmentExtensions',
+      ''
+    )
+      .split(' ')
+      .map(ext => '.' + ext.trim());
+    const attachmentProvider = new AttachmentResourceProvider(
+      attachmentExtConfig
+    );
 
     const foamPromise = bootstrap(
       matcher,

--- a/packages/foam-vscode/src/features/commands/create-note.spec.ts
+++ b/packages/foam-vscode/src/features/commands/create-note.spec.ts
@@ -194,7 +194,10 @@ describe('factories', () => {
   describe('forPlaceholder', () => {
     it('adds the .md extension to notes created for placeholders', async () => {
       await closeEditors();
-      const command = CREATE_NOTE_COMMAND.forPlaceholder('my-placeholder');
+      const command = CREATE_NOTE_COMMAND.forPlaceholder(
+        'my-placeholder',
+        '.md'
+      );
       await commands.executeCommand(command.name, command.params);
 
       const doc = window.activeTextEditor.document;

--- a/packages/foam-vscode/src/features/commands/create-note.ts
+++ b/packages/foam-vscode/src/features/commands/create-note.ts
@@ -114,16 +114,27 @@ async function createNote(args: CreateNoteArgs) {
 export const CREATE_NOTE_COMMAND = {
   command: 'foam-vscode.create-note',
 
+  /**
+   * Creates a command descriptor to create a note from the given placeholder.
+   *
+   * @param placeholder the placeholder
+   * @param defaultExtension the default extension (e.g. '.md')
+   * @param extra extra command arguments
+   * @returns the command descriptor
+   */
   forPlaceholder: (
     placeholder: string,
+    defaultExtension: string,
     extra: Partial<CreateNoteArgs> = {}
   ): CommandDescriptor<CreateNoteArgs> => {
-    const title = placeholder.endsWith('.md')
-      ? placeholder.replace(/\.md$/, '')
+    const endsWithDefaultExtension = new RegExp(defaultExtension + '$');
+
+    const title = placeholder.endsWith(defaultExtension)
+      ? placeholder.replace(endsWithDefaultExtension, '')
       : placeholder;
-    const notePath = placeholder.endsWith('.md')
+    const notePath = placeholder.endsWith(defaultExtension)
       ? placeholder
-      : placeholder + '.md';
+      : placeholder + defaultExtension;
     return {
       name: CREATE_NOTE_COMMAND.command,
       params: {

--- a/packages/foam-vscode/src/features/hover-provider.ts
+++ b/packages/foam-vscode/src/features/hover-provider.ts
@@ -106,10 +106,14 @@ export class HoverProvider implements vscode.HoverProvider {
         : this.workspace.get(targetUri).title;
     }
 
-    const command = CREATE_NOTE_COMMAND.forPlaceholder(targetUri.path, {
-      askForTemplate: true,
-      onFileExists: 'open',
-    });
+    const command = CREATE_NOTE_COMMAND.forPlaceholder(
+      targetUri.path,
+      this.workspace.defaultExtension,
+      {
+        askForTemplate: true,
+        onFileExists: 'open',
+      }
+    );
     const newNoteFromTemplate = new vscode.MarkdownString(
       `[Create note from template for '${targetUri.getBasename()}'](${commandAsURI(
         command

--- a/packages/foam-vscode/src/features/navigation-provider.spec.ts
+++ b/packages/foam-vscode/src/features/navigation-provider.spec.ts
@@ -83,7 +83,7 @@ describe('Document navigation', () => {
       expect(links.length).toEqual(1);
       expect(links[0].target).toEqual(
         commandAsURI(
-          CREATE_NOTE_COMMAND.forPlaceholder('a placeholder', {
+          CREATE_NOTE_COMMAND.forPlaceholder('a placeholder', '.md', {
             onFileExists: 'open',
           })
         )

--- a/packages/foam-vscode/src/features/navigation-provider.ts
+++ b/packages/foam-vscode/src/features/navigation-provider.ts
@@ -161,9 +161,13 @@ export class NavigationProvider
     return targets
       .filter(o => o.target.isPlaceholder()) // links to resources are managed by the definition provider
       .map(o => {
-        const command = CREATE_NOTE_COMMAND.forPlaceholder(o.target.path, {
-          onFileExists: 'open',
-        });
+        const command = CREATE_NOTE_COMMAND.forPlaceholder(
+          o.target.path,
+          this.workspace.defaultExtension,
+          {
+            onFileExists: 'open',
+          }
+        );
 
         const documentLink = new vscode.DocumentLink(
           new vscode.Range(

--- a/packages/foam-vscode/src/settings.spec.ts
+++ b/packages/foam-vscode/src/settings.spec.ts
@@ -22,7 +22,7 @@ describe('Default note settings', () => {
           async () => {
             const { notesExtensions } = getNotesExtensions();
             expect(notesExtensions).toEqual(
-              expect.arrayContaining(['.mdxx', 'md', 'markdown'])
+              expect.arrayContaining(['.mdxx', '.md', '.markdown'])
             );
           }
         );

--- a/packages/foam-vscode/src/settings.spec.ts
+++ b/packages/foam-vscode/src/settings.spec.ts
@@ -1,0 +1,21 @@
+import { getNotesExtensions } from './settings';
+import { withModifiedFoamConfiguration } from './test/test-utils-vscode';
+
+describe('Default note settings', () => {
+  it('should default to md', async () => {
+    const config = getNotesExtensions();
+    expect(config.defaultExtension).toEqual('.md');
+    expect(config.notesExtensions).toEqual(['.md']);
+  });
+
+  it('should always include the default note extension in the list of notes extensions', async () => {
+    withModifiedFoamConfiguration(
+      'files.defaultNoteExtension',
+      'mdxx',
+      async () => {
+        const { notesExtensions } = getNotesExtensions();
+        expect(notesExtensions).toEqual(['.md', '.mdxx']);
+      }
+    );
+  });
+});

--- a/packages/foam-vscode/src/settings.spec.ts
+++ b/packages/foam-vscode/src/settings.spec.ts
@@ -2,7 +2,7 @@ import { getNotesExtensions } from './settings';
 import { withModifiedFoamConfiguration } from './test/test-utils-vscode';
 
 describe('Default note settings', () => {
-  it('should default to md', async () => {
+  it('should default to .md', async () => {
     const config = getNotesExtensions();
     expect(config.defaultExtension).toEqual('.md');
     expect(config.notesExtensions).toEqual(['.md']);
@@ -14,7 +14,18 @@ describe('Default note settings', () => {
       'mdxx',
       async () => {
         const { notesExtensions } = getNotesExtensions();
-        expect(notesExtensions).toEqual(['.md', '.mdxx']);
+        expect(notesExtensions).toEqual(['.mdxx']);
+
+        withModifiedFoamConfiguration(
+          'files.notesExtensions',
+          'md markdown',
+          async () => {
+            const { notesExtensions } = getNotesExtensions();
+            expect(notesExtensions).toEqual(
+              expect.arrayContaining(['.mdxx', 'md', 'markdown'])
+            );
+          }
+        );
       }
     );
   });

--- a/packages/foam-vscode/src/settings.ts
+++ b/packages/foam-vscode/src/settings.ts
@@ -1,5 +1,5 @@
 import { workspace, GlobPattern } from 'vscode';
-import _ from 'lodash';
+import { uniq } from 'lodash';
 import { LogLevel } from './core/utils/log';
 import { getFoamVsCodeConfig } from './services/config';
 
@@ -10,8 +10,8 @@ import { getFoamVsCodeConfig } from './services/config';
  */
 export function getNotesExtensions() {
   const notesExtensionsFromSetting = getFoamVsCodeConfig(
-    'files.noteExtensions',
-    'md'
+    'files.notesExtensions',
+    ''
   )
     .split(' ')
     .map(ext => '.' + ext.trim());
@@ -20,7 +20,7 @@ export function getNotesExtensions() {
     (getFoamVsCodeConfig('files.defaultNoteExtension', 'md') ?? 'md').trim();
 
   // we make sure that the default extension is always included in the list of extensions
-  const notesExtensions = _.uniq(
+  const notesExtensions = uniq(
     notesExtensionsFromSetting.concat(defaultExtension)
   );
 

--- a/packages/foam-vscode/src/settings.ts
+++ b/packages/foam-vscode/src/settings.ts
@@ -28,6 +28,17 @@ export function getNotesExtensions() {
   return { notesExtensions, defaultExtension };
 }
 
+/**
+ * Gets the attachment extensions from the config.
+ *
+ * @returns string[]
+ */
+export function getAttachmentsExtensions() {
+  return getFoamVsCodeConfig('files.attachmentExtensions', '')
+    .split(' ')
+    .map(ext => '.' + ext.trim());
+}
+
 export function getWikilinkDefinitionSetting():
   | 'withExtensions'
   | 'withoutExtensions'

--- a/packages/foam-vscode/src/settings.ts
+++ b/packages/foam-vscode/src/settings.ts
@@ -14,6 +14,7 @@ export function getNotesExtensions() {
     ''
   )
     .split(' ')
+    .filter(ext => ext.trim() !== '')
     .map(ext => '.' + ext.trim());
   const defaultExtension =
     '.' +

--- a/packages/foam-vscode/src/settings.ts
+++ b/packages/foam-vscode/src/settings.ts
@@ -1,5 +1,31 @@
 import { workspace, GlobPattern } from 'vscode';
+import _ from 'lodash';
 import { LogLevel } from './core/utils/log';
+import { getFoamVsCodeConfig } from './services/config';
+
+/**
+ * Gets the notes extensions and default extension from the config.
+ *
+ * @returns {notesExtensions: string[], defaultExtension: string}
+ */
+export function getNotesExtensions() {
+  const notesExtensionsFromSetting = getFoamVsCodeConfig(
+    'files.noteExtensions',
+    'md'
+  )
+    .split(' ')
+    .map(ext => '.' + ext.trim());
+  const defaultExtension =
+    '.' +
+    (getFoamVsCodeConfig('files.defaultNoteExtension', 'md') ?? 'md').trim();
+
+  // we make sure that the default extension is always included in the list of extensions
+  const notesExtensions = _.uniq(
+    notesExtensionsFromSetting.concat(defaultExtension)
+  );
+
+  return { notesExtensions, defaultExtension };
+}
 
 export function getWikilinkDefinitionSetting():
   | 'withExtensions'


### PR DESCRIPTION
Fixes #924 and #1129

Introducing the `foam.files.noteExtensions` property, which tells Foam what extensions to treat as (markdown) text notes.

The first extension from the list will be treated as the default extension.

The default extension is the one assumed when a `[[wikilink]]` doesn't include an extension, and is also the one used when creating notes from a `[[placeholder]]`

Still debating whether the default extension should be an explicit property or the first one from the list of extensions. Leaving for the first in terms of clarity, but I like the second as it enforces consistency (i.e. you can't have a default extension that is not part of the allowed extensions) and avoids extra configuration