### PR TITLE
Rename placeholder on note creation

### DIFF
--- a/packages/foam-vscode/src/core/model/foam.ts
+++ b/packages/foam-vscode/src/core/model/foam.ts
@@ -5,7 +5,7 @@ import { FoamGraph } from './graph';
 import { ResourceParser } from './note';
 import { ResourceProvider } from './provider';
 import { FoamTags } from './tags';
-import { Logger } from '../utils/log';
+import { Logger, withTiming, withTimingAsync } from '../utils/log';
 
 export interface Services {
   dataStore: IDataStore;
@@ -28,24 +28,25 @@ export const bootstrap = async (
   initialProviders: ResourceProvider[],
   defaultExtension: string = '.md'
 ) => {
-  const tsStart = Date.now();
-
-  const workspace = await FoamWorkspace.fromProviders(
-    initialProviders,
-    dataStore,
-    defaultExtension
+  const workspace = await withTimingAsync(
+    () =>
+      FoamWorkspace.fromProviders(
+        initialProviders,
+        dataStore,
+        defaultExtension
+      ),
+    ms => Logger.info(`Workspace loaded in ${ms}ms`)
   );
 
-  const tsWsDone = Date.now();
-  Logger.info(`Workspace loaded in ${tsWsDone - tsStart}ms`);
+  const graph = withTiming(
+    () => FoamGraph.fromWorkspace(workspace, true),
+    ms => Logger.info(`Graph loaded in ${ms}ms`)
+  );
 
-  const graph = FoamGraph.fromWorkspace(workspace, true);
-  const tsGraphDone = Date.now();
-  Logger.info(`Graph loaded in ${tsGraphDone - tsWsDone}ms`);
-
-  const tags = FoamTags.fromWorkspace(workspace, true);
-  const tsTagsEnd = Date.now();
-  Logger.info(`Tags loaded in ${tsTagsEnd - tsGraphDone}ms`);
+  const tags = withTiming(
+    () => FoamTags.fromWorkspace(workspace, true),
+    ms => Logger.info(`Tags loaded in ${ms}ms`)
+  );
 
   watcher?.onDidChange(async uri => {
     if (matcher.isMatch(uri)) {

--- a/packages/foam-vscode/src/core/model/graph.test.ts
+++ b/packages/foam-vscode/src/core/model/graph.test.ts
@@ -139,6 +139,21 @@ describe('Graph', () => {
     ).toEqual(['/path/another/page-c.md', '/somewhere/page-b.md']);
   });
 
+  it('should create inbound connections when targeting a section', () => {
+    const noteA = createTestNote({
+      uri: '/path/to/page-a.md',
+      links: [{ slug: 'page-b#section 2' }],
+    });
+    const noteB = createTestNote({
+      uri: '/somewhere/page-b.md',
+      text: '## Section 1\n\n## Section 2',
+    });
+    const ws = createTestWorkspace().set(noteA).set(noteB);
+    const graph = FoamGraph.fromWorkspace(ws);
+
+    expect(graph.getBacklinks(noteB.uri).length).toEqual(1);
+  });
+
   it('should support attachments', () => {
     const noteA = createTestNote({
       uri: '/path/to/page-a.md',

--- a/packages/foam-vscode/src/core/model/location.ts
+++ b/packages/foam-vscode/src/core/model/location.ts
@@ -1,0 +1,35 @@
+import { Range } from './range';
+import { URI } from './uri';
+import { ResourceLink } from './note';
+
+/**
+ * Represents a location inside a resource, such as a line
+ * inside a text file.
+ */
+export interface Location<T> {
+  /**
+   * The resource identifier of this location.
+   */
+  uri: URI;
+  /**
+   * The document range of this locations.
+   */
+  range: Range;
+  /**
+   * The data associated to this location.
+   */
+  data: T;
+}
+
+export abstract class Location<T> {
+  static create<T>(uri: URI, range: Range, data: T): Location<T> {
+    return { uri, range, data };
+  }
+
+  static forObjectWithRange<T extends { range: Range }>(
+    uri: URI,
+    obj: T
+  ): Location<T> {
+    return Location.create(uri, obj.range, obj);
+  }
+}

--- a/packages/foam-vscode/src/core/utils/log.ts
+++ b/packages/foam-vscode/src/core/utils/log.ts
@@ -89,3 +89,25 @@ export class Logger {
     Logger.defaultLogger = logger;
   }
 }
+
+export const withTiming = <T>(
+  fn: () => T,
+  onDidComplete: (elapsed: number) => void
+): T => {
+  const tsStart = Date.now();
+  const res = fn();
+  const tsEnd = Date.now();
+  onDidComplete(tsEnd - tsStart);
+  return res;
+};
+
+export const withTimingAsync = async <T>(
+  fn: () => Promise<T>,
+  onDidComplete: (elapsed: number) => void
+): Promise<T> => {
+  const tsStart = Date.now();
+  const res = await fn();
+  const tsEnd = Date.now();
+  onDidComplete(tsEnd - tsStart);
+  return res;
+};

--- a/packages/foam-vscode/src/extension.ts
+++ b/packages/foam-vscode/src/extension.ts
@@ -73,7 +73,9 @@ export async function activate(context: ExtensionContext) {
     );
 
     // Load the features
-    const resPromises = features.map(feature => feature(context, foamPromise));
+    const featuresPromises = features.map(feature =>
+      feature(context, foamPromise)
+    );
 
     const foam = await foamPromise;
     Logger.info(`Loaded ${foam.workspace.list().length} resources`);
@@ -102,14 +104,15 @@ export async function activate(context: ExtensionContext) {
       })
     );
 
-    const res = (await Promise.all(resPromises)).filter(r => r != null);
+    const feats = (await Promise.all(featuresPromises)).filter(r => r != null);
 
     return {
       extendMarkdownIt: (md: markdownit) => {
-        return res.reduce((acc: markdownit, r: any) => {
+        return feats.reduce((acc: markdownit, r: any) => {
           return r.extendMarkdownIt ? r.extendMarkdownIt(acc) : acc;
         }, md);
       },
+      foam,
     };
   } catch (e) {
     Logger.error('An error occurred while bootstrapping Foam', e);

--- a/packages/foam-vscode/src/features/hover-provider.ts
+++ b/packages/foam-vscode/src/features/hover-provider.ts
@@ -14,6 +14,7 @@ import { FoamGraph } from '../core/model/graph';
 import { OPEN_COMMAND } from './commands/open-resource';
 import { CREATE_NOTE_COMMAND } from './commands/create-note';
 import { commandAsURI } from '../utils/commands';
+import { Location } from '../core/model/location';
 
 export const CONFIG_KEY = 'links.hover.enable';
 
@@ -107,7 +108,7 @@ export class HoverProvider implements vscode.HoverProvider {
     }
 
     const command = CREATE_NOTE_COMMAND.forPlaceholder(
-      targetUri.path,
+      Location.forObjectWithRange(documentUri, targetLink),
       this.workspace.defaultExtension,
       {
         askForTemplate: true,

--- a/packages/foam-vscode/src/features/navigation-provider.spec.ts
+++ b/packages/foam-vscode/src/features/navigation-provider.spec.ts
@@ -12,6 +12,10 @@ import { createMarkdownParser } from '../core/services/markdown-parser';
 import { FoamGraph } from '../core/model/graph';
 import { commandAsURI } from '../utils/commands';
 import { CREATE_NOTE_COMMAND } from './commands/create-note';
+import { Location } from '../core/model/location';
+import { URI } from '../core/model/uri';
+import { Range } from '../core/model/range';
+import { ResourceLink } from '../core/model/note';
 
 describe('Document navigation', () => {
   const parser = createMarkdownParser([]);
@@ -71,9 +75,8 @@ describe('Document navigation', () => {
 
     it('should create links for placeholders', async () => {
       const fileA = await createFile(`this is a link to [[a placeholder]].`);
-      const ws = createTestWorkspace().set(
-        parser.parse(fileA.uri, fileA.content)
-      );
+      const noteA = parser.parse(fileA.uri, fileA.content);
+      const ws = createTestWorkspace().set(noteA);
       const graph = FoamGraph.fromWorkspace(ws);
 
       const { doc } = await showInEditor(fileA.uri);
@@ -83,9 +86,13 @@ describe('Document navigation', () => {
       expect(links.length).toEqual(1);
       expect(links[0].target).toEqual(
         commandAsURI(
-          CREATE_NOTE_COMMAND.forPlaceholder('a placeholder', '.md', {
-            onFileExists: 'open',
-          })
+          CREATE_NOTE_COMMAND.forPlaceholder(
+            Location.forObjectWithRange(noteA.uri, noteA.links[0]),
+            '.md',
+            {
+              onFileExists: 'open',
+            }
+          )
         )
       );
       expect(links[0].range).toEqual(new vscode.Range(0, 20, 0, 33));

--- a/packages/foam-vscode/src/features/navigation-provider.ts
+++ b/packages/foam-vscode/src/features/navigation-provider.ts
@@ -10,6 +10,7 @@ import { FoamGraph } from '../core/model/graph';
 import { Position } from '../core/model/position';
 import { CREATE_NOTE_COMMAND } from './commands/create-note';
 import { commandAsURI } from '../utils/commands';
+import { Location } from '../core/model/location';
 
 export default async function activate(
   context: vscode.ExtensionContext,
@@ -146,10 +147,8 @@ export class NavigationProvider
   public provideDocumentLinks(
     document: vscode.TextDocument
   ): vscode.DocumentLink[] {
-    const resource = this.parser.parse(
-      fromVsCodeUri(document.uri),
-      document.getText()
-    );
+    const documentUri = fromVsCodeUri(document.uri);
+    const resource = this.parser.parse(documentUri, document.getText());
 
     const targets: { link: ResourceLink; target: URI }[] = resource.links.map(
       link => ({
@@ -162,7 +161,7 @@ export class NavigationProvider
       .filter(o => o.target.isPlaceholder()) // links to resources are managed by the definition provider
       .map(o => {
         const command = CREATE_NOTE_COMMAND.forPlaceholder(
-          o.target.path,
+          Location.forObjectWithRange(documentUri, o.link),
           this.workspace.defaultExtension,
           {
             onFileExists: 'open',

--- a/packages/foam-vscode/src/utils/vsc-utils.ts
+++ b/packages/foam-vscode/src/utils/vsc-utils.ts
@@ -9,7 +9,7 @@ export const toVsCodePosition = (p: FoamPosition): Position =>
 export const toVsCodeRange = (r: FoamRange): Range =>
   new Range(r.start.line, r.start.character, r.end.line, r.end.character);
 
-export const toVsCodeUri = (u: FoamURI): Uri => Uri.parse(u.toString());
+export const toVsCodeUri = (u: FoamURI): Uri => Uri.from(u);
 
 export const fromVsCodeUri = (u: Uri): FoamURI => FoamURI.parse(u.toString());
 


### PR DESCRIPTION
This PR fixes #1327

Passing to the create-note command a source link, in which case it will check whether, once the note has been created (possibly using a template that changed the name of the original placeholder), the name of the new note matches the originating link - and if not updates it.

I made a conscious decision here to only update the source link, and not all placeholders that match the source link. 
Happy to have a conversation about that, for now it felt better this way.

Oh yeah, and I was playing with some logging stuff (minor)