### PR TITLE
#1328 Add support for wikilink image styling/sizing properties and title support in md image link

### DIFF
--- a/docs/user/features/embeds.md
+++ b/docs/user/features/embeds.md
@@ -75,3 +75,60 @@ Available options:
 - `full-inline`
 - `content-card`
 - `content-inline`
+
+## Image Sizing
+
+Resize images to make your documents more readable:
+
+```markdown
+![[image.png|300]]          # 300 pixels wide
+![[image.png|50%]]          # Half the container width
+```
+
+### Common Use Cases
+
+**Make large screenshots readable:**
+```markdown
+![[screenshot.png|600]]
+```
+
+**Create responsive images:**
+```markdown
+![[diagram.png|70%]]
+```
+
+**Size by width and height:**
+```markdown
+![[image.png|300x200]]
+```
+
+### Alignment
+
+Center, left, or right align images:
+
+```markdown
+![[image.png|300|center]]
+![[image.png|300|left]]
+![[image.png|300|right]]
+```
+
+### Alt Text
+
+Add descriptions for accessibility:
+
+```markdown
+![[chart.png|400|Monthly sales chart]]
+```
+
+### Units
+
+- `300` or `300px` - pixels (default)
+- `50%` - percentage of container
+- `20em` - relative to font size
+
+### Troubleshooting
+
+- Check image path: `![[path/to/image.png|300]]`
+- No spaces around pipes: `|300|` not `| 300 |`
+- Images only resize in preview mode, not edit mode
+- Use lowercase alignment: `center` not `Center`

--- a/packages/foam-vscode/src/core/services/markdown-link.test.ts
+++ b/packages/foam-vscode/src/core/services/markdown-link.test.ts
@@ -152,6 +152,94 @@ describe('MarkdownLink', () => {
     });
   });
 
+  describe('parse direct link with title attributes', () => {
+    it('should parse image with double-quoted title', () => {
+      const link = parser.parse(
+        getRandomURI(),
+        `![alt text](image.jpg "Title text")`
+      ).links[0];
+      const parsed = MarkdownLink.analyzeLink(link);
+      expect(parsed.target).toEqual('image.jpg');
+      expect(parsed.alias).toEqual('alt text');
+      expect(parsed.section).toEqual('');
+    });
+
+    it('should parse image with single-quoted title', () => {
+      const link = parser.parse(
+        getRandomURI(),
+        `![alt text](image.jpg 'Title text')`
+      ).links[0];
+      const parsed = MarkdownLink.analyzeLink(link);
+      expect(parsed.target).toEqual('image.jpg');
+      expect(parsed.alias).toEqual('alt text');
+      expect(parsed.section).toEqual('');
+    });
+
+    it('should handle sections with titles', () => {
+      const link = parser.parse(
+        getRandomURI(),
+        `![alt text](image.jpg#section "Title text")`
+      ).links[0];
+      const parsed = MarkdownLink.analyzeLink(link);
+      expect(parsed.target).toEqual('image.jpg');
+      expect(parsed.section).toEqual('section');
+      expect(parsed.alias).toEqual('alt text');
+    });
+
+    it('should handle URLs with spaces in titles', () => {
+      const link = parser.parse(
+        getRandomURI(),
+        `![alt](path/to/file.jpg "Title with spaces")`
+      ).links[0];
+      const parsed = MarkdownLink.analyzeLink(link);
+      expect(parsed.target).toEqual('path/to/file.jpg');
+      expect(parsed.alias).toEqual('alt');
+      expect(parsed.section).toEqual('');
+    });
+
+    it('should maintain compatibility with titleless images', () => {
+      const link = parser.parse(getRandomURI(), `![alt text](image.jpg)`)
+        .links[0];
+      const parsed = MarkdownLink.analyzeLink(link);
+      expect(parsed.target).toEqual('image.jpg');
+      expect(parsed.alias).toEqual('alt text');
+      expect(parsed.section).toEqual('');
+    });
+
+    it('should handle complex URLs with titles', () => {
+      const link = parser.parse(
+        getRandomURI(),
+        `![alt](path/to/image.jpg "Complex title with spaces")`
+      ).links[0];
+      const parsed = MarkdownLink.analyzeLink(link);
+      expect(parsed.target).toEqual('path/to/image.jpg');
+      expect(parsed.alias).toEqual('alt');
+      expect(parsed.section).toEqual('');
+    });
+
+    it('should parse regular links with titles', () => {
+      const link = parser.parse(
+        getRandomURI(),
+        `[link text](document.md "Link title")`
+      ).links[0];
+      const parsed = MarkdownLink.analyzeLink(link);
+      expect(parsed.target).toEqual('document.md');
+      expect(parsed.alias).toEqual('link text');
+      expect(parsed.section).toEqual('');
+    });
+
+    it('should handle titles with special characters', () => {
+      const link = parser.parse(
+        getRandomURI(),
+        `![alt](image.jpg "Title with special chars")`
+      ).links[0];
+      const parsed = MarkdownLink.analyzeLink(link);
+      expect(parsed.target).toEqual('image.jpg');
+      expect(parsed.alias).toEqual('alt');
+      expect(parsed.section).toEqual('');
+    });
+  });
+
   describe('rename wikilink', () => {
     it('should rename the target only', () => {
       const link = parser.parse(

--- a/packages/foam-vscode/src/core/services/markdown-link.ts
+++ b/packages/foam-vscode/src/core/services/markdown-link.ts
@@ -6,7 +6,7 @@ export abstract class MarkdownLink {
     /\[\[([^#|]+)?#?([^|]+)?\|?(.*)?\]\]/
   );
   private static directLinkRegex = new RegExp(
-    /\[(.*)\]\(<?([^#>]*)?#?([^\]>]+)?>?\)/
+    /\[(.*)\]\(<?([^#>]*?)(?:#([^>\s"'()]*))?(?:\s+(?:"[^"]*"|'[^']*'))?>?\)/
   );
 
   public static analyzeLink(link: ResourceLink) {

--- a/packages/foam-vscode/src/features/preview/wikilink-embed.test.ts
+++ b/packages/foam-vscode/src/features/preview/wikilink-embed.test.ts
@@ -2,6 +2,8 @@ import {
   WIKILINK_EMBED_REGEX,
   WIKILINK_EMBED_REGEX_GROUPS,
   retrieveNoteConfig,
+  parseImageParameters,
+  generateImageStyles,
 } from './wikilink-embed';
 import * as config from '../../services/config';
 
@@ -55,6 +57,264 @@ describe('Wikilink Note Embedding', () => {
       expect(match3[0]).toEqual('![[note-a#section 1]]');
       expect(match3[1]).toEqual(undefined);
       expect(match3[2]).toEqual('note-a#section 1');
+    });
+  });
+
+  describe('Image Parameter Parsing', () => {
+    it('should parse wikilinks with image sizing parameters', () => {
+      // Width only
+      const match1 = '![[image.png|300]]'.match(WIKILINK_EMBED_REGEX_GROUPS);
+      expect(match1[0]).toEqual('![[image.png|300]]');
+      expect(match1[1]).toEqual(undefined); // no modifier
+      expect(match1[2]).toEqual('image.png');
+      expect(match1[3]).toEqual('|300');
+
+      // Width and height
+      const match2 = '![[image.png|300x200]]'.match(WIKILINK_EMBED_REGEX_GROUPS);
+      expect(match2[0]).toEqual('![[image.png|300x200]]');
+      expect(match2[1]).toEqual(undefined);
+      expect(match2[2]).toEqual('image.png');
+      expect(match2[3]).toEqual('|300x200');
+
+      // Percentage width
+      const match3 = '![[image.png|50%]]'.match(WIKILINK_EMBED_REGEX_GROUPS);
+      expect(match3[0]).toEqual('![[image.png|50%]]');
+      expect(match3[1]).toEqual(undefined);
+      expect(match3[2]).toEqual('image.png');
+      expect(match3[3]).toEqual('|50%');
+    });
+
+    it('should parse wikilinks with modifiers and image parameters', () => {
+      const match = 'content![[image.png|300]]'.match(WIKILINK_EMBED_REGEX_GROUPS);
+      expect(match[0]).toEqual('content![[image.png|300]]');
+      expect(match[1]).toEqual('content');
+      expect(match[2]).toEqual('image.png');
+      expect(match[3]).toEqual('|300');
+    });
+
+    it('should parse wikilinks with multiple parameters', () => {
+      const match = '![[image.png|300|center]]'.match(WIKILINK_EMBED_REGEX_GROUPS);
+      expect(match[0]).toEqual('![[image.png|300|center]]');
+      expect(match[1]).toEqual(undefined);
+      expect(match[2]).toEqual('image.png');
+      expect(match[3]).toEqual('|300|center');
+    });
+
+    it('should handle wikilinks without parameters (backward compatibility)', () => {
+      const match = '![[image.png]]'.match(WIKILINK_EMBED_REGEX_GROUPS);
+      expect(match[0]).toEqual('![[image.png]]');
+      expect(match[1]).toEqual(undefined);
+      expect(match[2]).toEqual('image.png');
+      expect(match[3]).toEqual(undefined);
+    });
+
+    it('should parse complex filenames with parameters', () => {
+      const match = '![[folder/image-file.png|400px]]'.match(WIKILINK_EMBED_REGEX_GROUPS);
+      expect(match[0]).toEqual('![[folder/image-file.png|400px]]');
+      expect(match[1]).toEqual(undefined);
+      expect(match[2]).toEqual('folder/image-file.png');
+      expect(match[3]).toEqual('|400px');
+    });
+  });
+
+  describe('parseImageParameters Function', () => {
+    it('should parse width-only parameters', () => {
+      const result = parseImageParameters('image.png', '|300');
+      expect(result).toEqual({
+        filename: 'image.png',
+        width: '300',
+      });
+    });
+
+    it('should parse width x height parameters', () => {
+      const result = parseImageParameters('image.png', '|300x200');
+      expect(result).toEqual({
+        filename: 'image.png',
+        width: '300',
+        height: '200',
+      });
+    });
+
+    it('should parse percentage widths', () => {
+      const result = parseImageParameters('image.png', '|50%');
+      expect(result).toEqual({
+        filename: 'image.png',
+        width: '50%',
+      });
+    });
+
+    it('should parse width with units', () => {
+      const result = parseImageParameters('image.png', '|400px');
+      expect(result).toEqual({
+        filename: 'image.png',
+        width: '400px',
+      });
+    });
+
+    it('should parse width and alignment', () => {
+      const result = parseImageParameters('image.png', '|300|center');
+      expect(result).toEqual({
+        filename: 'image.png',
+        width: '300',
+        align: 'center',
+      });
+    });
+
+    it('should parse width, alignment, and alt text', () => {
+      const result = parseImageParameters('image.png', '|300|left|My image description');
+      expect(result).toEqual({
+        filename: 'image.png',
+        width: '300',
+        align: 'left',
+        alt: 'My image description',
+      });
+    });
+
+    it('should parse width and alt text (no alignment)', () => {
+      const result = parseImageParameters('image.png', '|300|My image description');
+      expect(result).toEqual({
+        filename: 'image.png',
+        width: '300',
+        alt: 'My image description',
+      });
+    });
+
+    it('should handle no parameters', () => {
+      const result = parseImageParameters('image.png');
+      expect(result).toEqual({
+        filename: 'image.png',
+      });
+    });
+
+    it('should handle empty parameters string', () => {
+      const result = parseImageParameters('image.png', '');
+      expect(result).toEqual({
+        filename: 'image.png',
+      });
+    });
+
+    it('should handle malformed parameters gracefully', () => {
+      const result = parseImageParameters('image.png', '|');
+      expect(result).toEqual({
+        filename: 'image.png',
+      });
+    });
+
+    it('should parse complex width x height with units', () => {
+      const result = parseImageParameters('image.png', '|400px x 300px');
+      expect(result).toEqual({
+        filename: 'image.png',
+        width: '400px',
+        height: '300px',
+      });
+    });
+
+    it('should handle right alignment', () => {
+      const result = parseImageParameters('image.png', '|300|right');
+      expect(result).toEqual({
+        filename: 'image.png',
+        width: '300',
+        align: 'right',
+      });
+    });
+
+    it('should handle alt text with pipes', () => {
+      const result = parseImageParameters('image.png', '|300|center|Alt text with | pipes');
+      expect(result).toEqual({
+        filename: 'image.png',
+        width: '300',
+        align: 'center',
+        alt: 'Alt text with | pipes',
+      });
+    });
+  });
+
+  describe('generateImageStyles Function', () => {
+    const mockMd = {
+      normalizeLink: (path: string) => path,
+    } as any;
+
+    it('should generate basic image HTML without parameters', () => {
+      const params = { filename: 'image.png' };
+      const result = generateImageStyles(params, mockMd);
+      expect(result).toEqual('<img src="image.png" alt="">');
+    });
+
+    it('should generate image with width only', () => {
+      const params = { filename: 'image.png', width: '300' };
+      const result = generateImageStyles(params, mockMd);
+      expect(result).toEqual('<img src="image.png" style="width: 300px; height: auto" alt="">');
+    });
+
+    it('should generate image with width and height', () => {
+      const params = { filename: 'image.png', width: '300', height: '200' };
+      const result = generateImageStyles(params, mockMd);
+      expect(result).toEqual('<img src="image.png" style="width: 300px; height: 200px" alt="">');
+    });
+
+    it('should generate image with percentage width', () => {
+      const params = { filename: 'image.png', width: '50%' };
+      const result = generateImageStyles(params, mockMd);
+      expect(result).toEqual('<img src="image.png" style="width: 50%; height: auto" alt="">');
+    });
+
+    it('should generate image with width and units preserved', () => {
+      const params = { filename: 'image.png', width: '400px' };
+      const result = generateImageStyles(params, mockMd);
+      expect(result).toEqual('<img src="image.png" style="width: 400px; height: auto" alt="">');
+    });
+
+    it('should generate image with center alignment', () => {
+      const params = { filename: 'image.png', width: '300', align: 'center' as const };
+      const result = generateImageStyles(params, mockMd);
+      expect(result).toEqual('<div style="text-align: center;"><img src="image.png" style="width: 300px; height: auto" alt=""></div>');
+    });
+
+    it('should generate image with left alignment', () => {
+      const params = { filename: 'image.png', width: '300', align: 'left' as const };
+      const result = generateImageStyles(params, mockMd);
+      expect(result).toEqual('<div style="text-align: left;"><img src="image.png" style="width: 300px; height: auto" alt=""></div>');
+    });
+
+    it('should generate image with right alignment', () => {
+      const params = { filename: 'image.png', width: '300', align: 'right' as const };
+      const result = generateImageStyles(params, mockMd);
+      expect(result).toEqual('<div style="text-align: right;"><img src="image.png" style="width: 300px; height: auto" alt=""></div>');
+    });
+
+    it('should generate image with alt text', () => {
+      const params = { filename: 'image.png', width: '300', alt: 'My image description' };
+      const result = generateImageStyles(params, mockMd);
+      expect(result).toEqual('<img src="image.png" style="width: 300px; height: auto" alt="My image description">');
+    });
+
+    it('should escape HTML in alt text', () => {
+      const params = { filename: 'image.png', alt: 'Image with <script>alert("xss")</script>' };
+      const result = generateImageStyles(params, mockMd);
+      expect(result).toEqual('<img src="image.png" alt="Image with &lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;">');
+    });
+
+    it('should generate image with width, alignment, and alt text', () => {
+      const params = {
+        filename: 'image.png',
+        width: '300',
+        align: 'center' as const,
+        alt: 'Centered image'
+      };
+      const result = generateImageStyles(params, mockMd);
+      expect(result).toEqual('<div style="text-align: center;"><img src="image.png" style="width: 300px; height: auto" alt="Centered image"></div>');
+    });
+
+    it('should handle em units', () => {
+      const params = { filename: 'image.png', width: '20em' };
+      const result = generateImageStyles(params, mockMd);
+      expect(result).toEqual('<img src="image.png" style="width: 20em; height: auto" alt="">');
+    });
+
+    it('should handle decimal values', () => {
+      const params = { filename: 'image.png', width: '300.5' };
+      const result = generateImageStyles(params, mockMd);
+      expect(result).toEqual('<img src="image.png" style="width: 300.5px; height: auto" alt="">');
     });
   });
 

--- a/packages/foam-vscode/src/features/preview/wikilink-embed.test.ts
+++ b/packages/foam-vscode/src/features/preview/wikilink-embed.test.ts
@@ -70,7 +70,9 @@ describe('Wikilink Note Embedding', () => {
       expect(match1[3]).toEqual('|300');
 
       // Width and height
-      const match2 = '![[image.png|300x200]]'.match(WIKILINK_EMBED_REGEX_GROUPS);
+      const match2 = '![[image.png|300x200]]'.match(
+        WIKILINK_EMBED_REGEX_GROUPS
+      );
       expect(match2[0]).toEqual('![[image.png|300x200]]');
       expect(match2[1]).toEqual(undefined);
       expect(match2[2]).toEqual('image.png');
@@ -85,7 +87,9 @@ describe('Wikilink Note Embedding', () => {
     });
 
     it('should parse wikilinks with modifiers and image parameters', () => {
-      const match = 'content![[image.png|300]]'.match(WIKILINK_EMBED_REGEX_GROUPS);
+      const match = 'content![[image.png|300]]'.match(
+        WIKILINK_EMBED_REGEX_GROUPS
+      );
       expect(match[0]).toEqual('content![[image.png|300]]');
       expect(match[1]).toEqual('content');
       expect(match[2]).toEqual('image.png');
@@ -93,7 +97,9 @@ describe('Wikilink Note Embedding', () => {
     });
 
     it('should parse wikilinks with multiple parameters', () => {
-      const match = '![[image.png|300|center]]'.match(WIKILINK_EMBED_REGEX_GROUPS);
+      const match = '![[image.png|300|center]]'.match(
+        WIKILINK_EMBED_REGEX_GROUPS
+      );
       expect(match[0]).toEqual('![[image.png|300|center]]');
       expect(match[1]).toEqual(undefined);
       expect(match[2]).toEqual('image.png');
@@ -109,7 +115,9 @@ describe('Wikilink Note Embedding', () => {
     });
 
     it('should parse complex filenames with parameters', () => {
-      const match = '![[folder/image-file.png|400px]]'.match(WIKILINK_EMBED_REGEX_GROUPS);
+      const match = '![[folder/image-file.png|400px]]'.match(
+        WIKILINK_EMBED_REGEX_GROUPS
+      );
       expect(match[0]).toEqual('![[folder/image-file.png|400px]]');
       expect(match[1]).toEqual(undefined);
       expect(match[2]).toEqual('folder/image-file.png');
@@ -161,7 +169,10 @@ describe('Wikilink Note Embedding', () => {
     });
 
     it('should parse width, alignment, and alt text', () => {
-      const result = parseImageParameters('image.png', '|300|left|My image description');
+      const result = parseImageParameters(
+        'image.png',
+        '|300|left|My image description'
+      );
       expect(result).toEqual({
         filename: 'image.png',
         width: '300',
@@ -171,7 +182,10 @@ describe('Wikilink Note Embedding', () => {
     });
 
     it('should parse width and alt text (no alignment)', () => {
-      const result = parseImageParameters('image.png', '|300|My image description');
+      const result = parseImageParameters(
+        'image.png',
+        '|300|My image description'
+      );
       expect(result).toEqual({
         filename: 'image.png',
         width: '300',
@@ -219,7 +233,10 @@ describe('Wikilink Note Embedding', () => {
     });
 
     it('should handle alt text with pipes', () => {
-      const result = parseImageParameters('image.png', '|300|center|Alt text with | pipes');
+      const result = parseImageParameters(
+        'image.png',
+        '|300|center|Alt text with | pipes'
+      );
       expect(result).toEqual({
         filename: 'image.png',
         width: '300',
@@ -243,55 +260,92 @@ describe('Wikilink Note Embedding', () => {
     it('should generate image with width only', () => {
       const params = { filename: 'image.png', width: '300' };
       const result = generateImageStyles(params, mockMd);
-      expect(result).toEqual('<img src="image.png" style="width: 300px; height: auto" alt="">');
+      expect(result).toEqual(
+        '<img src="image.png" style="width: 300px; height: auto" alt="">'
+      );
     });
 
     it('should generate image with width and height', () => {
       const params = { filename: 'image.png', width: '300', height: '200' };
       const result = generateImageStyles(params, mockMd);
-      expect(result).toEqual('<img src="image.png" style="width: 300px; height: 200px" alt="">');
+      expect(result).toEqual(
+        '<img src="image.png" style="width: 300px; height: 200px" alt="">'
+      );
     });
 
     it('should generate image with percentage width', () => {
       const params = { filename: 'image.png', width: '50%' };
       const result = generateImageStyles(params, mockMd);
-      expect(result).toEqual('<img src="image.png" style="width: 50%; height: auto" alt="">');
+      expect(result).toEqual(
+        '<img src="image.png" style="width: 50%; height: auto" alt="">'
+      );
     });
 
     it('should generate image with width and units preserved', () => {
       const params = { filename: 'image.png', width: '400px' };
       const result = generateImageStyles(params, mockMd);
-      expect(result).toEqual('<img src="image.png" style="width: 400px; height: auto" alt="">');
+      expect(result).toEqual(
+        '<img src="image.png" style="width: 400px; height: auto" alt="">'
+      );
     });
 
     it('should generate image with center alignment', () => {
-      const params = { filename: 'image.png', width: '300', align: 'center' as const };
+      const params = {
+        filename: 'image.png',
+        width: '300',
+        align: 'center' as const,
+      };
       const result = generateImageStyles(params, mockMd);
-      expect(result).toEqual('<div style="text-align: center;"><img src="image.png" style="width: 300px; height: auto" alt=""></div>');
+      expect(result).toEqual(
+        '<div style="text-align: center;"><img src="image.png" style="width: 300px; height: auto" alt=""></div>'
+      );
     });
 
     it('should generate image with left alignment', () => {
-      const params = { filename: 'image.png', width: '300', align: 'left' as const };
+      const params = {
+        filename: 'image.png',
+        width: '300',
+        align: 'left' as const,
+      };
       const result = generateImageStyles(params, mockMd);
-      expect(result).toEqual('<div style="text-align: left;"><img src="image.png" style="width: 300px; height: auto" alt=""></div>');
+      expect(result).toEqual(
+        '<div style="text-align: left;"><img src="image.png" style="width: 300px; height: auto" alt=""></div>'
+      );
     });
 
     it('should generate image with right alignment', () => {
-      const params = { filename: 'image.png', width: '300', align: 'right' as const };
+      const params = {
+        filename: 'image.png',
+        width: '300',
+        align: 'right' as const,
+      };
       const result = generateImageStyles(params, mockMd);
-      expect(result).toEqual('<div style="text-align: right;"><img src="image.png" style="width: 300px; height: auto" alt=""></div>');
+      expect(result).toEqual(
+        '<div style="text-align: right;"><img src="image.png" style="width: 300px; height: auto" alt=""></div>'
+      );
     });
 
     it('should generate image with alt text', () => {
-      const params = { filename: 'image.png', width: '300', alt: 'My image description' };
+      const params = {
+        filename: 'image.png',
+        width: '300',
+        alt: 'My image description',
+      };
       const result = generateImageStyles(params, mockMd);
-      expect(result).toEqual('<img src="image.png" style="width: 300px; height: auto" alt="My image description">');
+      expect(result).toEqual(
+        '<img src="image.png" style="width: 300px; height: auto" alt="My image description">'
+      );
     });
 
     it('should escape HTML in alt text', () => {
-      const params = { filename: 'image.png', alt: 'Image with <script>alert("xss")</script>' };
+      const params = {
+        filename: 'image.png',
+        alt: 'Image with <script>alert("xss")</script>',
+      };
       const result = generateImageStyles(params, mockMd);
-      expect(result).toEqual('<img src="image.png" alt="Image with &lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;">');
+      expect(result).toEqual(
+        '<img src="image.png" alt="Image with &lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;">'
+      );
     });
 
     it('should generate image with width, alignment, and alt text', () => {
@@ -299,22 +353,28 @@ describe('Wikilink Note Embedding', () => {
         filename: 'image.png',
         width: '300',
         align: 'center' as const,
-        alt: 'Centered image'
+        alt: 'Centered image',
       };
       const result = generateImageStyles(params, mockMd);
-      expect(result).toEqual('<div style="text-align: center;"><img src="image.png" style="width: 300px; height: auto" alt="Centered image"></div>');
+      expect(result).toEqual(
+        '<div style="text-align: center;"><img src="image.png" style="width: 300px; height: auto" alt="Centered image"></div>'
+      );
     });
 
     it('should handle em units', () => {
       const params = { filename: 'image.png', width: '20em' };
       const result = generateImageStyles(params, mockMd);
-      expect(result).toEqual('<img src="image.png" style="width: 20em; height: auto" alt="">');
+      expect(result).toEqual(
+        '<img src="image.png" style="width: 20em; height: auto" alt="">'
+      );
     });
 
     it('should handle decimal values', () => {
       const params = { filename: 'image.png', width: '300.5' };
       const result = generateImageStyles(params, mockMd);
-      expect(result).toEqual('<img src="image.png" style="width: 300.5px; height: auto" alt="">');
+      expect(result).toEqual(
+        '<img src="image.png" style="width: 300.5px; height: auto" alt="">'
+      );
     });
   });
 

--- a/packages/foam-vscode/src/features/preview/wikilink-embed.ts
+++ b/packages/foam-vscode/src/features/preview/wikilink-embed.ts
@@ -331,8 +331,8 @@ function parseImageParameters(
   const alignParam = params[1]?.trim().toLowerCase();
   if (alignParam && ['center', 'left', 'right'].includes(alignParam)) {
     result.align = alignParam as 'center' | 'left' | 'right';
-  } else if (alignParam && !alignParam.startsWith('class:')) {
-    // If not alignment and not a class, treat as alt text
+  } else if (alignParam) {
+    // If not alignment, treat as alt text
     result.alt = params.slice(1).join('|').trim();
   }
 

--- a/packages/foam-vscode/src/features/preview/wikilink-embed.ts
+++ b/packages/foam-vscode/src/features/preview/wikilink-embed.ts
@@ -39,9 +39,8 @@ export const markdownItWikilinkEmbed = (
     regex: WIKILINK_EMBED_REGEX,
     replace: (wikilinkItem: string) => {
       try {
-        const [, noteEmbedModifier, wikilink, parametersString] = wikilinkItem.match(
-          WIKILINK_EMBED_REGEX_GROUPS
-        );
+        const [, noteEmbedModifier, wikilink, parametersString] =
+          wikilinkItem.match(WIKILINK_EMBED_REGEX_GROUPS);
 
         if (isVirtualWorkspace()) {
           return `
@@ -140,7 +139,10 @@ Embed for attachments is not supported
       toRender = md.render(content);
       break;
     case 'image':
-      const imageParams = parseImageParameters(includedNote.uri.path, parametersString);
+      const imageParams = parseImageParameters(
+        includedNote.uri.path,
+        parametersString
+      );
       const imageHtml = generateImageStyles(imageParams, md);
       content = `<div class="embed-container-image">${imageHtml}</div>`;
       toRender = content;
@@ -288,7 +290,10 @@ interface ImageParameters {
   alt?: string;
 }
 
-function parseImageParameters(wikilink: string, parametersString?: string): ImageParameters {
+function parseImageParameters(
+  wikilink: string,
+  parametersString?: string
+): ImageParameters {
   const result: ImageParameters = {
     filename: wikilink,
   };
@@ -309,7 +314,9 @@ function parseImageParameters(wikilink: string, parametersString?: string): Imag
   if (sizeParam) {
     // Parse size parameter: could be "300", "300x200", "50%", "300px", etc.
     // Check for width x height format (but not if it's just a unit like "px")
-    const dimensionMatch = sizeParam.match(/^(\d+(?:\.\d+)?(?:px|%|em|rem|vw|vh)?)\s*x\s*(\d+(?:\.\d+)?(?:px|%|em|rem|vw|vh)?)$/i);
+    const dimensionMatch = sizeParam.match(
+      /^(\d+(?:\.\d+)?(?:px|%|em|rem|vw|vh)?)\s*x\s*(\d+(?:\.\d+)?(?:px|%|em|rem|vw|vh)?)$/i
+    );
     if (dimensionMatch) {
       // Width x Height format
       result.width = dimensionMatch[1]?.trim();
@@ -360,7 +367,9 @@ function generateImageStyles(params: ImageParameters, md: markdownit): string {
   const altAttr = alt ? ` alt="${escapeHtml(alt)}"` : ' alt=""';
 
   // Generate the image HTML
-  const imageHtml = `<img src="${md.normalizeLink(filename)}"${styleAttr}${altAttr}>`;
+  const imageHtml = `<img src="${md.normalizeLink(
+    filename
+  )}"${styleAttr}${altAttr}>`;
 
   // Wrap with alignment if specified
   if (align) {

--- a/packages/foam-vscode/src/features/preview/wikilink-embed.ts
+++ b/packages/foam-vscode/src/features/preview/wikilink-embed.ts
@@ -8,7 +8,7 @@ import { FoamWorkspace } from '../../core/model/workspace';
 import { Logger } from '../../core/utils/log';
 import { Resource, ResourceParser } from '../../core/model/note';
 import { getFoamVsCodeConfig } from '../../services/config';
-import { fromVsCodeUri, toVsCodeUri } from '../../utils/vsc-utils';
+import { fromVsCodeUri } from '../../utils/vsc-utils';
 import { MarkdownLink } from '../../core/services/markdown-link';
 import { URI } from '../../core/model/uri';
 import { Position } from '../../core/model/position';
@@ -138,7 +138,7 @@ Embed for attachments is not supported
 </div>`;
       toRender = md.render(content);
       break;
-    case 'image':
+    case 'image': {
       const imageParams = parseImageParameters(
         includedNote.uri.path,
         parametersString
@@ -147,6 +147,7 @@ Embed for attachments is not supported
       content = `<div class="embed-container-image">${imageHtml}</div>`;
       toRender = content;
       break;
+    }
     default:
       toRender = content;
   }


### PR DESCRIPTION
Resolves #1328

Examples:
```
![[image.png]]              // Original
![[image.png|300]]          // Width only → 300px
![[image.png|50%]]          // Percentage → responsive
![[image.png|300x200]]      // Width × height
![[image.png|20em]]         // With units
![[image.png|300|center]]   // With alignment
![[image.png|300|Alt text]] // With alt text
```

Also resolved #1262 