### PR TITLE
feat: Add GitHub-style task lists support in preview

### DIFF
--- a/docs/user/features/custom-markdown-preview-styles.md
+++ b/docs/user/features/custom-markdown-preview-styles.md
@@ -29,3 +29,22 @@ Foams offers the functionality to include other notes in your note. This will be
   Cyclic link detected for wikilink: ${wikilink}
 </div>
 ```
+
+### Task Lists
+
+Foam supports GitHub-style task lists in the preview. Task lists are rendered with the following classes:
+
+- `task-list-item`: Applied to the `<li>` element containing a task
+- `task-list-item-checkbox`: Applied to the checkbox `<input>` element
+
+You can customize the appearance of task lists with CSS like this:
+
+```css
+li.task-list-item {
+  list-style-type: none;
+}
+
+input.task-list-item-checkbox {
+  margin-right: 4px;
+}
+```

--- a/packages/foam-vscode/CHANGELOG.md
+++ b/packages/foam-vscode/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the "foam-vscode" extension will be documented in this fi
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [Unreleased]
+
+Features:
+- Added support for GitHub-style task lists in preview (`- [ ]` and `- [x]`)
+
 ## [0.26.11] - 2025-04-19
 
 Fixes and Improvements:

--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -733,6 +733,7 @@
     "lodash": "^4.17.21",
     "lru-cache": "^7.14.1",
     "markdown-it-regex": "^0.2.0",
+    "markdown-it-task-lists": "^2.1.1",
     "mnemonist": "^0.39.8",
     "path-browserify": "^1.0.1",
     "remark-frontmatter": "^2.0.0",

--- a/packages/foam-vscode/src/features/preview/index.ts
+++ b/packages/foam-vscode/src/features/preview/index.ts
@@ -6,6 +6,7 @@ import { default as markdownItFoamTags } from './tag-highlight';
 import { default as markdownItWikilinkNavigation } from './wikilink-navigation';
 import { default as markdownItRemoveLinkReferences } from './remove-wikilink-references';
 import { default as markdownItWikilinkEmbed } from './wikilink-embed';
+import { default as markdownItTaskListsPlugin } from './task-lists';
 
 export default async function activate(
   context: vscode.ExtensionContext,
@@ -16,6 +17,7 @@ export default async function activate(
   return {
     extendMarkdownIt: (md: markdownit) => {
       return [
+        markdownItTaskListsPlugin,
         markdownItWikilinkEmbed,
         markdownItFoamTags,
         markdownItWikilinkNavigation,

--- a/packages/foam-vscode/src/features/preview/task-lists.spec.ts
+++ b/packages/foam-vscode/src/features/preview/task-lists.spec.ts
@@ -1,0 +1,61 @@
+import markdownit from 'markdown-it';
+import markdownItTaskListsPlugin from './task-lists';
+
+describe('task-lists plugin', () => {
+  const md = markdownit().use(markdownItTaskListsPlugin);
+
+  it('renders unchecked checkbox', () => {
+    const input = '- [ ] Buy milk';
+    const output = md.render(input);
+
+    expect(output).toContain('class="task-list-item-checkbox"');
+    expect(output).toContain('type="checkbox"');
+    expect(output).toContain('Buy milk');
+    expect(output).not.toContain('checked=');
+  });
+
+  it('renders checked checkbox', () => {
+    const input = '- [x] Done task';
+    const output = md.render(input);
+
+    expect(output).toContain('class="task-list-item-checkbox"');
+    expect(output).toContain('type="checkbox"');
+    expect(output).toContain('Done task');
+    expect(output).toContain('checked=');
+  });
+
+  it('renders uppercase X checkbox as checked', () => {
+    const input = '- [X] Done task with uppercase';
+    const output = md.render(input);
+
+    expect(output).toContain('class="task-list-item-checkbox"');
+    expect(output).toContain('type="checkbox"');
+    expect(output).toContain('Done task with uppercase');
+    expect(output).toContain('checked=');
+  });
+
+  it('renders checkboxes inside nested lists', () => {
+    const input = '- Parent item\n  - [ ] Nested task';
+    const output = md.render(input);
+
+    expect(output).toContain('class="task-list-item-checkbox"');
+    expect(output).toContain('type="checkbox"');
+    expect(output).toContain('Nested task');
+  });
+
+  it('does not render checkbox when there is no space after brackets', () => {
+    const input = '- []No space';
+    const output = md.render(input);
+
+    expect(output).not.toContain('class="task-list-item-checkbox"');
+    expect(output).not.toContain('type="checkbox"');
+  });
+
+  it('does not render checkbox in regular text with brackets', () => {
+    const input = 'This is a [ ] normal text';
+    const output = md.render(input);
+
+    expect(output).not.toContain('class="task-list-item-checkbox"');
+    expect(output).not.toContain('type="checkbox"');
+  });
+});

--- a/packages/foam-vscode/src/features/preview/task-lists.ts
+++ b/packages/foam-vscode/src/features/preview/task-lists.ts
@@ -1,0 +1,27 @@
+/*global markdownit:readonly*/
+
+import markdownItTaskLists from 'markdown-it-task-lists';
+import { Foam } from '../../core/model/foam';
+import { FoamWorkspace } from '../../core/model/workspace';
+import { ResourceParser } from '../../core/model/note';
+
+/**
+ * Adds support for rendering GitHub-style task lists as checkboxes in the preview
+ *
+ * Example:
+ * - [ ] Unchecked task
+ * - [x] Checked task
+ */
+export const markdownItTaskListsPlugin = (
+  md: markdownit,
+  _workspace?: FoamWorkspace,
+  _parser?: ResourceParser
+) => {
+  return md.use(markdownItTaskLists, {
+    enabled: false, // checkboxes are disabled (non-interactive)
+    label: true, // wrap checkbox + text in <label>
+    labelAfter: true, // put text after checkbox
+  });
+};
+
+export default markdownItTaskListsPlugin;

--- a/readme.md
+++ b/readme.md
@@ -124,6 +124,14 @@ With references you can also make your notes navigable both in GitHub UI as well
 
 ![Generate references](./assets/screenshots/feature-definitions-generation.gif)
 
+### Task Lists
+
+Create interactive task lists in your notes using standard GitHub-style markdown syntax:
+```markdown
+- [ ] Unchecked task
+- [x] Checked task
+```
+
 ### Commands
 
 - Explore your knowledge base with the `Foam: Open Random Note` command

--- a/yarn.lock
+++ b/yarn.lock
@@ -8246,6 +8246,11 @@ markdown-it-regex@^0.2.0:
   resolved "https://registry.npmjs.org/markdown-it-regex/-/markdown-it-regex-0.2.0.tgz"
   integrity sha512-111UnMGJSt37gy+DlgcpQNwEfS2jvscOFSztzGhuXUHk7K1J5eAEj6C3jifmKb0cWtTuxdpHgIt4PyGQ+DtDjw==
 
+markdown-it-task-lists@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/markdown-it-task-lists/-/markdown-it-task-lists-2.1.1.tgz#f68f4d2ac2bad5a2c373ba93081a1a6848417088"
+  integrity sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==
+
 markdown-it@^12.0.4:
   version "12.3.2"
   resolved "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz"
@@ -10611,7 +10616,16 @@ string-natural-compare@^3.0.1:
   resolved "https://registry.npmjs.org/string-natural-compare/-/string-natural-compare-3.0.1.tgz"
   integrity sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -10683,7 +10697,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -10696,6 +10710,13 @@ strip-ansi@^4.0.0:
   integrity sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==
   dependencies:
     ansi-regex "^3.0.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -11715,7 +11736,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -11736,6 +11757,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
This commit introduces support for GitHub-style task lists (`- [ ]` and `- [x]`) in the Foam preview. Key changes include:

1. **Feature Implementation**:
   - Added `markdown-it-task-lists` plugin to parse and render task lists in the preview.
   - Updated the preview module to include the new plugin.

2. **Documentation**:
   - Added a section in the user documentation (`docs/user/features/custom-markdown-preview-styles.md`) explaining how to customize task list styles with CSS.
   - Updated the `readme.md` to highlight the new task list feature.

3. **Dependencies**:
   - Added `markdown-it-task-lists@^2.1.1` to `package.json` and updated `yarn.lock`.

4. **Changelog**:
   - Updated the `CHANGELOG.md` to reflect the new feature under the `[Unreleased]` section.

This enhancement improves the usability of Foam for users who rely on task lists for note-taking and project management.

Here is an example:
<img width="690" alt="image" src="https://github.com/user-attachments/assets/dd811e09-e327-4829-9439-54978d30d4cc" />
