### PR TITLE
Exclude workspace when linking to a file

### DIFF
--- a/packages/foam-vscode/src/features/preview/wikilink-navigation.ts
+++ b/packages/foam-vscode/src/features/preview/wikilink-navigation.ts
@@ -42,12 +42,18 @@ export const markdownItWikilinkNavigation = (
           return getPlaceholderLink(label);
         }
 
-        const link = `${vscode.workspace.asRelativePath(
+        const resourceLabel = isEmpty(alias)
+          ? `${resource.title}${formattedSection}`
+          : alias;
+        const resourceLink = `/${vscode.workspace.asRelativePath(
           toVsCodeUri(resource.uri),
           false
-        )}${formattedSection}`;
-        const title = `${resource.title}${formattedSection}`;
-        return `<a class='foam-note-link' title='${title}' href='/${link}' data-href='/${link}'>${label}</a>`;
+        )}`;
+        return getResourceLink(
+          `${resource.title}${formattedSection}`,
+          `${resourceLink}${linkSection}`,
+          resourceLabel
+        );
       } catch (e) {
         Logger.error(
           `Error while creating link for [[${wikilink}]] in Preview panel`,

--- a/packages/foam-vscode/src/features/preview/wikilink-navigation.ts
+++ b/packages/foam-vscode/src/features/preview/wikilink-navigation.ts
@@ -42,17 +42,12 @@ export const markdownItWikilinkNavigation = (
           return getPlaceholderLink(label);
         }
 
-        const resourceLabel = isEmpty(alias)
-          ? `${resource.title}${formattedSection}`
-          : alias;
-        const resourceLink = `/${vscode.workspace.asRelativePath(
-          toVsCodeUri(resource.uri)
-        )}`;
-        return getResourceLink(
-          `${resource.title}${formattedSection}`,
-          `${resourceLink}${linkSection}`,
-          resourceLabel
-        );
+        const link = `${vscode.workspace.asRelativePath(
+          toVsCodeUri(resource.uri),
+          false
+        )}${formattedSection}`;
+        const title = `${resource.title}${formattedSection}`;
+        return `<a class='foam-note-link' title='${title}' href='/${link}' data-href='/${link}'>${label}</a>`;
       } catch (e) {
         Logger.error(
           `Error while creating link for [[${wikilink}]] in Preview panel`,


### PR DESCRIPTION
This fixes #1332 and #1277.

`vscode.workspace.asRelativePath` needs to be told to exclude the workspace, as we already have in the resource location.
