### PR TITLE
Don't treat text in single brackets as links/placeholders if missing a ref

### DIFF
--- a/packages/foam-vscode/src/core/services/markdown-parser.test.ts
+++ b/packages/foam-vscode/src/core/services/markdown-parser.test.ts
@@ -144,6 +144,19 @@ this is some text with our [[second-wikilink]].
       ]);
     });
 
+    it('#1545 - should not detect single brackets as links', () => {
+      const note = createNoteFromMarkdown(`
+"She said [winning the award] was her best year."
+
+We use brackets ([ and ]) to surround links.
+
+This is not an easy task.[^1]
+
+[^1]: It would be easier if more papers were well written.
+      `);
+      expect(note.links.length).toEqual(0);
+    });
+
     it('should detect reference-style links', () => {
       const note = createNoteFromMarkdown(`
 # Test Document
@@ -181,12 +194,9 @@ This is a [reference-style link][missing-ref].
 [existing-ref]: target.md "Target"
       `);
 
-      expect(note.links.length).toEqual(1);
-      const link = note.links[0];
-      expect(link.type).toEqual('link');
-      expect(link.rawText).toEqual('[reference-style link][missing-ref]');
-      expect(ResourceLink.isUnresolvedReference(link)).toBe(true);
-      expect(link.definition).toEqual('missing-ref');
+      // Per CommonMark spec, reference links without matching definitions
+      // should be treated as plain text, not as links
+      expect(note.links.length).toEqual(0);
     });
 
     it('should handle mixed link types', () => {

--- a/packages/foam-vscode/src/core/services/markdown-parser.ts
+++ b/packages/foam-vscode/src/core/services/markdown-parser.ts
@@ -179,6 +179,14 @@ export function createMarkdownParser(
         }
       });
 
+      // For type: 'link', keep only if:
+      // - It's a direct link [text](url) - no definition field
+      // - It's a resolved reference - definition is an object
+      note.links = note.links.filter(
+        link =>
+          link.type === 'wikilink' || !ResourceLink.isUnresolvedReference(link)
+      );
+
       Logger.debug('Result:', note);
       return note;
     },

--- a/packages/foam-vscode/src/core/services/markdown-provider.test.ts
+++ b/packages/foam-vscode/src/core/services/markdown-provider.test.ts
@@ -303,8 +303,9 @@ describe('Link resolution', () => {
 
       expect(ws.resolveLink(noteB, noteB.links[0])).toEqual(noteA.uri);
       expect(ws.resolveLink(noteC, noteC.links[0])).toEqual(noteA.uri);
-      expect(noteD.links.length).toEqual(1);
-      expect(noteD.links[0].definition).toEqual('note'); // Unresolved reference
+      // noteD has malformed URL with unencoded space, which gets treated as
+      // shortcut reference [note] without definition, now correctly filtered out
+      expect(noteD.links.length).toEqual(0);
     });
 
     describe('Workspace-relative paths (root-path relative)', () => {


### PR DESCRIPTION
Fixes #1545