### PR TITLE
Fix parsing of tags when colon exists in other properties

### DIFF
--- a/packages/foam-vscode/src/core/services/markdown-parser.test.ts
+++ b/packages/foam-vscode/src/core/services/markdown-parser.test.ts
@@ -320,6 +320,28 @@ this is some #text that includes #tags we #care-about.
       ]);
     });
 
+    it('can find tags when other fields has colon', () => {
+      // This is a regression test. Previously a colon in
+      // other fields would throw an error, causing tags
+      // to be empty.
+      const noteA = createNoteFromMarkdown(`
+---
+date: 2023-10-10T00:00:00.000Z
+tags: [hello, world,  this_is_good]
+---
+# this is a heading
+this is some #text that includes #tags we #care-about.
+    `);
+      expect(noteA.tags.map(t => t.label)).toEqual([
+        'hello',
+        'world',
+        'this_is_good',
+        'text',
+        'tags',
+        'care-about',
+      ]);
+    });
+
     it('provides a specific range for tags in yaml', () => {
       // For now it's enough to just get the YAML block range
       // in the future we might want to be more specific

--- a/packages/foam-vscode/src/core/services/markdown-parser.ts
+++ b/packages/foam-vscode/src/core/services/markdown-parser.ts
@@ -173,40 +173,33 @@ const getTextFromChildren = (root: Node): string => {
   return text;
 };
 
-function getPropertiesInfoFromYAML(yamlText: string): {
-  [key: string]: { key: string; value: string; text: string; line: number };
+function getTagPropertyInfo(yamlText: string): {
+  lines: string[];
+  line: number;
 } {
-  const yamlProps = yamlText
-    .split(/(\w+:)/g)
-    .filter(item => item.trim() !== '');
   const lines = yamlText.split('\n');
-  let result: { line: number; key: string; text: string; value: string }[] = [];
-  for (let i = 0; i < yamlProps.length / 2; i++) {
-    const key = yamlProps[i * 2].replace(':', '');
-    const value = yamlProps[i * 2 + 1].trim();
-    const text = yamlProps[i * 2] + yamlProps[i * 2 + 1];
-    result.push({ key, value, text, line: -1 });
+  const startLine = lines.findIndex(line => line.trim().startsWith('tags:'));
+  if (startLine === -1) return { lines: [], line: -1 };
+
+  let endLine = startLine + 1;
+  while (endLine < lines.length && !lines[endLine].trim().includes(':')) {
+    endLine++;
   }
-  result = result.map(p => {
-    const line = lines.findIndex(l => l.startsWith(p.key + ':'));
-    return { ...p, line };
-  });
-  return result.reduce((acc, curr) => {
-    acc[curr.key] = curr;
-    return acc;
-  }, {});
+
+  return {
+    lines: lines.slice(startLine, endLine),
+    line: startLine,
+  };
 }
 
 const tagsPlugin: ParserPlugin = {
   name: 'tags',
   onDidFindProperties: (props, note, node) => {
     if (isSome(props.tags)) {
-      const tagPropertyInfo = getPropertiesInfoFromYAML((node as any).value)[
-        'tags'
-      ];
+      const tagPropertyInfo = getTagPropertyInfo((node as any).value);
       const tagPropertyStartLine =
         node.position!.start.line + tagPropertyInfo.line;
-      const tagPropertyLines = tagPropertyInfo.text.split('\n');
+      const tagPropertyLines = tagPropertyInfo.lines;
       const yamlTags = extractTagsFromProp(props.tags);
       for (const tag of yamlTags) {
         const tagLine = tagPropertyLines.findIndex(l => l.includes(tag));


### PR DESCRIPTION
The parsing of tags relies splitting on colon which does not work when other properties has colon. E.g. having a date property that includes time.

This commit fixes it by rewriting the logic to get tags -> line number.

Previously, having frontmatter like 
```
---
title: 2025 04 11
date: 2025-04-11T00:01:00+01:00
tags: 
    - new
---
```
causes the parser to silently error out and therefore doesn't parse the tags defined in the yaml at all.
