### PR TITLE
External Workspaces

### DIFF
--- a/docs/user/features/workspaces.md
+++ b/docs/user/features/workspaces.md
@@ -1,0 +1,20 @@
+# Workspaces
+
+It is possible to choose between two basic types of workspaces for the notes and templates:
+
+  1. **"internal" VSCode workspace:** Watch and access the note and template folders within "internal" workspace (exclusive VSCode workspace)
+  2. **"external" workspace:** Watch and access the note and template folders within 'external' workspace ("external" with respect to VSCode workspace; INFO: this may include folders from the "internal" VSCode workspace)
+
+The switch may be done via the config. property `foam.files.workspaceType` with possible values `[
+            "internal",
+            "external",
+            "combined"
+          ]`.
+
+This feature allows to decouple the essential foam workspace from the VSCode workspace and provides better flexibility and less workflow complexity, particularly when working with multiple VSCode workspaces and projects.
+
+The "external" and absolute note folder paths to be watched can be defined via the config. property 
+`foam.files.externalWatchPaths` with the path to be set within an array.
+The external and absolute template root directory path may be define via th econfig. property `foam.files.externalTemplatesRoot` .   
+ 
+**NOTE:** The "external" path definitions may be defined such that either only a respective root directory or, in addition, a glob pattern is provided.

--- a/docs/user/features/workspaces.md
+++ b/docs/user/features/workspaces.md
@@ -3,7 +3,7 @@
 It is possible to choose between two basic types of workspaces for the notes and templates:
 
   1. **"internal" VSCode workspace:** Watch and access the note and template folders within "internal" workspace (exclusive VSCode workspace)
-  2. **"external" workspace:** Watch and access the note and template folders within 'external' workspace ("external" with respect to VSCode workspace; INFO: this may include folders from the "internal" VSCode workspace)
+  2. **"external" workspace:** Watch and access the note and template folders within "external" workspace ("external" with respect to VSCode workspace; INFO: this may include folders from the "internal" VSCode workspace)
 
 The switch may be done via the config. property `foam.files.workspaceType` with possible values `[
             "internal",
@@ -15,6 +15,6 @@ This feature allows to decouple the essential foam workspace from the VSCode wor
 
 The "external" and absolute note folder paths to be watched can be defined via the config. property 
 `foam.files.externalWatchPaths` with the path to be set within an array.
-The external and absolute template root directory path may be define via th econfig. property `foam.files.externalTemplatesRoot` .   
+The external and absolute template root directory path may be defined via the config. property `foam.files.externalTemplatesRoot` .   
  
-**NOTE:** The "external" path definitions may be defined such that either only a respective root directory or, in addition, a glob pattern is provided.
+**NOTE:** The "external" path definitions may be defined such that either only a respective root directory or, in addition, also a glob pattern is provided.

--- a/packages/foam-vscode/README.md
+++ b/packages/foam-vscode/README.md
@@ -128,6 +128,10 @@ With references you can also make your notes navigable both in GitHub UI as well
   - This becomes very powerful when combined with [note templates](https://foambubble.github.io/foam/user/features/note-templates) and the `Foam: Create New Note from Template` command
 - See your workspace as a connected graph with the `Foam: Show Graph` command
 
+### Workspaces
+
+- Explore how to work with either the "internal" VSCode workspace or an "external" one: [workspaces](https://foambubble.github.io/foam/user/features/workspaces) .
+
 ## Recipes
 
 People use Foam in different ways for different use cases, check out the [recipes](https://foambubble.github.io/foam/user/recipes/recipes) page for inspiration!

--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -525,6 +525,35 @@
             "Use the directory of the file in the current editor"
           ]
         },
+        "foam.files.workspaceType": { 
+          "type": "string",
+          "default": "internal",
+          "description": "Specifies which 'workspaces' of note folders to watch",
+          "enum": [
+            "internal",
+            "external",
+            "combined"
+          ],
+          "enumDescriptions": [
+            "Watch note folders within 'internal' workspace (exclusive VSCode workspace)",
+            "Watch note folders within 'external' workspace ('external' with respect to VSCode workspace; INFO: this may include folders from 'internal' workspace)",
+            "POTENTIALLY DEPRECATED: Watch note folders of both, 'internal' and 'external' workspace"
+          ]
+        },
+        "foam.files.externalWatchPaths": {
+          "type": "array",
+          "items": {
+              "type": "string",
+              "default": "**/*"
+          },
+          "default": [],
+          "description": "The array of root paths to be watched by the note file watcher"
+        },
+        "foam.files.externalTemplatesRoot": {
+          "type": "string",
+          "default": "",
+          "description": "'External' (as to VSCode workspace) root path for note templates"
+        },
         "foam.logging.level": {
           "type": "string",
           "default": "info",

--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -528,15 +528,15 @@
         "foam.files.workspaceType": { 
           "type": "string",
           "default": "internal",
-          "description": "Specifies which 'workspaces' of note folders to watch",
+          "description": "Specifies the 'workspace' type",
           "enum": [
             "internal",
             "external",
             "combined"
           ],
           "enumDescriptions": [
-            "Watch note folders within 'internal' workspace (exclusive VSCode workspace)",
-            "Watch note folders within 'external' workspace ('external' with respect to VSCode workspace; INFO: this may include folders from 'internal' workspace)",
+            "Watch and access the note and template folders within 'internal' workspace (exclusive VSCode workspace)",
+            "Watch and access the note and template folders within 'external' workspace ('external' with respect to VSCode workspace; INFO: this may include folders from 'internal' workspace)",
             "POTENTIALLY DEPRECATED: Watch note folders of both, 'internal' and 'external' workspace"
           ]
         },

--- a/packages/foam-vscode/src/core/model/foam.ts
+++ b/packages/foam-vscode/src/core/model/foam.ts
@@ -22,7 +22,7 @@ export interface Foam extends IDisposable {
 
 export const bootstrap = async (
   matcher: IMatcher,
-  watcher: IWatcher | undefined,
+  watchers: IWatcher[] | undefined, 
   dataStore: IDataStore,
   parser: ResourceParser,
   initialProviders: ResourceProvider[],
@@ -48,20 +48,22 @@ export const bootstrap = async (
     ms => Logger.info(`Tags loaded in ${ms}ms`)
   );
 
-  watcher?.onDidChange(async uri => {
-    if (matcher.isMatch(uri)) {
-      await workspace.fetchAndSet(uri);
-    }
-  });
-  watcher?.onDidCreate(async uri => {
-    await matcher.refresh();
-    if (matcher.isMatch(uri)) {
-      await workspace.fetchAndSet(uri);
-    }
-  });
-  watcher?.onDidDelete(uri => {
-    workspace.delete(uri);
-  });
+  for (const watcher of watchers) {
+    watcher?.onDidChange(async uri => {
+      if (matcher.isMatch(uri)) {
+        await workspace.fetchAndSet(uri);
+      }
+    });
+    watcher?.onDidCreate(async uri => {
+      await matcher.refresh();
+      if (matcher.isMatch(uri)) {
+        await workspace.fetchAndSet(uri);
+      }
+    });
+    watcher?.onDidDelete(uri => {
+      workspace.delete(uri);
+    });
+  }
 
   const foam: Foam = {
     workspace,

--- a/packages/foam-vscode/src/settings.ts
+++ b/packages/foam-vscode/src/settings.ts
@@ -46,3 +46,19 @@ export function getIgnoredFilesSetting(): GlobPattern[] {
     ...Object.keys(workspace.getConfiguration().get('files.exclude', {})),
   ];
 }
+
+/** Retrieve external (with respect to VSCode workspace) root paths for note file watching. */
+export function getExternalWatchPaths() { 
+  return getFoamVsCodeConfig('files.externalWatchPaths', []);
+}
+
+/** Retrieve external (with respect to VSCode workspace) root path for note templates. */
+export function getExternalTemplatesRoot() {
+  return getFoamVsCodeConfig('files.externalTemplatesRoot', '');
+}
+
+/** Retrieve external (with respect to VSCode workspace) root paths for file watching. */
+export function getWorkspaceType() {
+  return getFoamVsCodeConfig('files.workspaceType', 'internal');
+}
+

--- a/packages/foam-vscode/src/utils/vsc-utils.ts
+++ b/packages/foam-vscode/src/utils/vsc-utils.ts
@@ -1,4 +1,4 @@
-import { Memento, Position, Range, Uri, commands } from 'vscode';
+import { Memento, Position, Range, RelativePattern, Uri, commands } from 'vscode'; 
 import { Position as FoamPosition } from '../core/model/position';
 import { Range as FoamRange } from '../core/model/range';
 import { URI as FoamURI } from '../core/model/uri';
@@ -51,4 +51,30 @@ export class MapBasedMemento implements Memento {
     this.map.set(key, value);
     return Promise.resolve();
   }
+}
+
+const externalRelativePatternExtract = (path: string): string[] => {
+  let rootPath: string = "";
+  let relativeGlobPattern: string = "";
+  if(!path.match(/^.*[\*\?\{\}\[\]\!].*$/)){
+    rootPath = path;
+    relativeGlobPattern = "*.md";
+    return [rootPath, relativeGlobPattern];
+  } 
+  const match = path.match(/^((?:[^\*\?\{\}\[\]\!]*\/)*)\s*(.*)$/);
+  if (!match) {
+    throw new Error(`Invalid glob pattern: ${path}`);
+  }
+  [, rootPath, relativeGlobPattern] = match;
+  return [rootPath, relativeGlobPattern];
+}
+
+export const externalGlobPattern = (path: string): RelativePattern => {
+  const [rootPath, relativeGlobPattern] = externalRelativePatternExtract(path);
+  return new RelativePattern(Uri.file(rootPath), relativeGlobPattern);
+}
+
+export const externalRelativePatternRootPath = (path: string): string => {
+  const [rootPath] = externalRelativePatternExtract(path);
+  return rootPath;
 }

--- a/packages/foam-vscode/tsconfig.json
+++ b/packages/foam-vscode/tsconfig.json
@@ -4,7 +4,7 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
     "outDir": "out",
-    "lib": ["ES2019", "es2020.string", "DOM"],
+    "lib": ["ES2022", "es2022.string", "DOM"],
     "sourceMap": true,
     "strict": false,
     "downlevelIteration": true

--- a/readme.md
+++ b/readme.md
@@ -132,6 +132,10 @@ With references you can also make your notes navigable both in GitHub UI as well
   - This becomes very powerful when combined with [note templates](https://foambubble.github.io/foam/user/features/note-templates) and the `Foam: Create New Note from Template` command
 - See your workspace as a connected graph with the `Foam: Show Graph` command
 
+### Workspaces
+
+- Explore how to work with either the "internal" VSCode workspace or an "external" one: [workspaces](https://foambubble.github.io/foam/user/features/workspaces) .
+
 ## Recipes
 
 People use Foam in different ways for different use cases, check out the [recipes](https://foambubble.github.io/foam/user/recipes/recipes) page for inspiration!

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,7 +5,7 @@
     "declarationMap": true,
     "baseUrl": ".",
     "module": "commonjs",
-    "target": "ES2019",
+    "target": "ES2022",
     "paths": {
       "foam-core": ["./packages/foam-core/src"],
       "foam-vscode": ["./packages/foam-vscode/src"]


### PR DESCRIPTION
The requested changes make it possible to choose between two basic types of workspaces for the notes and templates:

  1. **"internal" VSCode workspace:** Watch and access the note and template folders within "internal" workspace (exclusive VSCode workspace)
  2. **"external" workspace:** Watch and access the note and template folders within 'external' workspace ("external" with respect to VSCode workspace; INFO: this may include folders from the "internal" VSCode workspace)

The switch may be done via the config. property `foam.files.workspaceType` .

This feature allows to decouple the essential foam workspace from the VSCode workspace and provides better flexibility and less workflow complexity, particularly when working with multiple VSCode workspaces and projects.

The "external" and absolute note folder paths that are to be watched can be defined via the config. property 
`foam.files.externalWatchPaths` .
The external and absolute template root directory path may be defined via the config. property `foam.files.externalTemplatesRoot` .   
 
**NOTE:** The "external" path definitions may be defined such that either only a respective root directory or, in addition, a glob pattern is provided.