### PR TITLE
Unsanitize characters permissible in Windows paths

### DIFF
--- a/packages/foam-vscode/src/services/note-creation-engine.test.ts
+++ b/packages/foam-vscode/src/services/note-creation-engine.test.ts
@@ -499,8 +499,8 @@ foam_template:
 
       const result = await engine.processTemplate(trigger, template, resolver);
 
-      // All invalid characters should become dashes
-      expect(result.filepath.path).toBe('Test-------------Title-----.md');
+      // All invalid characters should become dashes, and valid should stay unchanged
+      expect(result.filepath.path).toBe("Test#%&{}----$!'-Title@+`-=.md");
 
       // Content should remain unchanged
       expect(result.content).toContain('# Test#%&{}<>?*$!\'"Title@+`|=');

--- a/packages/foam-vscode/src/services/note-creation-engine.ts
+++ b/packages/foam-vscode/src/services/note-creation-engine.ts
@@ -15,9 +15,9 @@ import { URI } from '../core/model/uri';
 /**
  * Characters that are invalid in file names
  * Based on UNALLOWED_CHARS from variable-resolver.ts but excluding filepaths
- * related chars
+ * related chars and chars permissible in filepaths
  */
-const FILEPATH_UNALLOWED_CHARS = '#%&{}<>?*$!\'"@+`|=';
+const FILEPATH_UNALLOWED_CHARS = '<>?*"|';
 
 /**
  * Sanitizes a filepath by replacing invalid characters with dashes


### PR DESCRIPTION
Removes sanitizing of filepath characters which are permitted on Windows.
I have consulted https://stackoverflow.com/questions/1976007/what-characters-are-forbidden-in-windows-and-linux-directory-names, and also tested all of the removed characters on a Windows machine.