### PR TITLE
Fix #1282: Unexpected cyclic link detected

### DIFF
--- a/packages/foam-vscode/src/features/preview/wikilink-embed.spec.ts
+++ b/packages/foam-vscode/src/features/preview/wikilink-embed.spec.ts
@@ -364,6 +364,27 @@ content-card![[note-e#Section 2]]`);
     );
   });
 
+  it('should render the bare text for an embedded note that is embedding a note that is not found', async () => {
+    const note = await createFile(
+      'This is the text of note A which includes ![[does-not-exist]]',
+      ['note.md']
+    );
+
+    const ws = new FoamWorkspace().set(parser.parse(note.uri, note.content));
+
+    await withModifiedFoamConfiguration(
+      CONFIG_EMBED_NOTE_TYPE,
+      'full-inline',
+      () => {
+        const md = markdownItWikilinkEmbed(MarkdownIt(), ws, parser);
+        expect(md.render(`This is the root node. ![[note]]`)).toMatch(
+          `<p>This is the root node. <p>This is the text of note A which includes ![[does-not-exist]]</p>
+</p>`
+        );
+      }
+    );
+  });
+
   it('should display a warning in case of cyclical inclusions', async () => {
     const noteA = await createFile(
       'This is the text of note A which includes ![[note-b]]',


### PR DESCRIPTION
Fixes #1282 

A note that embeds a note that does not exist is not properly handled. The exception then bubbles up so that the wikilink isn't rendered, but is still in the ref stack (what we use to determine if there's a cyclic link), causing erroneous cyclic link warnings. 

## Testing

Given
![c](https://github.com/foambubble/foam/assets/8953212/9a7a2a01-e4c6-46b8-af2e-be6df5c660c6)

Then
![a](https://github.com/foambubble/foam/assets/8953212/173160cd-f78c-46b7-ac37-b044c7c13b00)

