### PR TITLE
docs: remove duplicate sentence

### DIFF
--- a/docs/user/features/link-reference-definitions.md
+++ b/docs/user/features/link-reference-definitions.md
@@ -18,7 +18,6 @@ The following example:
 [github-pages]: github-pages 'GitHub Pages'
 ```
 
-You can open the [raw markdown](https://foambubble.github.io/foam/features/link-reference-definitions.md) to see them at the bottom of this file
 You can open the [raw markdown](https://foambubble.github.io/foam/user/features/link-reference-definitions.md) to see them at the bottom of this file
 
 ## Specification


### PR DESCRIPTION
One of the sentences also contained a wrong link ("https://foambubble.github.io/foam/features/link-reference-definitions.md" instead of the correct "https://foambubble.github.io/foam/user/features/link-reference-definitions.md")