### PR TITLE
Graph: added option to automatically start graph

### DIFF
--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -701,6 +701,11 @@
           "type": "object",
           "description": "Custom graph styling settings. An example is present in the documentation.",
           "default": {}
+        },
+        "foam.graph.onStartup": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether to open the graph on startup."
         }
       }
     },

--- a/packages/foam-vscode/src/features/panels/dataviz.ts
+++ b/packages/foam-vscode/src/features/panels/dataviz.ts
@@ -3,6 +3,7 @@ import { Foam } from '../../core/model/foam';
 import { Logger } from '../../core/utils/log';
 import { fromVsCodeUri } from '../../utils/vsc-utils';
 import { isSome } from '../../core/utils';
+import { getFoamVsCodeConfig } from '../../services/config';
 
 export default async function activate(
   context: vscode.ExtensionContext,
@@ -51,6 +52,10 @@ export default async function activate(
       });
     }
   });
+  const shouldOpenGraphOnStartup = getFoamVsCodeConfig('graph.onStartup');
+  if (shouldOpenGraphOnStartup) {
+    vscode.commands.executeCommand('foam-vscode.show-graph');
+  }
 }
 
 function updateGraph(panel: vscode.WebviewPanel, foam: Foam) {


### PR DESCRIPTION
Start the foam graph on extension startup.
Add "foam.graph.onStartup": true,  to settings.json