### PR TITLE
Support resolving absolute path

### DIFF
--- a/packages/foam-vscode/src/core/model/foam.ts
+++ b/packages/foam-vscode/src/core/model/foam.ts
@@ -1,6 +1,6 @@
 import { IDisposable } from '../common/lifecycle';
 import { IDataStore, IMatcher, IWatcher } from '../services/datastore';
-import { FoamWorkspace } from './workspace';
+import { FoamWorkspace, RootChecker, DummyRootChecker } from './workspace';
 import { FoamGraph } from './graph';
 import { ResourceParser } from './note';
 import { ResourceProvider } from './provider';
@@ -26,14 +26,16 @@ export const bootstrap = async (
   dataStore: IDataStore,
   parser: ResourceParser,
   initialProviders: ResourceProvider[],
-  defaultExtension: string = '.md'
+  defaultExtension: string = '.md',
+  checker: RootChecker = new DummyRootChecker()
 ) => {
   const workspace = await withTimingAsync(
     () =>
       FoamWorkspace.fromProviders(
         initialProviders,
         dataStore,
-        defaultExtension
+        defaultExtension,
+        checker
       ),
     ms => Logger.info(`Workspace loaded in ${ms}ms`)
   );

--- a/packages/foam-vscode/src/core/services/markdown-provider.ts
+++ b/packages/foam-vscode/src/core/services/markdown-provider.ts
@@ -91,7 +91,11 @@ export class MarkdownResourceProvider implements ResourceProvider {
             : './' + target;
         targetUri =
           workspace.find(path, resource.uri)?.uri ??
-          URI.placeholder(resource.uri.resolve(path).path);
+          URI.placeholder(
+            URI.parse(path).isAbsolute()
+              ? workspace.resolveRoot(resource.uri).joinPath(path).path
+              : resource.uri.resolve(path).path
+          );
         if (section && !targetUri.isPlaceholder()) {
           targetUri = targetUri.with({ fragment: section });
         }

--- a/packages/foam-vscode/src/extension.ts
+++ b/packages/foam-vscode/src/extension.ts
@@ -1,8 +1,9 @@
 /*global markdownit:readonly*/
 
-import { workspace, ExtensionContext, window, commands } from 'vscode';
+import { workspace, ExtensionContext, window, commands, Uri } from 'vscode';
 import { MarkdownResourceProvider } from './core/services/markdown-provider';
 import { bootstrap } from './core/model/foam';
+import { RootChecker } from './core/model/workspace';
 import { Logger } from './core/utils/log';
 
 import { features } from './features';
@@ -17,6 +18,13 @@ import { VsCodeWatcher } from './services/watcher';
 import { createMarkdownParser } from './core/services/markdown-parser';
 import VsCodeBasedParserCache from './services/cache';
 import { createMatcherAndDataStore } from './services/editor';
+
+class RealRootChecker implements RootChecker {
+  where(path: string): string | null {
+    const folder = workspace.getWorkspaceFolder(Uri.file(path));
+    return folder !== undefined ? folder.uri.fsPath : null;
+  }
+}
 
 export async function activate(context: ExtensionContext) {
   const logger = new VsCodeOutputLogger();
@@ -68,7 +76,8 @@ export async function activate(context: ExtensionContext) {
       dataStore,
       parser,
       [markdownProvider, attachmentProvider],
-      defaultExtension
+      defaultExtension,
+      new RealRootChecker()
     );
 
     // Load the features


### PR DESCRIPTION
Consider absolute path to be related to current workspace root, instead of actual path in the filesystem.

Current root is decided by base URI, if any.
Since that we can have multi-root workspace, the root for each resolving process may be different, according to the base URI.

---

The implement try to use one `FoamWorkspace` instance, and inject a `RootChecker` for resolving root folder for some base URI.
This is probably the minimal possible implementation for this feature, but will have some problem like

- The Foam graph feature will merge nodes from all workspace roots into one single graph.

Another potential implementation, is to have multiple `FoamWorkspace` instance, and dispatch resolving process to
corresponding instance based on current context.

Also, the implementation looks a little dirty, by exposing and using `resolveRoot` during placeholder generation and file creation.
If there is any concern around this, please let me know. :D
