### PR TITLE
Add FOAM_CURRENT_DIR template variable 

### DIFF
--- a/.claude/commands/research-issue.md
+++ b/.claude/commands/research-issue.md
@@ -1,0 +1,61 @@
+# Research Issue Command
+
+Research a GitHub issue by analyzing the issue details and codebase to generate a comprehensive task analysis file.
+
+## Usage
+
+```
+/research-issue <issue-number>
+```
+
+## Parameters
+
+- `issue-number` (required): The GitHub issue number to research
+
+## Description
+
+This command performs comprehensive research on a GitHub issue by:
+
+1. **Fetching Issue Details**: Uses `gh issue view` to get issue title, description, labels, comments, and related information
+2. **Codebase Analysis**: Searches the codebase for relevant files, patterns, and components mentioned in the issue
+3. **Root Cause Analysis**: Identifies possible technical causes based on the issue description and codebase findings
+4. **Solution Planning**: Proposes two solution approaches ranked by preference
+5. **Documentation**: Creates a structured task file in `.agent/tasks/<issue-id>-<sanitized-title>.md`
+
+If there is already a `.agent/tasks/<issue-id>-<sanitized-title>.md` file, use it for context and update it accordingly.
+If at any time during these steps you need clarifying information from me, please ask.
+
+## Output Format
+
+Creates a markdown file with:
+
+- Issue summary and key details
+- Research findings from codebase analysis
+- Identified possible root causes
+- Two ranked solution approaches with pros/cons
+- Technical considerations and dependencies
+
+## Examples
+
+```
+/research-issue 1234
+/research-issue 567
+```
+
+## Implementation
+
+The command will:
+
+1. Validate the issue number and check if it exists
+2. Fetch issue details using GitHub CLI
+3. Search codebase for relevant patterns, files, and components
+4. Analyze findings to identify root causes
+5. Generate structured markdown file with research results
+6. Save to `.agent/tasks/` directory with standardized naming
+
+## Error Handling
+
+- Invalid issue numbers
+- GitHub CLI authentication issues
+- Network connectivity problems
+- File system write permissions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,8 @@ This allows features to:
 ## Development Workflow
 
 We build production code together. I handle implementation details while you guide architecture and catch complexity early.
+When working on an issue, check if a `.agent/tasks/<issue-id>-<sanitized-title>.md` exists. If not, suggest whether we should start by doing a research on it (using the `/research-issue <issue-id>`) command.
+Whenever we work together on a task, feel free to challenge my assumptions and ideas and be critical if useful.
 
 ## Core Workflow: Research → Plan → Implement → Validate
 

--- a/docs/user/features/templates.md
+++ b/docs/user/features/templates.md
@@ -246,6 +246,7 @@ In addition, you can also use variables provided by Foam:
 | `FOAM_TITLE`         | The title of the note. If used, Foam will prompt you to enter a title for the note.                                                                                                                                                          |
 | `FOAM_TITLE_SAFE`    | The title of the note in a file system safe format. If used, Foam will prompt you to enter a title for the note unless `FOAM_TITLE` has already caused the prompt.                                                                           |
 | `FOAM_SLUG`          | The sluggified title of the note (using the default github slug method). If used, Foam will prompt you to enter a title for the note unless `FOAM_TITLE` has already caused the prompt.                                                      |
+| `FOAM_CURRENT_DIR`   | The current editor's directory path. Resolves to the directory of the currently active file, or falls back to workspace root if no editor is active. Useful for creating notes in the current directory context.                             |
 | `FOAM_DATE_*`        | `FOAM_DATE_YEAR`, `FOAM_DATE_MONTH`, `FOAM_DATE_WEEK` etc. Foam-specific versions of [VS Code's datetime snippet variables](https://code.visualstudio.com/docs/editor/userdefinedsnippets#_variables). Prefer these versions over VS Code's. |
 
 ### `FOAM_DATE_*` variables
@@ -305,6 +306,30 @@ foam_template:
 
 # $FOAM_DATE_YEAR-$FOAM_DATE_MONTH-$FOAM_DATE_DATE Daily Notes
 ```
+
+##### Creating notes in the current directory
+
+To create notes in the same directory as your currently active file, use the `FOAM_CURRENT_DIR` variable in your template's `filepath`:
+
+```markdown
+---
+foam_template:
+  name: Current Directory Note
+  filepath: '$FOAM_CURRENT_DIR/$FOAM_SLUG.md'
+---
+
+# $FOAM_TITLE
+
+$FOAM_SELECTED_TEXT
+```
+
+**Best practices for filepath patterns:**
+
+- **Explicit current directory:** `$FOAM_CURRENT_DIR/$FOAM_SLUG.md` - Creates notes in the current editor's directory
+- **Workspace root:** `/$FOAM_SLUG.md` - Always creates notes in workspace root
+- **Subdirectories:** `$FOAM_CURRENT_DIR/meetings/$FOAM_SLUG.md` - Creates notes in subdirectories relative to current location
+
+The `FOAM_CURRENT_DIR` approach is recommended over relative paths (like `./file.md`) because it makes the template's behavior explicit and doesn't depend on configuration settings.
 
 #### `name` and `description` attributes
 

--- a/packages/foam-vscode/src/features/commands/create-note.spec.ts
+++ b/packages/foam-vscode/src/features/commands/create-note.spec.ts
@@ -355,7 +355,7 @@ Template content using FOAM_CURRENT_DIR`,
         },
         {} as any
       );
-      // The note should be created in the subdir because FOAM_CURRENT_DIR resolves to current editor directory
+      // The note should be created in the workspace root because FOAM_CURRENT_DIR resolves to workspace root when no editor is active
       expect(resultInRoot.uri).toEqual(
         fromVsCodeUri(workspace.workspaceFolders[0].uri).joinPath(
           'my-new-note.md'

--- a/packages/foam-vscode/src/features/commands/create-note.ts
+++ b/packages/foam-vscode/src/features/commands/create-note.ts
@@ -11,7 +11,6 @@ import { TemplateLoader } from '../../services/template-loader';
 import { Template } from '../../services/note-creation-types';
 import { Resolver } from '../../services/variable-resolver';
 import { asAbsoluteWorkspaceUri, fileExists } from '../../services/editor';
-import { isSome } from '../../core/utils';
 import { CommandDescriptor } from '../../utils/commands';
 import { Foam } from '../../core/model/foam';
 import { Location } from '../../core/model/location';

--- a/packages/foam-vscode/src/services/note-creation-engine.ts
+++ b/packages/foam-vscode/src/services/note-creation-engine.ts
@@ -10,8 +10,7 @@ import {
   isPlaceholderTrigger,
 } from './note-creation-types';
 import { extractFoamTemplateFrontmatterMetadata } from '../utils/template-frontmatter-parser';
-import { asAbsoluteUri, URI } from '../core/model/uri';
-import { isAbsolute } from 'path';
+import { URI } from '../core/model/uri';
 
 /**
  * Unified engine for creating notes from both Markdown and JavaScript templates
@@ -57,9 +56,6 @@ export class NoteCreationEngine {
     template: Template & { type: 'javascript' },
     resolver: Resolver
   ): Promise<NoteCreationResult> {
-    // Convert resolver's variables back to extraParams for backward compatibility
-    const extraParams = resolver.getVariables();
-
     const templateContext: TemplateContext = {
       trigger,
       resolver,

--- a/packages/foam-vscode/src/services/variable-resolver.spec.ts
+++ b/packages/foam-vscode/src/services/variable-resolver.spec.ts
@@ -243,12 +243,9 @@ describe('variable-resolver, variable resolution', () => {
 
   describe('FOAM_CURRENT_DIR', () => {
     it('should resolve to workspace root when no active editor', async () => {
-      const resolver = new Resolver(
-        new Map<string, string>(),
-        new Date()
-      );
+      const resolver = new Resolver(new Map<string, string>(), new Date());
       const result = await resolver.resolve(new Variable('FOAM_CURRENT_DIR'));
-      
+
       // Should resolve to some directory path
       expect(typeof result).toBe('string');
       expect(result.length).toBeGreaterThan(0);
@@ -256,18 +253,18 @@ describe('variable-resolver, variable resolution', () => {
 
     it('should resolve to current directory when editor is active', async () => {
       // Create a test file in a subdirectory
-      const testFile = await createFile('Test content', ['test-dir', 'test-file.md']);
-      
+      const testFile = await createFile('Test content', [
+        'test-dir',
+        'test-file.md',
+      ]);
+
       try {
         // Open the file to make it the active editor
         await showInEditor(testFile.uri);
-        
-        const resolver = new Resolver(
-          new Map<string, string>(),
-          new Date()
-        );
+
+        const resolver = new Resolver(new Map<string, string>(), new Date());
         const result = await resolver.resolve(new Variable('FOAM_CURRENT_DIR'));
-        
+
         // Should resolve to the test-dir directory
         expect(typeof result).toBe('string');
         expect(result).toContain('test-dir');
@@ -281,7 +278,7 @@ describe('variable-resolver, variable resolution', () => {
       const input = '${FOAM_CURRENT_DIR}';
       const resolver = new Resolver(new Map(), new Date());
       const result = await resolver.resolveText(input);
-      
+
       // Should resolve to a directory path, not remain as ${FOAM_CURRENT_DIR}
       expect(result).not.toEqual(input);
       expect(typeof result).toBe('string');

--- a/packages/foam-vscode/src/services/variable-resolver.ts
+++ b/packages/foam-vscode/src/services/variable-resolver.ts
@@ -277,8 +277,8 @@ function resolveFoamCurrentDir() {
     if (workspace.workspaceFolders && workspace.workspaceFolders.length > 0) {
       return fromVsCodeUri(workspace.workspaceFolders[0].uri).toFsPath();
     }
-    // Final fallback to current working directory
-    return process.cwd();
+    // If no workspace is open, raise
+    throw new Error('No workspace is open');
   }
 }
 

--- a/packages/foam-vscode/src/test/test-utils-vscode.ts
+++ b/packages/foam-vscode/src/test/test-utils-vscode.ts
@@ -9,7 +9,6 @@ import { Logger } from '../core/utils/log';
 import { URI } from '../core/model/uri';
 import { Resource } from '../core/model/note';
 import { randomString, wait } from './test-utils';
-import { FoamWorkspace } from '../core/model/workspace';
 import { Foam } from '../core/model/foam';
 
 Logger.setLevel('error');


### PR DESCRIPTION
Resolves: #1498

## Summary

This PR introduces a new `FOAM_CURRENT_DIR` template variable that provides explicit current directory.

Benefits:

- ✅ Self-documenting templates - Clear intent about where notes will be created
- ✅ Configuration-independent - Works regardless of files.newNotePath setting
- ✅ Predictable behavior - Always resolves to current editor's directory when possible
- ✅ Better architecture - Avoids split-configuration anti-pattern

## Migration Path

Before (problematic):
```
---
foam_template:
  filepath: ./${FOAM_SLUG}.md  # Unclear behavior, depends on config
---
```

After (explicit):
```
---
foam_template:
  filepath: ${FOAM_CURRENT_DIR}/${FOAM_SLUG}.md  # Clear intent
---
```

### Examples

The new variable works in both Markdown and JavaScript templates:

Markdown template:
```markdown
---
foam_template:
  name: Meeting Notes
  filepath: ${FOAM_CURRENT_DIR}/meetings/${FOAM_SLUG}.md
---
# ${FOAM_TITLE}
```

JavaScript template:
```javascript
async function createNote({ resolver }) {
  const currentDir = await resolver.resolveFromName('FOAM_CURRENT_DIR');
  return {
    content: '# Meeting Notes',
    filepath: `${currentDir}/meetings/meeting.md`
  };
}
```

## Backwards Compatibility

This change is fully backwards compatible - existing templates continue to work unchanged. The new variable provides an additional, better option for users who want explicit directory control.