### PR TITLE
Added foam.wikilinks.order setting, which changes the order of Page Name and Alias in wikilinks

### DIFF
--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -655,6 +655,18 @@
           "type": "object",
           "description": "Custom graph styling settings. An example is present in the documentation.",
           "default": {}
+        },
+        "foam.wikilinks.order": {
+          "type": "string",
+          "default": "alias-last",
+          "enum": [
+            "alias-first",
+            "alias-last"
+          ],
+          "enumDescriptions": [
+            "Wiki links as [[Alias|Page Name]]",
+            "Wiki links as [[Page Name|Alias]]"
+          ]
         }
       }
     },

--- a/packages/foam-vscode/src/core/services/markdown-link.ts
+++ b/packages/foam-vscode/src/core/services/markdown-link.ts
@@ -8,7 +8,7 @@ export abstract class MarkdownLink {
   );
   private static wikilinkRegex2 = new RegExp(
     /\[\[\s*([^|\]]+)\s*\|?\s*([^#\]]+)?#?([^\]]*)?\s*\]\]/
-  ); 
+  );
   private static directLinkRegex = new RegExp(
     /\[(.*)\]\(<?([^#>]*)?#?([^\]>]+)?>?\)/
   );
@@ -16,9 +16,8 @@ export abstract class MarkdownLink {
   public static analyzeLink(link: ResourceLink) {
     try {
       if (link.type === 'wikilink') {
-        const wikiLinkOrder = getFoamVsCodeConfig("wikilinks.order");
-        if (wikiLinkOrder === 'alias-last') 
-        {
+        const wikiLinkOrder = getFoamVsCodeConfig('wikilinks.order');
+        if (wikiLinkOrder === 'alias-last') {
           const [, target, section, alias] = this.wikilinkRegex.exec(
             link.rawText
           );
@@ -27,27 +26,22 @@ export abstract class MarkdownLink {
             section: section ?? '',
             alias: alias ?? '',
           };
-        }
-        else
-        {
-          // use Gollum style syntact
+        } else {
+          // use Gollum-style syntact
           const [, alias, target, section] = this.wikilinkRegex2.exec(
             link.rawText
           );
-          if(!target)
-          {
+          if (!target) {
             return {
               target: alias?.replace(/\\/g, '') ?? '',
               section: section ?? '',
-              alias: ''
-            }
-          }
-          else
-          {
+              alias: '',
+            };
+          } else {
             return {
               target: target?.replace(/\\/g, '') ?? '',
               section: section ?? '',
-              alias: alias ?? ''
+              alias: alias ?? '',
             };
           }
         }


### PR DESCRIPTION
## Usage

- "foam.wikilinks.order": "alias-first" → [[Alias|Page Name]] _(GitHub wiki / Gollum)_
- "foam.wikilinks.order": "alias-last" → [[Page Name|Alias]] _(default: MediaWiki)_
