### PR TITLE
Fix embedded notes not generating proper reference links

### DIFF
--- a/packages/foam-vscode/src/core/services/markdown-provider.test.ts
+++ b/packages/foam-vscode/src/core/services/markdown-provider.test.ts
@@ -316,4 +316,40 @@ describe('Generation of markdown references', () => {
       '../dir3/page-c.md',
     ]);
   });
+
+  it('should generate links for embedded notes that are formatted properly', () => {
+    const workspace = createTestWorkspace();
+    const noteA = createNoteFromMarkdown(
+      'Link to ![[page-b]] and [[page-c]]',
+      '/dir1/page-a.md'
+    );
+    workspace
+      .set(noteA)
+      .set(createNoteFromMarkdown('Content of note B', '/dir2/page-b.md'))
+      .set(createNoteFromMarkdown('Content of note C', '/dir3/page-c.md'));
+
+    const references = createMarkdownReferences(workspace, noteA.uri, true);
+    expect(references.map(r => [r.url, r.label])).toEqual([
+      ['../dir2/page-b.md', 'page-b'],
+      ['../dir3/page-c.md', 'page-c'],
+    ]);
+  });
+
+  it('should not generate links for placeholders', () => {
+    const workspace = createTestWorkspace();
+    const noteA = createNoteFromMarkdown(
+      'Link to ![[page-b]] and [[page-c]] and [[does-not-exist]] and ![[does-not-exist-either]]',
+      '/dir1/page-a.md'
+    );
+    workspace
+      .set(noteA)
+      .set(createNoteFromMarkdown('Content of note B', '/dir2/page-b.md'))
+      .set(createNoteFromMarkdown('Content of note C', '/dir3/page-c.md'));
+
+    const references = createMarkdownReferences(workspace, noteA.uri, true);
+    expect(references.map(r => r.url)).toEqual([
+      '../dir2/page-b.md',
+      '../dir3/page-c.md',
+    ]);
+  });
 });

--- a/packages/foam-vscode/src/core/services/markdown-provider.ts
+++ b/packages/foam-vscode/src/core/services/markdown-provider.ts
@@ -137,12 +137,22 @@ export function createMarkdownReferences(
         relativeUri = relativeUri.changeExtension('*', '');
       }
 
+      let label = link.rawText;
+      if (link.rawText.indexOf('[[') > -1) {
+        if (link.isEmbed) {
+          // ![[embedded-note]]
+          label = link.rawText.substring(3, link.rawText.length - 2);
+        } else {
+          // [[standard-note]]
+          label = link.rawText.substring(2, link.rawText.length - 2);
+        }
+      } else {
+        label = link.rawText;
+      }
+
       // [wikilink-text]: path/to/file.md "Page title"
       return {
-        label:
-          link.rawText.indexOf('[[') > -1
-            ? link.rawText.substring(2, link.rawText.length - 2)
-            : link.rawText,
+        label,
         url: relativeUri.path,
         title: target.title,
       };

--- a/packages/foam-vscode/src/core/services/markdown-provider.ts
+++ b/packages/foam-vscode/src/core/services/markdown-provider.ts
@@ -137,22 +137,14 @@ export function createMarkdownReferences(
         relativeUri = relativeUri.changeExtension('*', '');
       }
 
-      let label = link.rawText;
-      if (link.rawText.indexOf('[[') > -1) {
-        if (link.isEmbed) {
-          // ![[embedded-note]]
-          label = link.rawText.substring(3, link.rawText.length - 2);
-        } else {
-          // [[standard-note]]
-          label = link.rawText.substring(2, link.rawText.length - 2);
-        }
-      } else {
-        label = link.rawText;
-      }
-
       // [wikilink-text]: path/to/file.md "Page title"
       return {
-        label,
+        // embedded looks like ![[note-a]]
+        // regular note looks like [[note-a]]
+        label: link.rawText.substring(
+          link.isEmbed ? 3 : 2,
+          link.rawText.length - 2
+        ),
         url: relativeUri.path,
         title: target.title,
       };


### PR DESCRIPTION
I noticed when generating reference links for a note that includes embedded notes, the reference links have a syntax error.
![before](https://github.com/foambubble/foam/assets/8953212/b25b4037-3f2b-4650-9985-f40dac4dc256)

This is caused by an off-by-one error when extracting the label after gathering the links for a note since embedded notes have an extra `!`. 

After the fix:
![after](https://github.com/foambubble/foam/assets/8953212/755041eb-d63c-49ec-9010-6fee40c4f9a6)

Appreciate any feedback!