### PR TITLE
Stop iterating over all resources for finding matching identifiers

### DIFF
--- a/packages/foam-vscode/src/core/model/workspace.ts
+++ b/packages/foam-vscode/src/core/model/workspace.ts
@@ -104,21 +104,19 @@ export class FoamWorkspace implements IDisposable {
   public getIdentifier(forResource: URI, exclude?: URI[]): string {
     const amongst = [];
     const basename = forResource.getBasename();
-    for (const res of this._resources.values()) {
-      // skip elements that cannot possibly match
-      if (!res.uri.path.endsWith(basename)) {
-        continue;
-      }
+
+    this.listByIdentifier(basename).map(res => {
       // skip self
       if (res.uri.isEqual(forResource)) {
-        continue;
+        return;
       }
+
       // skip exclude list
       if (exclude && exclude.find(ex => ex.isEqual(res.uri))) {
-        continue;
+        return;
       }
       amongst.push(res.uri);
-    }
+    });
 
     let identifier = FoamWorkspace.getShortestIdentifier(
       forResource.path,


### PR DESCRIPTION
This fixes #1410 and will improve on the symptoms mentioned by @theAkito in #1375.

This commit changes the behaviour of `FoamWorkspace.getIdentifier`. Instead of iterating over all resources it will reap the benefits of the TrieMap. I've changed the algorithm to take the basename as identifier. This is then used to list all matching resources for that identifier. Internally, this uses the reversed TrieMap identifier. Optimising the retrieval of any matching resources of the given identifier.

This removes the cartesian product causing the problems in #1410. 

@riccardoferretti Please check and verify.