### PR TITLE
Added navigation for tags in editor

### DIFF
--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -406,6 +406,11 @@
         "icon": "$(expand-all)"
       },
       {
+        "command": "foam-vscode.views.tags-explorer.focus",
+        "title": "Focus on tag",
+        "icon": "$(symbol-number)"
+      },
+      {
         "command": "foam-vscode.views.placeholders.show:for-current-file",
         "title": "Show placeholders in current file",
         "icon": "$(file)"

--- a/packages/foam-vscode/src/features/navigation-provider.ts
+++ b/packages/foam-vscode/src/features/navigation-provider.ts
@@ -157,7 +157,7 @@ export class NavigationProvider
       })
     );
 
-    return targets
+    const links: vscode.DocumentLink[] = targets
       .filter(o => o.target.isPlaceholder()) // links to resources are managed by the definition provider
       .map(o => {
         const command = CREATE_NOTE_COMMAND.forPlaceholder(
@@ -180,5 +180,26 @@ export class NavigationProvider
         documentLink.tooltip = `Create note for '${o.target.path}'`;
         return documentLink;
       });
+
+    const tags: vscode.DocumentLink[] = resource.tags.map(tag => {
+      const command = {
+        name: 'foam-vscode.views.tags-explorer.focus',
+        params: [tag.label, documentUri],
+      };
+
+      const documentLink = new vscode.DocumentLink(
+        new vscode.Range(
+          tag.range.start.line,
+          tag.range.start.character,
+          tag.range.end.line,
+          tag.range.end.character
+        ),
+        commandAsURI(command)
+      );
+      documentLink.tooltip = `Explore tag '${tag.label}'`;
+      return documentLink;
+    });
+
+    return links.concat(tags);
   }
 }

--- a/packages/foam-vscode/src/features/preview/tag-highlight.ts
+++ b/packages/foam-vscode/src/features/preview/tag-highlight.ts
@@ -4,6 +4,7 @@ import markdownItRegex from 'markdown-it-regex';
 import { FoamWorkspace } from '../../core/model/workspace';
 import { Logger } from '../../core/utils/log';
 import { isNone } from '../../core/utils';
+import { commandAsURI } from '../../utils/commands';
 
 export const markdownItFoamTags = (
   md: markdownit,
@@ -14,10 +15,7 @@ export const markdownItFoamTags = (
     regex: /(?<=^|\s)(#[0-9]*[\p{L}/_-][\p{L}\p{N}/_-]*)/u,
     replace: (tag: string) => {
       try {
-        const resource = workspace.find(tag);
-        if (isNone(resource)) {
-          return getFoamTag(tag);
-        }
+        return getFoamTag(tag);
       } catch (e) {
         Logger.error(
           `Error while creating link for ${tag} in Preview panel`,
@@ -29,6 +27,8 @@ export const markdownItFoamTags = (
   });
 };
 
+// Commands can't be run in the preview (see https://github.com/microsoft/vscode/issues/102532)
+// for we just return the tag as a span
 const getFoamTag = (content: string) =>
   `<span class='foam-tag'>${content}</span>`;
 


### PR DESCRIPTION
Unfortunately VS Code Preview doesn't support link commands (see https://github.com/microsoft/vscode/issues/102532), so this is only working in the editor
fixes #1420 