### PR TITLE
Add last week's notes to snippet provider

### DIFF
--- a/packages/foam-vscode/src/features/date-snippets.ts
+++ b/packages/foam-vscode/src/features/date-snippets.ts
@@ -38,21 +38,42 @@ const daysOfWeek = [
 ];
 
 const generateDayOfWeekSnippets = (): DateSnippet[] => {
-  const getTarget = (day: number) => {
+  const getFutureTarget = (day: number) => {
     const target = new Date();
     const currentDay = target.getDay();
     const distance = (day + 7 - currentDay) % 7;
     target.setDate(target.getDate() + distance);
     return target;
   };
+  // needs work
+  const getPastTarget = (day: number) => {
+    const target = new Date();
+    const currentDay = target.getDay();
+    const distance = currentDay === day ? 7 : (7 + currentDay - day) % 7;
+    target.setDate(target.getDate() - distance);
+    return target;
+  };
+
   const snippets = daysOfWeek.map(({ day, index }) => {
-    const target = getTarget(index);
+    const target = getFutureTarget(index);
     return {
       date: target,
       detail: `Get a daily note link for ${day}`,
       snippet: `/${day}`,
     };
   });
+
+  // append snippets previous days
+  snippets.push(
+    ...daysOfWeek.map(({ day, index }) => {
+      const target = getPastTarget(index);
+      return {
+        date: target,
+        detail: `Get a daily note link for last ${day}`,
+        snippet: `/-${day}`,
+      };
+    })
+  );
   return snippets;
 };
 


### PR DESCRIPTION
This is a speculative PR, feel free to disregard if it doesn't fit the product direction.

I often make references to daily notes _in the past_ to create basically a double-linked list of my notes. 

This PR adds shortcuts for _last_ week's notes:

* `/-monday` -- last monday
* `/-tuesday` -- last tuesday

![image](https://github.com/foambubble/foam/assets/430293/cdd0a269-82ce-48d4-86dd-e060982f4152)

etc.

If there's a good `.test` file for me to add unit tests, let me know where those should live.