### PR TITLE
[graph] Randomly color nodes by directory

### DIFF
--- a/packages/foam-vscode/package.json
+++ b/packages/foam-vscode/package.json
@@ -756,6 +756,11 @@
           "type": "boolean",
           "default": false,
           "description": "Whether to open the graph on startup."
+        },
+        "foam.graph.appearance.colorByDirectory": {
+          "type": "boolean",
+          "default": false,
+          "description": "When true, colours the node name in the graph with a random colour based on directory"
         }
       }
     },

--- a/packages/foam-vscode/src/features/panels/dataviz.ts
+++ b/packages/foam-vscode/src/features/panels/dataviz.ts
@@ -204,5 +204,9 @@ async function getWebviewContent(
 }
 
 function getGraphStyle(): object {
-  return vscode.workspace.getConfiguration('foam.graph').get('style');
+  const config = vscode.workspace.getConfiguration('foam.graph');
+  return {
+    style: config.get('style'),
+    colorByDirectory: config.get('appearance.colorByDirectory', false),
+  };
 }


### PR DESCRIPTION
<img width="1920" height="1078" alt="foam colorByDirectory" src="https://github.com/user-attachments/assets/091bd75a-edc6-4ec2-a45b-7c8df6e179df" />
When checkmark is clicked, the node text will be assigned a random color based on the directory of the node's file. A new setting is exposed to allow the setting default to be changed. 


Relevant Issues: #835, #452