### PR TITLE
Expand all button in tree views

### DIFF
--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -181,6 +181,11 @@
           "command": "foam-vscode.views.notes-explorer.show:all",
           "when": "view == foam-vscode.notes-explorer && foam-vscode.views.notes-explorer.show == 'notes-only'",
           "group": "navigation"
+        },
+        {
+          "command": "foam-vscode.views.notes-explorer.expand-all",
+          "when": "view == foam-vscode.notes-explorer",
+          "group": "navigation"
         }
       ],
       "commandPalette": [
@@ -250,6 +255,10 @@
         },
         {
           "command": "foam-vscode.views.notes-explorer.show:notes",
+          "when": "false"
+        },
+        {
+          "command": "foam-vscode.views.notes-explorer.expand-all",
           "when": "false"
         },
         {
@@ -388,6 +397,11 @@
         "command": "foam-vscode.views.notes-explorer.show:all",
         "title": "Show all resources",
         "icon": "$(files)"
+      },
+      {
+        "command": "foam-vscode.views.notes-explorer.expand-all",
+        "title": "Expand all",
+        "icon": "$(expand-all)"
       },
       {
         "command": "foam-vscode.views.notes-explorer.show:notes",

--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -153,6 +153,11 @@
           "group": "navigation"
         },
         {
+          "command": "foam-vscode.views.tags-explorer.expand-all",
+          "when": "view == foam-vscode.tags-explorer",
+          "group": "navigation"
+        },
+        {
           "command": "foam-vscode.views.placeholders.show:for-current-file",
           "when": "view == foam-vscode.placeholders && foam-vscode.views.placeholders.show == 'all'",
           "group": "navigation"
@@ -236,6 +241,10 @@
         },
         {
           "command": "foam-vscode.views.tags-explorer.group-by:off",
+          "when": "false"
+        },
+        {
+          "command": "foam-vscode.views.tags-explorer.expand-all",
           "when": "false"
         },
         {
@@ -381,6 +390,11 @@
         "command": "foam-vscode.views.tags-explorer.group-by:off",
         "title": "Flat list",
         "icon": "$(list-flat)"
+      },
+      {
+        "command": "foam-vscode.views.tags-explorer.expand-all",
+        "title": "Expand all",
+        "icon": "$(expand-all)"
       },
       {
         "command": "foam-vscode.views.placeholders.show:for-current-file",

--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -173,6 +173,11 @@
           "group": "navigation"
         },
         {
+          "command": "foam-vscode.views.placeholders.expand-all",
+          "when": "view == foam-vscode.placeholders",
+          "group": "navigation"
+        },
+        {
           "command": "foam-vscode.views.notes-explorer.show:notes",
           "when": "view == foam-vscode.notes-explorer && foam-vscode.views.notes-explorer.show == 'all'",
           "group": "navigation"
@@ -247,6 +252,10 @@
         },
         {
           "command": "foam-vscode.views.placeholders.group-by:off",
+          "when": "false"
+        },
+        {
+          "command": "foam-vscode.views.placeholders.expand-all",
           "when": "false"
         },
         {
@@ -392,6 +401,11 @@
         "command": "foam-vscode.views.placeholders.group-by:off",
         "title": "Flat list",
         "icon": "$(list-flat)"
+      },
+      {
+        "command": "foam-vscode.views.placeholders.expand-all",
+        "title": "Expand all",
+        "icon": "$(expand-all)"
       },
       {
         "command": "foam-vscode.views.notes-explorer.show:all",

--- a/packages/foam-vscode/src/features/panels/notes-explorer.ts
+++ b/packages/foam-vscode/src/features/panels/notes-explorer.ts
@@ -144,18 +144,19 @@ export class NotesProvider extends FolderTreeProvider<
     value: Resource,
     parent: FolderTreeItem<Resource>
   ): NotesTreeItems {
-    const res = new ResourceTreeItem(value, this.workspace, {
+    const item = new ResourceTreeItem(value, this.workspace, {
       parent,
       collapsibleState:
         this.graph.getBacklinks(value.uri).length > 0
           ? vscode.TreeItemCollapsibleState.Collapsed
           : vscode.TreeItemCollapsibleState.None,
     });
-    res.getChildren = async () => {
+    item.id = value.uri.toString();
+    item.getChildren = async () => {
       const backlinks = await createBacklinkTreeItemsForResource(
         this.workspace,
         this.graph,
-        res.uri
+        item.uri
       );
       backlinks.forEach(item => {
         item.description = item.label;
@@ -163,11 +164,11 @@ export class NotesProvider extends FolderTreeProvider<
       });
       return backlinks;
     };
-    res.description =
+    item.description =
       value.uri.getName().toLocaleLowerCase() ===
       value.title.toLocaleLowerCase()
         ? undefined
         : value.uri.getBasename();
-    return res;
+    return item;
   }
 }

--- a/packages/foam-vscode/src/features/panels/notes-explorer.ts
+++ b/packages/foam-vscode/src/features/panels/notes-explorer.ts
@@ -5,6 +5,7 @@ import {
   ResourceRangeTreeItem,
   ResourceTreeItem,
   createBacklinkItemsForResource as createBacklinkTreeItemsForResource,
+  expandAll,
 } from './utils/tree-view-utils';
 import { Resource } from '../../core/model/note';
 import { FoamGraph } from '../../core/model/graph';
@@ -60,6 +61,11 @@ export default async function activate(
     foam.graph.onDidUpdate(() => {
       provider.refresh();
     }),
+    vscode.commands.registerCommand(
+      `foam-vscode.views.notes-explorer.expand-all`,
+      (...args) =>
+        expandAll(treeView, provider, node => node.contextValue === 'folder')
+    ),
     vscode.window.onDidChangeActiveTextEditor(revealTextEditorItem),
     treeView.onDidChangeVisibility(revealTextEditorItem)
   );

--- a/packages/foam-vscode/src/features/panels/placeholders.ts
+++ b/packages/foam-vscode/src/features/panels/placeholders.ts
@@ -6,6 +6,7 @@ import { GroupedResourcesTreeDataProvider } from './utils/grouped-resources-tree
 import {
   UriTreeItem,
   createBacklinkItemsForResource,
+  expandAll,
   groupRangesByResource,
 } from './utils/tree-view-utils';
 import { IMatcher } from '../../core/services/datastore';
@@ -47,6 +48,17 @@ export default async function activate(
     provider.onDidChangeTreeData(() => {
       treeView.title = baseTitle + ` (${provider.nValues})`;
     }),
+    vscode.commands.registerCommand(
+      `foam-vscode.views.placeholders.expand-all`,
+      () =>
+        expandAll(
+          treeView,
+          provider,
+          node =>
+            node.contextValue === 'placeholder' ||
+            node.contextValue === 'folder'
+        )
+    ),
     vscode.window.onDidChangeActiveTextEditor(() => {
       if (provider.show.get() === 'for-current-file') {
         provider.refresh();
@@ -92,6 +104,8 @@ export class PlaceholderTreeView extends GroupedResourcesTreeDataProvider {
       parent,
       collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
     });
+    item.contextValue = 'placeholder';
+    item.id = uri.toString();
     item.getChildren = async () => {
       return groupRangesByResource(
         this.workspace,

--- a/packages/foam-vscode/src/features/panels/utils/tree-view-utils.ts
+++ b/packages/foam-vscode/src/features/panels/utils/tree-view-utils.ts
@@ -251,10 +251,12 @@ export async function expandNode<T>(
         expand: true,
       });
     }
-  } catch {
+  } catch (e) {
     const obj = element as any;
     const label = obj.label ?? obj.toString();
-    Logger.warn(`Could not expand element: ${label}`);
+    Logger.warn(
+      `Could not expand element: ${label}. Try setting the ID property of the TreeItem`
+    );
   }
 
   const children = await provider.getChildren(element);


### PR DESCRIPTION
Fixes #1258 

Added an "expand all" button in all the tree views where I think it makes sense to have this possibility.

The main thing to keep in mind in the implementation was that `TreeItems` might need an ID to be properly tracked.