### PR TITLE
Updated to include foam_week_year

### DIFF
--- a/packages/foam-vscode/src/services/variable-resolver.ts
+++ b/packages/foam-vscode/src/services/variable-resolver.ts
@@ -22,6 +22,7 @@ const knownFoamVariables = new Set([
   'FOAM_DATE_MONTH_NAME_SHORT',
   'FOAM_DATE_DATE',
   'FOAM_DATE_WEEK',
+  'FOAM_DATE_WEEK_YEAR',
   'FOAM_DATE_DAY_NAME',
   'FOAM_DATE_DAY_NAME_SHORT',
   'FOAM_DATE_HOUR',
@@ -213,6 +214,18 @@ export class Resolver implements VariableResolver {
           const days = Math.round((thursday - janFirst) / 86400000); // 1 day = 86400000 ms
           const weekDay = Math.floor(days / 7) + 1;
           value = Promise.resolve(String(weekDay.valueOf()).padStart(2, '0'));
+          break;
+        }
+        case 'FOAM_DATE_WEEK_YEAR': {
+          // ISO 8601 week-numbering year
+          // The year that contains the Thursday of the current week
+          const date = new Date(this.foamDate);
+
+          // Find Thursday of this week starting on Monday
+          date.setDate(date.getDate() + 4 - (date.getDay() || 7));
+
+          // The year of this Thursday is the ISO week year
+          value = Promise.resolve(String(date.getFullYear()));
           break;
         }
         case 'FOAM_DATE_DAY_NAME':


### PR DESCRIPTION
**Add FOAM_DATE_WEEK_YEAR variable**
Adds support for FOAM_DATE_WEEK_YEAR to complement the existing FOAM_DATE_WEEK variable.
This variable returns the ISO 8601 week-numbering year, which can differ from the calendar year for dates at the start/end of the year. For example:

December 30, 2024 (Monday) is in week 1 of 2025, so FOAM_DATE_WEEK_YEAR returns 2025
January 1, 2023 (Sunday) is in week 52 of 2022, so FOAM_DATE_WEEK_YEAR returns 2022

This enables proper ISO week date formatting: ${FOAM_DATE_WEEK_YEAR}-W${FOAM_DATE_WEEK}
Changes:

Added FOAM_DATE_WEEK_YEAR to knownFoamVariables set
Implemented resolver logic following ISO 8601 week date rules
Added tests for edge cases where week year differs from calendar year