### PR TITLE
Implements tag navigation and peek functionality (#893)

### DIFF
--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -106,7 +106,7 @@
     "menus": {
       "view/item/context": [
         {
-          "command": "foam-vscode.search-tag-from-explorer",
+          "command": "foam-vscode.search-tag",
           "when": "view == foam-vscode.tags-explorer && viewItem == tag",
           "group": "inline",
           "icon": "$(search)"
@@ -362,11 +362,7 @@
       },
       {
         "command": "foam-vscode.search-tag",
-        "title": "Foam: Search Tag"
-      },
-      {
-        "command": "foam-vscode.search-tag-from-explorer",
-        "title": "Search Workspace for Tag",
+        "title": "Foam: Search Tag",
         "icon": "$(search)"
       },
       {

--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -104,6 +104,14 @@
       }
     ],
     "menus": {
+      "view/item/context": [
+        {
+          "command": "foam-vscode.search-tag-from-explorer",
+          "when": "view == foam-vscode.tags-explorer && viewItem == tag",
+          "group": "inline",
+          "icon": "$(search)"
+        }
+      ],
       "view/title": [
         {
           "command": "foam-vscode.views.connections.show:backlinks",
@@ -351,6 +359,15 @@
       {
         "command": "foam-vscode.convert-link-style-incopy",
         "title": "Foam: Convert Link Format in Copy"
+      },
+      {
+        "command": "foam-vscode.search-tag",
+        "title": "Foam: Search Tag"
+      },
+      {
+        "command": "foam-vscode.search-tag-from-explorer",
+        "title": "Search Workspace for Tag",
+        "icon": "$(search)"
       },
       {
         "command": "foam-vscode.views.orphans.group-by:folder",

--- a/packages/foam-vscode/src/core/model/tags.test.ts
+++ b/packages/foam-vscode/src/core/model/tags.test.ts
@@ -1,5 +1,6 @@
 import { createTestNote, createTestWorkspace } from '../../test/test-utils';
 import { FoamTags } from './tags';
+import { Location } from './location';
 
 describe('FoamTags', () => {
   it('Collects tags from a list of resources', () => {
@@ -23,12 +24,17 @@ describe('FoamTags', () => {
     ws.set(pageB);
 
     const tags = FoamTags.fromWorkspace(ws);
-
     expect(tags.tags).toEqual(
       new Map([
-        ['primary', [pageA.uri, pageB.uri]],
-        ['secondary', [pageA.uri]],
-        ['third', [pageB.uri]],
+        [
+          'primary',
+          [
+            Location.forObjectWithRange(pageA.uri, pageA.tags[0]),
+            Location.forObjectWithRange(pageB.uri, pageB.tags[0]),
+          ],
+        ],
+        ['secondary', [Location.forObjectWithRange(pageA.uri, pageA.tags[1])]],
+        ['third', [Location.forObjectWithRange(pageB.uri, pageB.tags[1])]],
       ])
     );
   });
@@ -51,7 +57,11 @@ describe('FoamTags', () => {
     ws.set(taglessPage);
 
     const tags = FoamTags.fromWorkspace(ws);
-    expect(tags.tags).toEqual(new Map([['primary', [page.uri]]]));
+    expect(tags.tags).toEqual(
+      new Map([
+        ['primary', [Location.forObjectWithRange(page.uri, page.tags[0])]],
+      ])
+    );
 
     const newPage = createTestNote({
       uri: '/page-b.md',
@@ -62,7 +72,17 @@ describe('FoamTags', () => {
     ws.set(newPage);
     tags.update();
 
-    expect(tags.tags).toEqual(new Map([['primary', [page.uri, newPage.uri]]]));
+    expect(tags.tags).toEqual(
+      new Map([
+        [
+          'primary',
+          [
+            Location.forObjectWithRange(page.uri, page.tags[0]),
+            Location.forObjectWithRange(newPage.uri, newPage.tags[0]),
+          ],
+        ],
+      ])
+    );
   });
 
   it('Replaces the tag when a note is updated with an altered tag', () => {
@@ -78,7 +98,11 @@ describe('FoamTags', () => {
     ws.set(page);
 
     const tags = FoamTags.fromWorkspace(ws);
-    expect(tags.tags).toEqual(new Map([['primary', [page.uri]]]));
+    expect(tags.tags).toEqual(
+      new Map([
+        ['primary', [Location.forObjectWithRange(page.uri, page.tags[0])]],
+      ])
+    );
 
     const pageEdited = createTestNote({
       uri: '/page-a.md',
@@ -90,7 +114,14 @@ describe('FoamTags', () => {
     ws.set(pageEdited);
     tags.update();
 
-    expect(tags.tags).toEqual(new Map([['new', [page.uri]]]));
+    expect(tags.tags).toEqual(
+      new Map([
+        [
+          'new',
+          [Location.forObjectWithRange(pageEdited.uri, pageEdited.tags[0])],
+        ],
+      ])
+    );
   });
 
   it('Updates the metadata of a tag when the note is moved', () => {
@@ -105,7 +136,11 @@ describe('FoamTags', () => {
     ws.set(page);
 
     const tags = FoamTags.fromWorkspace(ws);
-    expect(tags.tags).toEqual(new Map([['primary', [page.uri]]]));
+    expect(tags.tags).toEqual(
+      new Map([
+        ['primary', [Location.forObjectWithRange(page.uri, page.tags[0])]],
+      ])
+    );
 
     const pageEdited = createTestNote({
       uri: '/new-place/page-a.md',
@@ -118,7 +153,14 @@ describe('FoamTags', () => {
     ws.set(pageEdited);
     tags.update();
 
-    expect(tags.tags).toEqual(new Map([['primary', [pageEdited.uri]]]));
+    expect(tags.tags).toEqual(
+      new Map([
+        [
+          'primary',
+          [Location.forObjectWithRange(pageEdited.uri, pageEdited.tags[0])],
+        ],
+      ])
+    );
   });
 
   it('Updates the metadata of a tag when a note is deleted', () => {
@@ -133,11 +175,15 @@ describe('FoamTags', () => {
     ws.set(page);
 
     const tags = FoamTags.fromWorkspace(ws);
-    expect(tags.tags).toEqual(new Map([['primary', [page.uri]]]));
+    expect(tags.tags).toEqual(
+      new Map([
+        ['primary', [Location.forObjectWithRange(page.uri, page.tags[0])]],
+      ])
+    );
 
     ws.delete(page.uri);
     tags.update();
 
-    expect(tags.tags).toEqual(new Map());
+    expect(tags.tags.size).toEqual(0);
   });
 });

--- a/packages/foam-vscode/src/core/model/tags.ts
+++ b/packages/foam-vscode/src/core/model/tags.ts
@@ -1,11 +1,12 @@
 import { FoamWorkspace } from './workspace';
-import { URI } from './uri';
 import { IDisposable } from '../common/lifecycle';
 import { debounce } from 'lodash';
 import { Emitter } from '../common/event';
+import { Tag } from './note';
+import { Location } from './location';
 
 export class FoamTags implements IDisposable {
-  public readonly tags: Map<string, URI[]> = new Map();
+  public readonly tags: Map<string, Location<Tag>[]> = new Map();
 
   private onDidUpdateEmitter = new Emitter<void>();
   onDidUpdate = this.onDidUpdateEmitter.event;
@@ -50,10 +51,10 @@ export class FoamTags implements IDisposable {
   update(): void {
     this.tags.clear();
     for (const resource of this.workspace.resources()) {
-      for (const tag of new Set(resource.tags.map(t => t.label))) {
-        const tagMeta = this.tags.get(tag) ?? [];
-        tagMeta.push(resource.uri);
-        this.tags.set(tag, tagMeta);
+      for (const tag of resource.tags) {
+        const tagLocations = this.tags.get(tag.label) ?? [];
+        tagLocations.push(Location.forObjectWithRange(resource.uri, tag));
+        this.tags.set(tag.label, tagLocations);
       }
     }
     this.onDidUpdateEmitter.fire();

--- a/packages/foam-vscode/src/features/commands/index.ts
+++ b/packages/foam-vscode/src/features/commands/index.ts
@@ -11,3 +11,4 @@ export { default as updateGraphCommand } from './update-graph';
 export { default as updateWikilinksCommand } from './update-wikilinks';
 export { default as createNote } from './create-note';
 export { default as generateStandaloneNote } from './convert-links-format-in-note';
+export { default as searchTagCommand } from './search-tag';

--- a/packages/foam-vscode/src/features/commands/search-tag.ts
+++ b/packages/foam-vscode/src/features/commands/search-tag.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { Foam } from '../../core/model/foam';
+import { TagItem } from '../panels/tags-explorer';
 
 export const SEARCH_TAG_COMMAND = {
   command: 'foam-vscode.search-tag',
@@ -15,7 +16,16 @@ export default async function activate(
   context.subscriptions.push(
     vscode.commands.registerCommand(
       SEARCH_TAG_COMMAND.command,
-      async (tagLabel?: string) => {
+      async (tagLabelOrItem?: string | TagItem) => {
+        let tagLabel: string | undefined;
+
+        // Handle both string and TagItem parameters
+        if (typeof tagLabelOrItem === 'string') {
+          tagLabel = tagLabelOrItem;
+        } else if (tagLabelOrItem && typeof tagLabelOrItem === 'object' && 'tag' in tagLabelOrItem) {
+          tagLabel = tagLabelOrItem.tag;
+        }
+
         if (!tagLabel) {
           // If no tag provided, show tag picker
           const allTags = Array.from(foam.tags.tags.keys()).sort();

--- a/packages/foam-vscode/src/features/commands/search-tag.ts
+++ b/packages/foam-vscode/src/features/commands/search-tag.ts
@@ -1,0 +1,49 @@
+import * as vscode from 'vscode';
+import { Foam } from '../../core/model/foam';
+
+export const SEARCH_TAG_COMMAND = {
+  command: 'foam-vscode.search-tag',
+  title: 'Foam: Search Tag',
+};
+
+export default async function activate(
+  context: vscode.ExtensionContext,
+  foamPromise: Promise<Foam>
+) {
+  const foam = await foamPromise;
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      SEARCH_TAG_COMMAND.command,
+      async (tagLabel?: string) => {
+        if (!tagLabel) {
+          // If no tag provided, show tag picker
+          const allTags = Array.from(foam.tags.tags.keys()).sort();
+          if (allTags.length === 0) {
+            vscode.window.showInformationMessage('No tags found in workspace.');
+            return;
+          }
+
+          tagLabel = await vscode.window.showQuickPick(allTags, {
+            title: 'Select a tag to search',
+            placeHolder: 'Choose a tag to search for...',
+          });
+
+          if (!tagLabel) {
+            return; // User cancelled
+          }
+        }
+
+        // Use VS Code's built-in search with the tag pattern
+        const searchQuery = `#${tagLabel}`;
+
+        await vscode.commands.executeCommand('workbench.action.findInFiles', {
+          query: searchQuery,
+          triggerSearch: true,
+          matchWholeWord: false,
+          isCaseSensitive: true,
+        });
+      }
+    )
+  );
+}

--- a/packages/foam-vscode/src/features/commands/search-tag.ts
+++ b/packages/foam-vscode/src/features/commands/search-tag.ts
@@ -22,7 +22,11 @@ export default async function activate(
         // Handle both string and TagItem parameters
         if (typeof tagLabelOrItem === 'string') {
           tagLabel = tagLabelOrItem;
-        } else if (tagLabelOrItem && typeof tagLabelOrItem === 'object' && 'tag' in tagLabelOrItem) {
+        } else if (
+          tagLabelOrItem &&
+          typeof tagLabelOrItem === 'object' &&
+          'tag' in tagLabelOrItem
+        ) {
           tagLabel = tagLabelOrItem.tag;
         }
 

--- a/packages/foam-vscode/src/features/commands/search-tag.ts
+++ b/packages/foam-vscode/src/features/commands/search-tag.ts
@@ -49,10 +49,8 @@ export default async function activate(
         }
 
         // Use VS Code's built-in search with the tag pattern
-        const searchQuery = `#${tagLabel}`;
-
         await vscode.commands.executeCommand('workbench.action.findInFiles', {
-          query: searchQuery,
+          query: `#${tagLabel}`,
           triggerSearch: true,
           matchWholeWord: false,
           isCaseSensitive: true,

--- a/packages/foam-vscode/src/features/navigation-provider.spec.ts
+++ b/packages/foam-vscode/src/features/navigation-provider.spec.ts
@@ -13,6 +13,7 @@ import { FoamGraph } from '../core/model/graph';
 import { commandAsURI } from '../utils/commands';
 import { CREATE_NOTE_COMMAND } from './commands/create-note';
 import { Location } from '../core/model/location';
+import { FoamTags } from '../core/model/tags';
 
 describe('Document navigation', () => {
   const parser = createMarkdownParser([]);
@@ -33,9 +34,10 @@ describe('Document navigation', () => {
       const { uri, content } = await createFile('');
       const ws = createTestWorkspace().set(parser.parse(uri, content));
       const graph = FoamGraph.fromWorkspace(ws);
+      const tags = FoamTags.fromWorkspace(ws);
 
       const doc = await vscode.workspace.openTextDocument(toVsCodeUri(uri));
-      const provider = new NavigationProvider(ws, graph, parser);
+      const provider = new NavigationProvider(ws, graph, parser, tags);
       const links = provider.provideDocumentLinks(doc);
 
       expect(links.length).toEqual(0);
@@ -47,9 +49,10 @@ describe('Document navigation', () => {
       );
       const ws = createTestWorkspace().set(parser.parse(uri, content));
       const graph = FoamGraph.fromWorkspace(ws);
+      const tags = FoamTags.fromWorkspace(ws);
 
       const doc = await vscode.workspace.openTextDocument(toVsCodeUri(uri));
-      const provider = new NavigationProvider(ws, graph, parser);
+      const provider = new NavigationProvider(ws, graph, parser, tags);
       const links = provider.provideDocumentLinks(doc);
 
       expect(links.length).toEqual(0);
@@ -62,9 +65,10 @@ describe('Document navigation', () => {
         .set(parser.parse(fileA.uri, fileA.content))
         .set(parser.parse(fileA.uri, fileB.content));
       const graph = FoamGraph.fromWorkspace(ws);
+      const tags = FoamTags.fromWorkspace(ws);
 
       const { doc } = await showInEditor(fileB.uri);
-      const provider = new NavigationProvider(ws, graph, parser);
+      const provider = new NavigationProvider(ws, graph, parser, tags);
       const links = provider.provideDocumentLinks(doc);
 
       expect(links.length).toEqual(0);
@@ -75,9 +79,10 @@ describe('Document navigation', () => {
       const noteA = parser.parse(fileA.uri, fileA.content);
       const ws = createTestWorkspace().set(noteA);
       const graph = FoamGraph.fromWorkspace(ws);
+      const tags = FoamTags.fromWorkspace(ws);
 
       const { doc } = await showInEditor(fileA.uri);
-      const provider = new NavigationProvider(ws, graph, parser);
+      const provider = new NavigationProvider(ws, graph, parser, tags);
       const links = provider.provideDocumentLinks(doc);
 
       expect(links.length).toEqual(1);
@@ -103,9 +108,10 @@ describe('Document navigation', () => {
         parser.parse(fileA.uri, fileA.content)
       );
       const graph = FoamGraph.fromWorkspace(ws);
+      const tags = FoamTags.fromWorkspace(ws);
 
       const { doc } = await showInEditor(fileA.uri);
-      const provider = new NavigationProvider(ws, graph, parser);
+      const provider = new NavigationProvider(ws, graph, parser, tags);
       const definitions = await provider.provideDefinition(
         doc,
         new vscode.Position(0, 22)
@@ -120,9 +126,10 @@ describe('Document navigation', () => {
         .set(parser.parse(fileA.uri, fileA.content))
         .set(parser.parse(fileB.uri, fileB.content));
       const graph = FoamGraph.fromWorkspace(ws);
+      const tags = FoamTags.fromWorkspace(ws);
 
       const { doc } = await showInEditor(fileB.uri);
-      const provider = new NavigationProvider(ws, graph, parser);
+      const provider = new NavigationProvider(ws, graph, parser, tags);
       const definitions = await provider.provideDefinition(
         doc,
         new vscode.Position(0, 22)
@@ -147,9 +154,10 @@ describe('Document navigation', () => {
         .set(parser.parse(fileA.uri, fileA.content))
         .set(parser.parse(fileB.uri, fileB.content));
       const graph = FoamGraph.fromWorkspace(ws);
+      const tags = FoamTags.fromWorkspace(ws);
 
       const { doc } = await showInEditor(fileB.uri);
-      const provider = new NavigationProvider(ws, graph, parser);
+      const provider = new NavigationProvider(ws, graph, parser, tags);
 
       const definitions = await provider.provideDefinition(
         doc,
@@ -170,9 +178,10 @@ describe('Document navigation', () => {
         .set(parser.parse(fileA.uri, fileA.content))
         .set(parser.parse(fileB.uri, fileB.content));
       const graph = FoamGraph.fromWorkspace(ws);
+      const tags = FoamTags.fromWorkspace(ws);
 
       const { doc } = await showInEditor(fileB.uri);
-      const provider = new NavigationProvider(ws, graph, parser);
+      const provider = new NavigationProvider(ws, graph, parser, tags);
       const definitions = await provider.provideDefinition(
         doc,
         new vscode.Position(0, 22)
@@ -193,9 +202,10 @@ describe('Document navigation', () => {
         .set(parser.parse(fileA.uri, fileA.content))
         .set(parser.parse(fileB.uri, fileB.content));
       const graph = FoamGraph.fromWorkspace(ws);
+      const tags = FoamTags.fromWorkspace(ws);
 
       const { doc } = await showInEditor(fileB.uri);
-      const provider = new NavigationProvider(ws, graph, parser);
+      const provider = new NavigationProvider(ws, graph, parser, tags);
       const definitions = await provider.provideDefinition(
         doc,
         new vscode.Position(3, 10)
@@ -223,9 +233,10 @@ describe('Document navigation', () => {
         .set(parser.parse(fileC.uri, fileC.content))
         .set(parser.parse(fileD.uri, fileD.content));
       const graph = FoamGraph.fromWorkspace(ws);
+      const tags = FoamTags.fromWorkspace(ws);
 
       const { doc } = await showInEditor(fileB.uri);
-      const provider = new NavigationProvider(ws, graph, parser);
+      const provider = new NavigationProvider(ws, graph, parser, tags);
 
       const refs = await provider.provideReferences(
         doc,
@@ -254,9 +265,10 @@ describe('Document navigation', () => {
         .set(parser.parse(fileB.uri, fileB.content))
         .set(parser.parse(fileC.uri, fileC.content));
       const graph = FoamGraph.fromWorkspace(ws);
+      const tags = FoamTags.fromWorkspace(ws);
 
       const { doc } = await showInEditor(fileA.uri);
-      const provider = new NavigationProvider(ws, graph, parser);
+      const provider = new NavigationProvider(ws, graph, parser, tags);
 
       // Test references for #tag1 (position 15 is within the #tag1 text)
       const tag1Refs = await provider.provideReferences(
@@ -282,9 +294,10 @@ describe('Document navigation', () => {
         parser.parse(fileA.uri, fileA.content)
       );
       const graph = FoamGraph.fromWorkspace(ws);
+      const tags = FoamTags.fromWorkspace(ws);
 
       const { doc } = await showInEditor(fileA.uri);
-      const provider = new NavigationProvider(ws, graph, parser);
+      const provider = new NavigationProvider(ws, graph, parser, tags);
 
       // Test references for #same-tag (clicking on first occurrence)
       const refs = await provider.provideReferences(
@@ -312,9 +325,10 @@ describe('Document navigation', () => {
         parser.parse(fileA.uri, fileA.content)
       );
       const graph = FoamGraph.fromWorkspace(ws);
+      const tags = FoamTags.fromWorkspace(ws);
 
       const { doc } = await showInEditor(fileA.uri);
-      const provider = new NavigationProvider(ws, graph, parser);
+      const provider = new NavigationProvider(ws, graph, parser, tags);
 
       // Position on "normal text" (not on a tag or link)
       const refs = await provider.provideReferences(

--- a/packages/foam-vscode/src/features/navigation-provider.spec.ts
+++ b/packages/foam-vscode/src/features/navigation-provider.spec.ts
@@ -244,7 +244,9 @@ describe('Document navigation', () => {
 
     it('should provide references for tags', async () => {
       const fileA = await createFile('This file has #tag1 and #tag2.');
-      const fileB = await createFile('This file also has #tag1 and other content.');
+      const fileB = await createFile(
+        'This file also has #tag1 and other content.'
+      );
       const fileC = await createFile('This file has #tag2 and #tag3.');
 
       const ws = createTestWorkspace()
@@ -272,10 +274,13 @@ describe('Document navigation', () => {
     });
 
     it('should provide references for tags with different positions', async () => {
-      const fileA = await createFile('Multiple #same-tag mentions #same-tag here.');
+      const fileA = await createFile(
+        'Multiple #same-tag mentions #same-tag here.'
+      );
 
-      const ws = createTestWorkspace()
-        .set(parser.parse(fileA.uri, fileA.content));
+      const ws = createTestWorkspace().set(
+        parser.parse(fileA.uri, fileA.content)
+      );
       const graph = FoamGraph.fromWorkspace(ws);
 
       const { doc } = await showInEditor(fileA.uri);
@@ -290,17 +295,22 @@ describe('Document navigation', () => {
       expect(refs.length).toEqual(2); // Both occurrences of #same-tag
 
       // Verify both ranges are correct
-      const sortedRefs = refs.sort((a, b) => a.range.start.character - b.range.start.character);
+      const sortedRefs = refs.sort(
+        (a, b) => a.range.start.character - b.range.start.character
+      );
 
       // First occurrence: "Multiple #same-tag mentions"
-      expect(sortedRefs[0].range.start.character).toBeLessThan(sortedRefs[1].range.start.character);
+      expect(sortedRefs[0].range.start.character).toBeLessThan(
+        sortedRefs[1].range.start.character
+      );
     });
 
     it('should not provide references when position is not on a tag', async () => {
       const fileA = await createFile('This file has #tag1 and normal text.');
 
-      const ws = createTestWorkspace()
-        .set(parser.parse(fileA.uri, fileA.content));
+      const ws = createTestWorkspace().set(
+        parser.parse(fileA.uri, fileA.content)
+      );
       const graph = FoamGraph.fromWorkspace(ws);
 
       const { doc } = await showInEditor(fileA.uri);

--- a/packages/foam-vscode/src/features/navigation-provider.ts
+++ b/packages/foam-vscode/src/features/navigation-provider.ts
@@ -112,7 +112,7 @@ export class NavigationProvider
    */
   private getTagReferences(tagLabel: string): vscode.Location[] {
     const references: vscode.Location[] = [];
-    const tagLocations = this.tags.tags.get(tagLabel);
+    const tagLocations = this.tags.tags.get(tagLabel) ?? [];
     for (const tagLocation of tagLocations) {
       references.push(
         new vscode.Location(

--- a/packages/foam-vscode/src/features/navigation-provider.ts
+++ b/packages/foam-vscode/src/features/navigation-provider.ts
@@ -115,21 +115,21 @@ export class NavigationProvider
    */
   private getTagReferences(tagLabel: string): vscode.Location[] {
     const references: vscode.Location[] = [];
-    const resourceUris = this.tags.tags.get(tagLabel);
-    for (const uri of resourceUris) {
-      const resource = this.workspace.get(uri);
-      // Find all tags in the resource that match the target tag label
-      const matchingTags = resource.tags.filter(tag => tag.label === tagLabel);
 
-      // Convert each matching tag to a VS Code location
-      for (const tag of matchingTags) {
-        references.push(
-          new vscode.Location(
-            toVsCodeUri(resource.uri),
-            toVsCodeRange(tag.range)
-          )
-        );
-      }
+    // Get tag locations from FoamTags
+    const tagLocations = this.tags.tags.get(tagLabel);
+    if (!tagLocations) {
+      return references;
+    }
+
+    // Convert each tag location to a VS Code location
+    for (const tagLocation of tagLocations) {
+      references.push(
+        new vscode.Location(
+          toVsCodeUri(tagLocation.uri),
+          toVsCodeRange(tagLocation.range)
+        )
+      );
     }
 
     return references;

--- a/packages/foam-vscode/src/features/navigation-provider.ts
+++ b/packages/foam-vscode/src/features/navigation-provider.ts
@@ -81,10 +81,7 @@ export class NavigationProvider
 
     // Check if position is on a tag first
     const targetTag = resource.tags.find(tag =>
-      Range.containsPosition(tag.range, {
-        line: position.line,
-        character: position.character,
-      })
+      Range.containsPosition(tag.range, position)
     );
     if (targetTag) {
       return this.getTagReferences(targetTag.label);
@@ -115,14 +112,7 @@ export class NavigationProvider
    */
   private getTagReferences(tagLabel: string): vscode.Location[] {
     const references: vscode.Location[] = [];
-
-    // Get tag locations from FoamTags
     const tagLocations = this.tags.tags.get(tagLabel);
-    if (!tagLocations) {
-      return references;
-    }
-
-    // Convert each tag location to a VS Code location
     for (const tagLocation of tagLocations) {
       references.push(
         new vscode.Location(
@@ -131,7 +121,6 @@ export class NavigationProvider
         )
       );
     }
-
     return references;
   }
 

--- a/packages/foam-vscode/src/features/navigation-provider.ts
+++ b/packages/foam-vscode/src/features/navigation-provider.ts
@@ -89,10 +89,7 @@ export class NavigationProvider
 
     // Check if position is on a link
     const targetLink: ResourceLink | undefined = resource.links.find(link =>
-      Range.containsPosition(link.range, {
-        line: position.line,
-        character: position.character,
-      })
+      Range.containsPosition(link.range, position)
     );
     if (!targetLink) {
       return;

--- a/packages/foam-vscode/src/features/panels/tags-explorer.ts
+++ b/packages/foam-vscode/src/features/panels/tags-explorer.ts
@@ -227,7 +227,7 @@ export class TagsProvider extends FolderTreeProvider<TagTreeItem, string> {
       const tagLocations = this.foamTags.tags.get(element.tag) ?? [];
       const resourceTagPromises = tagLocations.map(async tagLocation => {
         const note = this.workspace.get(tagLocation.uri);
-        return await ResourceRangeTreeItem.createStandardItem(
+        return ResourceRangeTreeItem.createStandardItem(
           this.workspace,
           note,
           tagLocation.range,

--- a/packages/foam-vscode/src/features/panels/tags-explorer.ts
+++ b/packages/foam-vscode/src/features/panels/tags-explorer.ts
@@ -99,6 +99,15 @@ export default async function activate(
           });
         }
       }
+    ),
+    vscode.commands.registerCommand(
+      'foam-vscode.search-tag-from-explorer',
+      async (tagItem: TagItem) => {
+        if (!tagItem || !tagItem.tag) {
+          return;
+        }
+        await vscode.commands.executeCommand('foam-vscode.search-tag', tagItem.tag);
+      }
     )
   );
 }

--- a/packages/foam-vscode/src/features/panels/tags-explorer.ts
+++ b/packages/foam-vscode/src/features/panels/tags-explorer.ts
@@ -164,7 +164,7 @@ export class TagsProvider extends FolderTreeProvider<TagTreeItem, string> {
 
   refresh(): void {
     this.tags = [...this.foamTags.tags]
-      .map(([tag, notes]) => ({ tag, notes }))
+      .map(([tag, resources]) => ({ tag, notes: resources.map(r => r.uri) }))
       .sort((a, b) => a.tag.localeCompare(b.tag));
     super.refresh();
   }
@@ -183,11 +183,13 @@ export class TagsProvider extends FolderTreeProvider<TagTreeItem, string> {
   }
 
   private countResourcesInSubtree(node: Folder<string>) {
-    const nChildren = walk(
-      node,
-      tag => this.foamTags.tags.get(tag)?.length ?? 0
-    ).reduce((acc, nResources) => acc + nResources, 0);
-    return nChildren;
+    const uniqueUris = new Set<string>();
+    walk(node, tag => {
+      const tagLocations = this.foamTags.tags.get(tag) ?? [];
+      tagLocations.forEach(location => uniqueUris.add(location.uri.toString()));
+      return 0; // Return value not used when collecting URIs
+    });
+    return uniqueUris.size;
   }
 
   createFolderTreeItem(
@@ -205,8 +207,9 @@ export class TagsProvider extends FolderTreeProvider<TagTreeItem, string> {
     node: Folder<string>
   ): TagItem {
     const nChildren = this.countResourcesInSubtree(node);
-    const resources = this.foamTags.tags.get(value) ?? [];
-    return new TagItem(node, nChildren, resources, parent);
+    const tagLocations = this.foamTags.tags.get(value) ?? [];
+    const resourceUris = tagLocations.map(location => location.uri);
+    return new TagItem(node, nChildren, resourceUris, parent);
   }
 
   async getChildren(element?: TagItem): Promise<TagTreeItem[]> {
@@ -219,20 +222,20 @@ export class TagsProvider extends FolderTreeProvider<TagTreeItem, string> {
     const subtags = await super.getChildren(element);
 
     // Compute the resources children
-    const resourceTags: ResourceRangeTreeItem[] = (element?.notes ?? [])
-      .map(uri => this.workspace.get(uri))
-      .reduce((acc, note) => {
-        const tags = note.tags.filter(t => t.label === element.tag);
-        const items = tags.map(t =>
-          ResourceRangeTreeItem.createStandardItem(
-            this.workspace,
-            note,
-            t.range,
-            'tag'
-          )
+    const resourceTags: ResourceRangeTreeItem[] = [];
+    if (element) {
+      const tagLocations = this.foamTags.tags.get(element.tag) ?? [];
+      const resourceTagPromises = tagLocations.map(async tagLocation => {
+        const note = this.workspace.get(tagLocation.uri);
+        return await ResourceRangeTreeItem.createStandardItem(
+          this.workspace,
+          note,
+          tagLocation.range,
+          'tag'
         );
-        return [...acc, ...items];
-      }, []);
+      });
+      resourceTags.push(...(await Promise.all(resourceTagPromises)));
+    }
     const resources = (
       await groupRangesByResource(this.workspace, resourceTags)
     ).map(item => {

--- a/packages/foam-vscode/src/features/panels/tags-explorer.ts
+++ b/packages/foam-vscode/src/features/panels/tags-explorer.ts
@@ -99,15 +99,6 @@ export default async function activate(
           });
         }
       }
-    ),
-    vscode.commands.registerCommand(
-      'foam-vscode.search-tag-from-explorer',
-      async (tagItem: TagItem) => {
-        if (!tagItem || !tagItem.tag) {
-          return;
-        }
-        await vscode.commands.executeCommand('foam-vscode.search-tag', tagItem.tag);
-      }
     )
   );
 }


### PR DESCRIPTION
Resolves #893

Tag Peek References:
- Users can now press F12 on any tag to peek all references

Enhanced Tag Search:
- Created new "Foam: Search Tag" ('foam-vscode.search-tag') command for workspace tag search
- Added inline search action button that appears on hover over tag items in tag explorer
- Clicking search icon triggers VS Code's search panel with tag query