### PR TITLE
Tags explorer improvements

### DIFF
--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -143,6 +143,16 @@
           "group": "navigation"
         },
         {
+          "command": "foam-vscode.views.tags-explorer.group-by:folder",
+          "when": "view == foam-vscode.tags-explorer && foam-vscode.views.tags-explorer.group-by == 'off'",
+          "group": "navigation"
+        },
+        {
+          "command": "foam-vscode.views.tags-explorer.group-by:off",
+          "when": "view == foam-vscode.tags-explorer && foam-vscode.views.tags-explorer.group-by == 'folder'",
+          "group": "navigation"
+        },
+        {
           "command": "foam-vscode.views.placeholders.show:for-current-file",
           "when": "view == foam-vscode.placeholders && foam-vscode.views.placeholders.show == 'all'",
           "group": "navigation"
@@ -208,6 +218,22 @@
         },
         {
           "command": "foam-vscode.views.tags-explorer.show:all",
+          "when": "false"
+        },
+        {
+          "command": "foam-vscode.views.tags-explorer.group-by:folder",
+          "when": "false"
+        },
+        {
+          "command": "foam-vscode.views.tags-explorer.group-by:off",
+          "when": "false"
+        },
+        {
+          "command": "foam-vscode.views.tags-explorer.group-by:folder",
+          "when": "false"
+        },
+        {
+          "command": "foam-vscode.views.tags-explorer.group-by:off",
           "when": "false"
         },
         {
@@ -335,6 +361,16 @@
         "command": "foam-vscode.views.tags-explorer.show:all",
         "title": "Show tags in workspace",
         "icon": "$(files)"
+      },
+      {
+        "command": "foam-vscode.views.tags-explorer.group-by:folder",
+        "title": "Group By Folder",
+        "icon": "$(list-tree)"
+      },
+      {
+        "command": "foam-vscode.views.tags-explorer.group-by:off",
+        "title": "Flat list",
+        "icon": "$(list-flat)"
       },
       {
         "command": "foam-vscode.views.placeholders.show:for-current-file",

--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -133,6 +133,16 @@
           "group": "navigation"
         },
         {
+          "command": "foam-vscode.views.tags-explorer.show:for-current-file",
+          "when": "view == foam-vscode.tags-explorer && foam-vscode.views.tags-explorer.show == 'all'",
+          "group": "navigation"
+        },
+        {
+          "command": "foam-vscode.views.tags-explorer.show:all",
+          "when": "view == foam-vscode.tags-explorer && foam-vscode.views.tags-explorer.show == 'for-current-file'",
+          "group": "navigation"
+        },
+        {
           "command": "foam-vscode.views.placeholders.show:for-current-file",
           "when": "view == foam-vscode.placeholders && foam-vscode.views.placeholders.show == 'all'",
           "group": "navigation"
@@ -190,6 +200,14 @@
         },
         {
           "command": "foam-vscode.views.orphans.group-by:off",
+          "when": "false"
+        },
+        {
+          "command": "foam-vscode.views.tags-explorer.show:for-current-file",
+          "when": "false"
+        },
+        {
+          "command": "foam-vscode.views.tags-explorer.show:all",
           "when": "false"
         },
         {
@@ -307,6 +325,16 @@
         "command": "foam-vscode.views.orphans.group-by:off",
         "title": "Flat list",
         "icon": "$(list-flat)"
+      },
+      {
+        "command": "foam-vscode.views.tags-explorer.show:for-current-file",
+        "title": "Show tags in current file",
+        "icon": "$(file)"
+      },
+      {
+        "command": "foam-vscode.views.tags-explorer.show:all",
+        "title": "Show tags in workspace",
+        "icon": "$(files)"
       },
       {
         "command": "foam-vscode.views.placeholders.show:for-current-file",

--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -229,14 +229,6 @@
           "when": "false"
         },
         {
-          "command": "foam-vscode.views.tags-explorer.group-by:folder",
-          "when": "false"
-        },
-        {
-          "command": "foam-vscode.views.tags-explorer.group-by:off",
-          "when": "false"
-        },
-        {
           "command": "foam-vscode.views.placeholders.show:for-current-file",
           "when": "false"
         },

--- a/packages/foam-vscode/src/features/panels/notes-explorer.ts
+++ b/packages/foam-vscode/src/features/panels/notes-explorer.ts
@@ -134,10 +134,6 @@ export class NotesProvider extends FolderTreeProvider<
     return parts;
   }
 
-  isValueType(value: Resource): value is Resource {
-    return value.uri != null;
-  }
-
   createValueTreeItem(
     value: Resource,
     parent: FolderTreeItem<Resource>

--- a/packages/foam-vscode/src/features/panels/tags-explorer.spec.ts
+++ b/packages/foam-vscode/src/features/panels/tags-explorer.spec.ts
@@ -96,7 +96,7 @@ describe('Tags tree panel', () => {
         expect(child.label).not.toEqual('parent');
       }
     });
-    expect(childTreeItems).toHaveLength(3);
+    expect(childTreeItems).toHaveLength(2);
   });
 
   it('handles a parent and child tag in the same note', async () => {
@@ -135,7 +135,7 @@ describe('Tags tree panel', () => {
         expect(item.label).toEqual('subtopic');
       });
 
-    expect(childTreeItems).toHaveLength(3);
+    expect(childTreeItems).toHaveLength(2);
   });
 
   it('handles a tag with multiple levels of hierarchy - #1134', async () => {
@@ -157,16 +157,14 @@ describe('Tags tree panel', () => {
       parentTagItem
     )) as TagItem[];
 
-    expect(childTreeItems).toHaveLength(2);
-    expect(childTreeItems[0].label).toMatch(/^Search.*/);
-    expect(childTreeItems[1].label).toEqual('child');
+    expect(childTreeItems).toHaveLength(1);
+    expect(childTreeItems[0].label).toEqual('child');
 
     const grandchildTreeItems = (await provider.getChildren(
-      childTreeItems[1]
+      childTreeItems[0]
     )) as TagItem[];
 
-    expect(grandchildTreeItems).toHaveLength(2);
-    expect(grandchildTreeItems[0].label).toMatch(/^Search.*/);
-    expect(grandchildTreeItems[1].label).toEqual('second');
+    expect(grandchildTreeItems).toHaveLength(1);
+    expect(grandchildTreeItems[0].label).toEqual('second');
   });
 });

--- a/packages/foam-vscode/src/features/panels/tags-explorer.spec.ts
+++ b/packages/foam-vscode/src/features/panels/tags-explorer.spec.ts
@@ -25,7 +25,7 @@ describe('Tags tree panel', () => {
     });
     const workspace = new FoamWorkspace().set(noteA);
     const foamTags = FoamTags.fromWorkspace(workspace);
-    const provider = new TagsProvider(foamTags, workspace);
+    const provider = new TagsProvider(foamTags, workspace, false);
     provider.refresh();
 
     const treeItems = (await provider.getChildren()) as TagItem[];
@@ -43,7 +43,7 @@ describe('Tags tree panel', () => {
     });
     const workspace = new FoamWorkspace().set(noteA);
     const foamTags = FoamTags.fromWorkspace(workspace);
-    const provider = new TagsProvider(foamTags, workspace);
+    const provider = new TagsProvider(foamTags, workspace, false);
     provider.refresh();
 
     const parentTreeItems = (await provider.getChildren()) as TagItem[];
@@ -73,7 +73,7 @@ describe('Tags tree panel', () => {
     });
     const workspace = new FoamWorkspace().set(noteA).set(noteB);
     const foamTags = FoamTags.fromWorkspace(workspace);
-    const provider = new TagsProvider(foamTags, workspace);
+    const provider = new TagsProvider(foamTags, workspace, false);
     provider.refresh();
 
     const parentTreeItems = (await provider.getChildren()) as TagItem[];
@@ -107,7 +107,7 @@ describe('Tags tree panel', () => {
     });
     const workspace = new FoamWorkspace().set(noteC);
     const foamTags = FoamTags.fromWorkspace(workspace);
-    const provider = new TagsProvider(foamTags, workspace);
+    const provider = new TagsProvider(foamTags, workspace, false);
 
     provider.refresh();
 
@@ -145,7 +145,7 @@ describe('Tags tree panel', () => {
     });
     const workspace = new FoamWorkspace().set(noteA);
     const foamTags = FoamTags.fromWorkspace(workspace);
-    const provider = new TagsProvider(foamTags, workspace);
+    const provider = new TagsProvider(foamTags, workspace, false);
 
     provider.refresh();
 

--- a/packages/foam-vscode/src/features/panels/tags-explorer.spec.ts
+++ b/packages/foam-vscode/src/features/panels/tags-explorer.spec.ts
@@ -48,7 +48,7 @@ describe('Tags tree panel', () => {
 
     const parentTreeItems = (await provider.getChildren()) as TagItem[];
     const parentTagItem = parentTreeItems.pop();
-    expect(parentTagItem.title).toEqual('parent');
+    expect(parentTagItem.label).toEqual('parent');
 
     const childTreeItems = (await provider.getChildren(
       parentTagItem
@@ -57,7 +57,7 @@ describe('Tags tree panel', () => {
     childTreeItems.forEach(child => {
       if (child instanceof TagItem) {
         // eslint-disable-next-line jest/no-conditional-expect
-        expect(child.title).toEqual('child');
+        expect(child.label).toEqual('child');
       }
     });
   });
@@ -81,7 +81,7 @@ describe('Tags tree panel', () => {
       item => item instanceof TagItem
     )[0];
 
-    expect(parentTagItem.title).toEqual('parent');
+    expect(parentTagItem.label).toEqual('parent');
     expect(parentTreeItems).toHaveLength(1);
 
     const childTreeItems = (await provider.getChildren(
@@ -91,9 +91,9 @@ describe('Tags tree panel', () => {
     childTreeItems.forEach(child => {
       if (child instanceof TagItem) {
         // eslint-disable-next-line jest/no-conditional-expect
-        expect(['child', 'subchild']).toContain(child.title);
+        expect(['child', 'subchild']).toContain(child.label);
         // eslint-disable-next-line jest/no-conditional-expect
-        expect(child.title).not.toEqual('parent');
+        expect(child.label).not.toEqual('parent');
       }
     });
     expect(childTreeItems).toHaveLength(3);
@@ -116,7 +116,7 @@ describe('Tags tree panel', () => {
       item => item instanceof TagItem
     )[0];
 
-    expect(parentTagItem.title).toEqual('main');
+    expect(parentTagItem.label).toEqual('main');
 
     const childTreeItems = (await provider.getChildren(
       parentTagItem
@@ -132,7 +132,7 @@ describe('Tags tree panel', () => {
       .filter(item => item instanceof TagItem)
       .forEach(item => {
         expect(['main/subtopic']).toContain(item.tag);
-        expect(item.title).toEqual('subtopic');
+        expect(item.label).toEqual('subtopic');
       });
 
     expect(childTreeItems).toHaveLength(3);
@@ -151,7 +151,7 @@ describe('Tags tree panel', () => {
 
     const parentTreeItems = (await provider.getChildren()) as TagItem[];
     const parentTagItem = parentTreeItems.pop();
-    expect(parentTagItem.title).toEqual('parent');
+    expect(parentTagItem.label).toEqual('parent');
 
     const childTreeItems = (await provider.getChildren(
       parentTagItem

--- a/packages/foam-vscode/src/features/panels/tags-explorer.ts
+++ b/packages/foam-vscode/src/features/panels/tags-explorer.ts
@@ -118,62 +118,6 @@ export class TagsProvider extends FolderTreeProvider<TagTreeItem, string> {
 
     return [...subtags, ...resources];
   }
-
-  //   async getChildren2(element?: TagItem): Promise<TagTreeItem[]> {
-  //     if ((element as any)?.getChildren) {
-  //       const children = await (element as any).getChildren();
-  //       return children;
-  //     }
-  //     const parentTag = element ? element.tag : '';
-  //     const parentPrefix = element ? parentTag + TAG_SEPARATOR : '';
-
-  //     const tagsAtThisLevel = this.tags
-  //       .filter(({ tag }) => tag.startsWith(parentPrefix))
-  //       .map(({ tag }) => {
-  //         const nextSeparator = tag.indexOf(TAG_SEPARATOR, parentPrefix.length);
-  //         const label =
-  //           nextSeparator > -1
-  //             ? tag.substring(parentPrefix.length, nextSeparator)
-  //             : tag.substring(parentPrefix.length);
-  //         const tagId = parentPrefix + label;
-  //         return { label, tagId, tag };
-  //       })
-  //       .reduce((acc, { label, tagId, tag }) => {
-  //         const existing = acc.has(label);
-  //         const nResources = this.foamTags.tags.get(tag).length ?? 0;
-  //         if (!existing) {
-  //           acc.set(label, { label, tagId, nResources: 0 });
-  //         }
-  //         acc.get(label).nResources += nResources;
-  //         return acc;
-  //       }, new Map() as Map<string, { label: string; tagId: string; nResources: number }>);
-
-  //     const subtags = Array.from(tagsAtThisLevel.values())
-  //       .map(({ label, tagId, nResources }) => {
-  //         const resources = this.foamTags.tags.get(tagId) ?? [];
-  //         return new TagItem(tagId, label, nResources, resources);
-  //       })
-  //       .sort((a, b) => a.title.localeCompare(b.title));
-
-  //     const resourceTags: ResourceRangeTreeItem[] = (element?.notes ?? [])
-  //       .map(uri => this.workspace.get(uri))
-  //       .reduce((acc, note) => {
-  //         const tags = note.tags.filter(t => t.label === element.tag);
-  //         const items = tags.map(t =>
-  //           ResourceRangeTreeItem.createStandardItem(
-  //             this.workspace,
-  //             note,
-  //             t.range,
-  //             'tag'
-  //           )
-  //         );
-  //         return [...acc, ...items];
-  //       }, []);
-
-  //     const resources = await groupRangesByResource(this.workspace, resourceTags);
-
-  //     return Promise.resolve([...subtags, ...resources].filter(Boolean));
-  //   }
 }
 
 type TagTreeItem = TagItem | ResourceTreeItem | ResourceRangeTreeItem;

--- a/packages/foam-vscode/src/features/panels/tags-explorer.ts
+++ b/packages/foam-vscode/src/features/panels/tags-explorer.ts
@@ -124,9 +124,7 @@ export class TagsProvider extends FolderTreeProvider<TagTreeItem, string> {
   }
 
   valueToPath(value: string) {
-    return this.groupBy.get() === 'folder'
-      ? value.split(TAG_SEPARATOR)
-      : [value];
+    return this.groupBy.get() === 'off' ? [value] : value.split(TAG_SEPARATOR);
   }
 
   private countResourcesInSubtree(node: Folder<string>) {

--- a/packages/foam-vscode/src/features/panels/tags-explorer.ts
+++ b/packages/foam-vscode/src/features/panels/tags-explorer.ts
@@ -8,6 +8,12 @@ import {
   ResourceTreeItem,
   groupRangesByResource,
 } from './utils/tree-view-utils';
+import {
+  Folder,
+  FolderTreeItem,
+  FolderTreeProvider,
+  walk,
+} from './utils/folder-tree-provider';
 
 const TAG_SEPARATOR = '/';
 export default async function activate(
@@ -20,9 +26,9 @@ export default async function activate(
     treeDataProvider: provider,
     showCollapseAll: true,
   });
+  provider.refresh();
   const baseTitle = treeView.title;
   treeView.title = baseTitle + ` (${foam.tags.tags.size})`;
-
   context.subscriptions.push(
     treeView,
     foam.tags.onDidUpdate(() => {
@@ -32,40 +38,54 @@ export default async function activate(
   );
 }
 
-export class TagsProvider implements vscode.TreeDataProvider<TagTreeItem> {
-  // prettier-ignore
-  private _onDidChangeTreeData: vscode.EventEmitter<
-    TagTreeItem | undefined | void
-  > = new vscode.EventEmitter<TagTreeItem | undefined | void>();
-  // prettier-ignore
-  readonly onDidChangeTreeData: vscode.Event<TagTreeItem | undefined | void> =
-    this._onDidChangeTreeData.event;
-
+export class TagsProvider extends FolderTreeProvider<TagTreeItem, string> {
   private tags: {
     tag: string;
     notes: URI[];
   }[];
 
-  private foamTags: FoamTags;
-
-  constructor(tags: FoamTags, private workspace: FoamWorkspace) {
-    this.foamTags = tags;
-    this.computeTags();
+  constructor(private foamTags: FoamTags, private workspace: FoamWorkspace) {
+    super();
   }
 
   refresh(): void {
-    this.computeTags();
-    this._onDidChangeTreeData.fire();
-  }
-
-  private computeTags() {
     this.tags = [...this.foamTags.tags]
       .map(([tag, notes]) => ({ tag, notes }))
       .sort((a, b) => a.tag.localeCompare(b.tag));
+    super.refresh();
   }
 
-  getTreeItem(element: TagTreeItem): vscode.TreeItem {
-    return element;
+  getValues(): string[] {
+    return Array.from(this.tags.values()).map(tag => tag.tag);
+  }
+
+  valueToPath(value: string) {
+    return value.split(TAG_SEPARATOR);
+  }
+
+  createFolderTreeItem(
+    node: Folder<string>,
+    name: string,
+    parent: FolderTreeItem<string>
+  ): FolderTreeItem<string> {
+    const nChildren = walk(
+      node,
+      tag => this.foamTags.tags.get(tag)?.length ?? 0
+    ).reduce((acc, nResources) => acc + nResources, 0);
+    return new TagItem(node, name, name, name, nChildren, [], parent);
+  }
+
+  createValueTreeItem(
+    value: string,
+    parent: FolderTreeItem<string>,
+    node: Folder<string>
+  ): TagItem {
+    const nChildren = walk(
+      node,
+      tag => this.foamTags.tags.get(tag)?.length ?? 0
+    ).reduce((acc, nResources) => acc + nResources, 0);
+    const resources = this.foamTags.tags.get(value) ?? [];
+    return new TagItem(node, value, value, value, nChildren, resources, parent);
   }
 
   async getChildren(element?: TagItem): Promise<TagTreeItem[]> {
@@ -73,36 +93,8 @@ export class TagsProvider implements vscode.TreeDataProvider<TagTreeItem> {
       const children = await (element as any).getChildren();
       return children;
     }
-    const parentTag = element ? element.tag : '';
-    const parentPrefix = element ? parentTag + TAG_SEPARATOR : '';
-
-    const tagsAtThisLevel = this.tags
-      .filter(({ tag }) => tag.startsWith(parentPrefix))
-      .map(({ tag }) => {
-        const nextSeparator = tag.indexOf(TAG_SEPARATOR, parentPrefix.length);
-        const label =
-          nextSeparator > -1
-            ? tag.substring(parentPrefix.length, nextSeparator)
-            : tag.substring(parentPrefix.length);
-        const tagId = parentPrefix + label;
-        return { label, tagId, tag };
-      })
-      .reduce((acc, { label, tagId, tag }) => {
-        const existing = acc.has(label);
-        const nResources = this.foamTags.tags.get(tag).length ?? 0;
-        if (!existing) {
-          acc.set(label, { label, tagId, nResources: 0 });
-        }
-        acc.get(label).nResources += nResources;
-        return acc;
-      }, new Map() as Map<string, { label: string; tagId: string; nResources: number }>);
-
-    const subtags = Array.from(tagsAtThisLevel.values())
-      .map(({ label, tagId, nResources }) => {
-        const resources = this.foamTags.tags.get(tagId) ?? [];
-        return new TagItem(tagId, label, nResources, resources);
-      })
-      .sort((a, b) => a.title.localeCompare(b.title));
+    // This is managed by the FolderTreeProvider
+    const subtags = await super.getChildren(element);
 
     const resourceTags: ResourceRangeTreeItem[] = (element?.notes ?? [])
       .map(uri => this.workspace.get(uri))
@@ -121,38 +113,79 @@ export class TagsProvider implements vscode.TreeDataProvider<TagTreeItem> {
 
     const resources = await groupRangesByResource(this.workspace, resourceTags);
 
-    return Promise.resolve(
-      [element && new TagSearch(element.tag), ...subtags, ...resources].filter(
-        Boolean
-      )
-    );
+    return [...subtags, ...resources];
   }
 
-  async resolveTreeItem(item: TagTreeItem): Promise<TagTreeItem> {
-    if (
-      item instanceof ResourceTreeItem ||
-      item instanceof ResourceRangeTreeItem
-    ) {
-      return item.resolveTreeItem();
-    }
-    return Promise.resolve(item);
-  }
+  //   async getChildren2(element?: TagItem): Promise<TagTreeItem[]> {
+  //     if ((element as any)?.getChildren) {
+  //       const children = await (element as any).getChildren();
+  //       return children;
+  //     }
+  //     const parentTag = element ? element.tag : '';
+  //     const parentPrefix = element ? parentTag + TAG_SEPARATOR : '';
+
+  //     const tagsAtThisLevel = this.tags
+  //       .filter(({ tag }) => tag.startsWith(parentPrefix))
+  //       .map(({ tag }) => {
+  //         const nextSeparator = tag.indexOf(TAG_SEPARATOR, parentPrefix.length);
+  //         const label =
+  //           nextSeparator > -1
+  //             ? tag.substring(parentPrefix.length, nextSeparator)
+  //             : tag.substring(parentPrefix.length);
+  //         const tagId = parentPrefix + label;
+  //         return { label, tagId, tag };
+  //       })
+  //       .reduce((acc, { label, tagId, tag }) => {
+  //         const existing = acc.has(label);
+  //         const nResources = this.foamTags.tags.get(tag).length ?? 0;
+  //         if (!existing) {
+  //           acc.set(label, { label, tagId, nResources: 0 });
+  //         }
+  //         acc.get(label).nResources += nResources;
+  //         return acc;
+  //       }, new Map() as Map<string, { label: string; tagId: string; nResources: number }>);
+
+  //     const subtags = Array.from(tagsAtThisLevel.values())
+  //       .map(({ label, tagId, nResources }) => {
+  //         const resources = this.foamTags.tags.get(tagId) ?? [];
+  //         return new TagItem(tagId, label, nResources, resources);
+  //       })
+  //       .sort((a, b) => a.title.localeCompare(b.title));
+
+  //     const resourceTags: ResourceRangeTreeItem[] = (element?.notes ?? [])
+  //       .map(uri => this.workspace.get(uri))
+  //       .reduce((acc, note) => {
+  //         const tags = note.tags.filter(t => t.label === element.tag);
+  //         const items = tags.map(t =>
+  //           ResourceRangeTreeItem.createStandardItem(
+  //             this.workspace,
+  //             note,
+  //             t.range,
+  //             'tag'
+  //           )
+  //         );
+  //         return [...acc, ...items];
+  //       }, []);
+
+  //     const resources = await groupRangesByResource(this.workspace, resourceTags);
+
+  //     return Promise.resolve([...subtags, ...resources].filter(Boolean));
+  //   }
 }
 
-type TagTreeItem =
-  | TagItem
-  | TagSearch
-  | ResourceTreeItem
-  | ResourceRangeTreeItem;
+type TagTreeItem = TagItem | ResourceTreeItem | ResourceRangeTreeItem;
 
-export class TagItem extends vscode.TreeItem {
+export class TagItem extends FolderTreeItem<string> {
   constructor(
+    public readonly node: Folder<string>,
+    public readonly name: string,
     public readonly tag: string,
     public readonly title: string,
     public readonly nResourcesInSubtree: number,
-    public readonly notes: URI[]
+    public readonly notes: URI[],
+    public readonly parentElement?: FolderTreeItem<string>
   ) {
-    super(title, vscode.TreeItemCollapsibleState.Collapsed);
+    super(node, title, parentElement);
     this.description = `${nResourcesInSubtree} reference${
       nResourcesInSubtree !== 1 ? 's' : ''
     }`;
@@ -160,28 +193,4 @@ export class TagItem extends vscode.TreeItem {
 
   iconPath = new vscode.ThemeIcon('symbol-number');
   contextValue = 'tag';
-}
-
-export class TagSearch extends vscode.TreeItem {
-  public readonly title: string;
-  constructor(public readonly tag: string) {
-    super(`Search #${tag}`, vscode.TreeItemCollapsibleState.None);
-    const searchString = `#${tag}`;
-    this.tooltip = `Search ${searchString} in workspace`;
-    this.command = {
-      command: 'workbench.action.findInFiles',
-      arguments: [
-        {
-          query: searchString,
-          triggerSearch: true,
-          matchWholeWord: true,
-          isCaseSensitive: true,
-        },
-      ],
-      title: 'Search',
-    };
-  }
-
-  iconPath = new vscode.ThemeIcon('search');
-  contextValue = 'tag-search';
 }

--- a/packages/foam-vscode/src/features/panels/tags-explorer.ts
+++ b/packages/foam-vscode/src/features/panels/tags-explorer.ts
@@ -66,8 +66,15 @@ export class TagsProvider extends FolderTreeProvider<TagTreeItem, string> {
     notes: URI[];
   }[];
 
-  constructor(private foamTags: FoamTags, private workspace: FoamWorkspace) {
+  constructor(
+    private foamTags: FoamTags,
+    private workspace: FoamWorkspace,
+    registerCommands: boolean = true
+  ) {
     super();
+    if (!registerCommands) {
+      return;
+    }
     this.disposables.push(
       vscode.commands.registerCommand(
         `foam-vscode.views.${this.providerId}.show:all`,

--- a/packages/foam-vscode/src/features/panels/utils/folder-tree-provider.ts
+++ b/packages/foam-vscode/src/features/panels/utils/folder-tree-provider.ts
@@ -10,6 +10,7 @@ export interface Folder<T> {
     [basename: string]: Folder<T>;
   };
   value?: T;
+  path: string[];
 }
 
 /**
@@ -90,6 +91,7 @@ export abstract class FolderTreeProvider<I, T> extends BaseTreeProvider<I> {
   createTree(values: T[], filterFn: (value: T) => boolean): Folder<T> {
     const root: Folder<T> = {
       children: {},
+      path: [],
     };
 
     for (const r of values) {
@@ -101,10 +103,12 @@ export abstract class FolderTreeProvider<I, T> extends BaseTreeProvider<I> {
           if (index < parts.length - 1) {
             currentNode.children[part] = {
               children: {},
+              path: parts.slice(0, index + 1),
             };
           } else if (filterFn(r)) {
             currentNode.children[part] = {
               children: {},
+              path: parts.slice(0, index + 1),
               value: r,
             };
           }

--- a/packages/foam-vscode/src/features/panels/utils/folder-tree-provider.ts
+++ b/packages/foam-vscode/src/features/panels/utils/folder-tree-provider.ts
@@ -6,7 +6,10 @@ import { BaseTreeItem, ResourceTreeItem } from './tree-view-utils';
  * A folder is a map of basenames to either folders or values (e.g. resources).
  */
 export interface Folder<T> {
-  [basename: string]: Folder<T> | T;
+  children: {
+    [basename: string]: Folder<T>;
+  };
+  value?: T;
 }
 
 /**
@@ -18,7 +21,7 @@ export class FolderTreeItem<T> extends vscode.TreeItem {
   iconPath = new vscode.ThemeIcon('folder');
 
   constructor(
-    public parent: Folder<T>,
+    public node: Folder<T>,
     public name: string,
     public parentElement?: FolderTreeItem<T>
   ) {
@@ -52,11 +55,11 @@ export abstract class FolderTreeProvider<I, T> extends BaseTreeProvider<I> {
   }
 
   createFolderTreeItem(
-    value: Folder<T>,
+    node: Folder<T>,
     name: string,
     parent: FolderTreeItem<T>
   ) {
-    return new FolderTreeItem<T>(value, name, parent);
+    return new FolderTreeItem<T>(node, name, parent);
   }
 
   async getChildren(item?: I): Promise<I[]> {
@@ -64,42 +67,49 @@ export abstract class FolderTreeProvider<I, T> extends BaseTreeProvider<I> {
       return item.getChildren() as Promise<I[]>;
     }
 
-    const parent = (item as any)?.parent ?? this.root;
+    const parent: Folder<T> = (item as any)?.node ?? this.root;
 
-    const children: vscode.TreeItem[] = Object.keys(parent).map(name => {
-      const value = parent[name];
-      if (this.isValueType(value)) {
-        return this.createValueTreeItem(value, undefined);
-      } else {
-        return this.createFolderTreeItem(
-          value,
-          name,
-          item as unknown as FolderTreeItem<T>
-        );
+    const children: vscode.TreeItem[] = Object.keys(parent.children).map(
+      name => {
+        const node = parent.children[name];
+        if (node.value != null) {
+          return this.createValueTreeItem(node.value, undefined);
+        } else {
+          return this.createFolderTreeItem(
+            node,
+            name,
+            item as unknown as FolderTreeItem<T>
+          );
+        }
       }
-    });
+    );
 
     return children.sort((a, b) => sortFolderTreeItems(a, b)) as any;
   }
 
   createTree(values: T[], filterFn: (value: T) => boolean): Folder<T> {
-    const root: Folder<T> = {};
+    const root: Folder<T> = {
+      children: {},
+    };
 
     for (const r of values) {
       const parts = this.valueToPath(r);
       let currentNode: Folder<T> = root;
 
       parts.forEach((part, index) => {
-        if (!currentNode[part]) {
+        if (!currentNode.children[part]) {
           if (index < parts.length - 1) {
-            currentNode[part] = {};
-          } else {
-            if (filterFn(r)) {
-              currentNode[part] = r;
-            }
+            currentNode.children[part] = {
+              children: {},
+            };
+          } else if (filterFn(r)) {
+            currentNode.children[part] = {
+              children: {},
+              value: r,
+            };
           }
         }
-        currentNode = currentNode[part] as Folder<T>;
+        currentNode = currentNode.children[part];
       });
     }
 
@@ -109,15 +119,15 @@ export abstract class FolderTreeProvider<I, T> extends BaseTreeProvider<I> {
 
   getTreeItemsHierarchy(path: string[]): vscode.TreeItem[] {
     const treeItemsHierarchy: vscode.TreeItem[] = [];
-    let currentNode: Folder<T> | T = this.root;
+    let currentNode: Folder<T> = this.root;
 
     for (const part of path) {
-      if (currentNode[part] !== undefined) {
-        currentNode = currentNode[part] as Folder<T> | T;
-        if (this.isValueType(currentNode as T)) {
+      if (currentNode.children[part] !== undefined) {
+        currentNode = currentNode.children[part] as Folder<T>;
+        if (currentNode.value) {
           treeItemsHierarchy.push(
             this.createValueTreeItem(
-              currentNode as T,
+              currentNode.value,
               treeItemsHierarchy[
                 treeItemsHierarchy.length - 1
               ] as FolderTreeItem<T>
@@ -126,7 +136,7 @@ export abstract class FolderTreeProvider<I, T> extends BaseTreeProvider<I> {
         } else {
           treeItemsHierarchy.push(
             new FolderTreeItem(
-              currentNode as Folder<T>,
+              currentNode,
               part,
               treeItemsHierarchy[
                 treeItemsHierarchy.length - 1

--- a/packages/foam-vscode/src/features/panels/utils/folder-tree-provider.ts
+++ b/packages/foam-vscode/src/features/panels/utils/folder-tree-provider.ts
@@ -183,12 +183,6 @@ export abstract class FolderTreeProvider<I, T> extends BaseTreeProvider<I> {
   abstract getValues(): T[];
 
   /**
-   * Returns true if the given value is of the type that should be displayed
-   * as a leaf in the tree. That is, not as a folder.
-   */
-  abstract isValueType(value: T): value is T;
-
-  /**
    * Creates a tree item for the given value.
    */
   abstract createValueTreeItem(value: T, parent: FolderTreeItem<T>): I;

--- a/packages/foam-vscode/src/features/panels/utils/folder-tree-provider.ts
+++ b/packages/foam-vscode/src/features/panels/utils/folder-tree-provider.ts
@@ -198,7 +198,7 @@ export abstract class FolderTreeProvider<I, T> extends BaseTreeProvider<I> {
 }
 
 /**
- * walks the node and perfoms an action on each value
+ * walks the node and performs an action on each value
  * @returns
  */
 export function walk<T, R>(node: Folder<T>, fn: (value: T) => R): R[] {

--- a/packages/foam-vscode/src/features/panels/utils/grouped-resources-tree-data-provider.ts
+++ b/packages/foam-vscode/src/features/panels/utils/grouped-resources-tree-data-provider.ts
@@ -92,10 +92,6 @@ export abstract class GroupedResourcesTreeDataProvider extends FolderTreeProvide
     return uris.filter(uri => this.matcher.isMatch(uri));
   }
 
-  isValueType(value: URI): value is URI {
-    return value instanceof URI;
-  }
-
   createFolderTreeItem(
     value: Folder<URI>,
     name: string,

--- a/packages/foam-vscode/src/features/panels/utils/grouped-resources-tree-data-provider.ts
+++ b/packages/foam-vscode/src/features/panels/utils/grouped-resources-tree-data-provider.ts
@@ -93,13 +93,13 @@ export abstract class GroupedResourcesTreeDataProvider extends FolderTreeProvide
   }
 
   createFolderTreeItem(
-    value: Folder<URI>,
+    node: Folder<URI>,
     name: string,
     parent: FolderTreeItem<URI>
   ) {
-    const item = super.createFolderTreeItem(value, name, parent);
+    const item = super.createFolderTreeItem(node, name, parent);
     item.label = item.label || '(Not Created)';
-    item.description = `(${Object.keys(value).length})`;
+    item.description = `(${Object.keys(node.children).length})`;
     return item;
   }
 

--- a/packages/foam-vscode/src/test/run-tests.ts
+++ b/packages/foam-vscode/src/test/run-tests.ts
@@ -1,4 +1,3 @@
-import rf from 'rimraf';
 import path from 'path';
 import { runTests } from 'vscode-test';
 import { runUnit } from './suite-unit';
@@ -39,10 +38,6 @@ async function main() {
         extensionDevelopmentPath,
         '.test-workspace'
       );
-      // clean test workspace
-      rf.sync(path.join(testWorkspace, '*'));
-      rf.sync(path.join(testWorkspace, '.vscode'));
-      rf.sync(path.join(testWorkspace, '.foam'));
 
       // Download VS Code, unzip it and run the integration test
       await runTests({

--- a/packages/foam-vscode/src/test/suite.ts
+++ b/packages/foam-vscode/src/test/suite.ts
@@ -15,6 +15,8 @@
 process.env.FORCE_COLOR = '1';
 process.env.NODE_ENV = 'test';
 
+import rf from 'rimraf';
+
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { runCLI } from '@jest/core';
 import { cleanWorkspace } from './test-utils-vscode';
@@ -42,6 +44,12 @@ export function run(): Promise<void> {
   // eslint-disable-next-line no-async-promise-executor
   return new Promise(async (resolve, reject) => {
     await cleanWorkspace();
+    const testWorkspace = path.join(__dirname, '..', '..', '.test-workspace');
+
+    // clean test workspace
+    rf.sync(path.join(testWorkspace, '*'));
+    rf.sync(path.join(testWorkspace, '.vscode'));
+    rf.sync(path.join(testWorkspace, '.foam'));
     try {
       const { results } = await runCLI(
         {


### PR DESCRIPTION
Inspired by #1270 I took the chance to rework the tags explorer:

- refactored to use `FolderTreeProvider`
- added support for hierarchical and flat views
- added support for only showing tags in current file
- removed the "Search" option

All in all, it aligns the tags explorer with the other panels.
It also forced a bit of a cleanup in the `Folder` and `FolderTreeProvider` stack. (which requires a small renaming/refactoring, which will be for another PR)