### PR TITLE
fix root-path relative links opening new notes instead of existing files (#1505)

### DIFF
--- a/packages/foam-vscode/src/extension.ts
+++ b/packages/foam-vscode/src/extension.ts
@@ -4,6 +4,7 @@ import { workspace, ExtensionContext, window, commands } from 'vscode';
 import { MarkdownResourceProvider } from './core/services/markdown-provider';
 import { bootstrap } from './core/model/foam';
 import { Logger } from './core/utils/log';
+import { fromVsCodeUri } from './utils/vsc-utils';
 
 import { features } from './features';
 import { VsCodeOutputLogger, exposeLogger } from './services/logging';
@@ -51,10 +52,16 @@ export async function activate(context: ExtensionContext) {
 
     const { notesExtensions, defaultExtension } = getNotesExtensions();
 
+    // Get workspace roots for workspace-relative path resolution
+    const workspaceRoots =
+      workspace.workspaceFolders?.map(folder => fromVsCodeUri(folder.uri)) ??
+      [];
+
     const markdownProvider = new MarkdownResourceProvider(
       dataStore,
       parser,
-      notesExtensions
+      notesExtensions,
+      workspaceRoots
     );
 
     const attachmentExtConfig = getAttachmentsExtensions();

--- a/packages/foam-vscode/src/test/test-utils.ts
+++ b/packages/foam-vscode/src/test/test-utils.ts
@@ -29,7 +29,7 @@ const position = Range.create(0, 0, 0, 100);
  */
 export const strToUri = URI.file;
 
-export const createTestWorkspace = () => {
+export const createTestWorkspace = (workspaceRoots: URI[] = []) => {
   const workspace = new FoamWorkspace();
   const parser = createMarkdownParser();
   const provider = new MarkdownResourceProvider(
@@ -37,7 +37,9 @@ export const createTestWorkspace = () => {
       read: _ => Promise.resolve(''),
       list: () => Promise.resolve([]),
     },
-    parser
+    parser,
+    ['.md'],
+    workspaceRoots
   );
   workspace.registerProvider(provider);
   return workspace;


### PR DESCRIPTION
Resolves #1505
When using root-path relative links (e.g., `[text](/path/file.md)`), Ctrl+clicking would create new notes instead of opening existing files. This was caused by the markdown provider treating workspace-relative paths as filesystem absolute paths.

**Changes:**
- Enhanced MarkdownResourceProvider to accept workspace roots context
- Updated link resolution logic to handle workspace-relative paths correctly
- Modified extension initialization to pass VS Code workspace folders
- Enhanced createTestWorkspace() utility to support workspace roots testing

**Behavior:**
- Links starting with `/` now resolve against workspace roots first
- Falls back to existing absolute path behavior when no workspace roots
- Supports multiple workspace scenarios and fragments
- Maintains full backward compatibility