### PR TITLE
fix: foam.graph.style settings ignored in graph view (#1620)

### DIFF
--- a/packages/foam-vscode/src/features/panels/dataviz.test.ts
+++ b/packages/foam-vscode/src/features/panels/dataviz.test.ts
@@ -1,7 +1,11 @@
 import * as vscode from 'vscode';
 import { URI } from '../../core/model/uri';
 import { FoamWorkspace } from '../../core/model/workspace';
-import { getNodeNavigationCommand, handleActiveEditorChange } from './dataviz';
+import {
+  getGraphStyle,
+  getNodeNavigationCommand,
+  handleActiveEditorChange,
+} from './dataviz';
 
 describe('handleActiveEditorChange', () => {
   const makePanel = () =>
@@ -74,5 +78,35 @@ describe('getNodeNavigationCommand', () => {
         'vscode.open'
       );
     });
+  });
+});
+
+// Regression tests for https://github.com/foambubble/foam/issues/1620
+//
+// foam.graph.style settings were silently ignored because getGraphStyle()
+// returned the raw StyleConfig directly instead of wrapping it in the
+// StylePayload envelope { style: StyleConfig } that the webview expects.
+// As a result, payload.style was always undefined and theme defaults were used.
+describe('getGraphStyle', () => {
+  it('wraps the style config in a StylePayload envelope', () => {
+    vi.spyOn(vscode.workspace, 'getConfiguration').mockReturnValue({
+      get: (_key: string) => ({ background: '#ff0000', fontSize: 14 }),
+    } as any);
+
+    const payload = getGraphStyle();
+
+    expect(payload.style).toBeDefined();
+    expect(payload.style?.background).toBe('#ff0000');
+    expect(payload.style?.fontSize).toBe(14);
+  });
+
+  it('returns an empty style object when no config is set', () => {
+    vi.spyOn(vscode.workspace, 'getConfiguration').mockReturnValue({
+      get: (_key: string) => undefined,
+    } as any);
+
+    const payload = getGraphStyle();
+
+    expect(payload.style).toEqual({});
   });
 });

--- a/packages/foam-vscode/src/features/panels/dataviz/index.ts
+++ b/packages/foam-vscode/src/features/panels/dataviz/index.ts
@@ -232,8 +232,10 @@ async function getWebviewContent(
   return filled;
 }
 
-function getGraphStyle(): StylePayload {
-  return vscode.workspace.getConfiguration('foam.graph').get('style');
+export function getGraphStyle(): StylePayload {
+  const styleConfig =
+    vscode.workspace.getConfiguration('foam.graph').get('style') ?? {};
+  return { style: styleConfig };
 }
 
 export function handleActiveEditorChange(

--- a/packages/foam-vscode/webview-ui/graph/src/foam-graph.ts
+++ b/packages/foam-vscode/webview-ui/graph/src/foam-graph.ts
@@ -2,6 +2,7 @@ import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { getDefaultStyle } from './lib/defaults';
 import { augmentGraphInfo } from './lib/graph-utils';
+import { mergeStylePayloads, resolveStyle } from './lib/style';
 import type { GraphData, StylePayload } from './protocol';
 import type { AugmentedGraph, ResolvedStyle, Forces, Selection } from './lib/types';
 import './components/graph-canvas';
@@ -38,34 +39,8 @@ export class FoamGraph extends LitElement {
   @state() private localStylePatch: StylePayload = {};
 
   private get resolvedStyle(): ResolvedStyle {
-    return this._resolveStyle(this._mergedStylePayload);
-  }
-
-  private get _mergedStylePayload(): StylePayload {
-    // graphStyle from the outside takes precedence; localStylePatch layers on top
-    return {
-      ...this.graphStyle,
-      ...this.localStylePatch,
-      style: { ...this.graphStyle?.style, ...this.localStylePatch?.style },
-    };
-  }
-
-  private _resolveStyle(payload: StylePayload | null): ResolvedStyle {
-    const defaults = getDefaultStyle();
-    if (!payload) return defaults;
-    return {
-      ...defaults,
-      ...payload.style,
-      lineColor:
-        payload.style?.lineColor ||
-        payload.style?.node?.note ||
-        defaults.lineColor,
-      node: {
-        ...defaults.node,
-        ...payload.style?.node,
-      },
-      colorMode: payload.colorMode ?? defaults.colorMode,
-    };
+    const merged = mergeStylePayloads(this.graphStyle, this.localStylePatch);
+    return resolveStyle(merged, getDefaultStyle());
   }
 
   updated(changed: Map<string, unknown>) {

--- a/packages/foam-vscode/webview-ui/graph/src/lib/style.test.ts
+++ b/packages/foam-vscode/webview-ui/graph/src/lib/style.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { resolveStyle, mergeStylePayloads } from './style';
+import { makeStyle } from '../test-utils';
+import type { StylePayload } from '../protocol';
+
+describe('resolveStyle', () => {
+  const defaults = makeStyle();
+
+  it('returns defaults when payload is null', () => {
+    expect(resolveStyle(null, defaults)).toEqual(defaults);
+  });
+
+  it('applies background from payload.style', () => {
+    const result = resolveStyle({ style: { background: '#ff0000' } }, defaults);
+    expect(result.background).toBe('#ff0000');
+  });
+
+  it('leaves other defaults untouched when only one property is overridden', () => {
+    const result = resolveStyle({ style: { background: '#ff0000' } }, defaults);
+    expect(result.fontSize).toBe(defaults.fontSize);
+    expect(result.lineColor).toBe(defaults.lineColor);
+    expect(result.node).toEqual(defaults.node);
+  });
+
+  it('applies font settings from payload.style', () => {
+    const result = resolveStyle(
+      { style: { fontSize: 16, fontFamily: 'Monospace' } },
+      defaults
+    );
+    expect(result.fontSize).toBe(16);
+    expect(result.fontFamily).toBe('Monospace');
+  });
+
+  it('applies node colors from payload.style.node', () => {
+    const result = resolveStyle(
+      { style: { node: { note: '#abcdef' } } },
+      defaults
+    );
+    expect(result.node.note).toBe('#abcdef');
+    expect(result.node.placeholder).toBe(defaults.node.placeholder);
+  });
+
+  it('uses explicit lineColor from payload.style', () => {
+    const result = resolveStyle({ style: { lineColor: '#123456' } }, defaults);
+    expect(result.lineColor).toBe('#123456');
+  });
+
+  it('falls back to node.note as lineColor when lineColor is not set', () => {
+    const result = resolveStyle(
+      { style: { node: { note: '#aabbcc' } } },
+      defaults
+    );
+    expect(result.lineColor).toBe('#aabbcc');
+  });
+
+  it('applies colorMode from payload', () => {
+    const result = resolveStyle({ colorMode: 'directory' }, defaults);
+    expect(result.colorMode).toBe('directory');
+  });
+
+  it('keeps default colorMode when payload does not specify one', () => {
+    const result = resolveStyle({ style: { background: '#ff0000' } }, defaults);
+    expect(result.colorMode).toBe(defaults.colorMode);
+  });
+
+  // Regression test for https://github.com/foambubble/foam/issues/1620
+  //
+  // The extension was sending the raw StyleConfig (foam.graph.style) directly
+  // as the message payload instead of wrapping it in { style: StyleConfig }.
+  // This meant payload.style was always undefined and user settings were silently
+  // dropped in favour of theme defaults.
+  it('does not apply settings when payload.style is absent (documents the #1620 failure mode)', () => {
+    const buggyPayload = { background: '#ff0000' } as unknown as StylePayload;
+    const result = resolveStyle(buggyPayload, defaults);
+    expect(result.background).toBe(defaults.background);
+    expect(result.background).not.toBe('#ff0000');
+  });
+});
+
+describe('mergeStylePayloads', () => {
+  it('patch overrides base style properties', () => {
+    const base: StylePayload = { style: { background: '#111111', fontSize: 10 } };
+    const patch: StylePayload = { style: { background: '#222222' } };
+    const merged = mergeStylePayloads(base, patch);
+    expect(merged.style?.background).toBe('#222222');
+    expect(merged.style?.fontSize).toBe(10);
+  });
+
+  it('patch overrides colorMode', () => {
+    const base: StylePayload = { colorMode: 'none' };
+    const patch: StylePayload = { colorMode: 'directory' };
+    expect(mergeStylePayloads(base, patch).colorMode).toBe('directory');
+  });
+
+  it('handles null base', () => {
+    const patch: StylePayload = { style: { background: '#ff0000' } };
+    const merged = mergeStylePayloads(null, patch);
+    expect(merged.style?.background).toBe('#ff0000');
+  });
+});

--- a/packages/foam-vscode/webview-ui/graph/src/lib/style.ts
+++ b/packages/foam-vscode/webview-ui/graph/src/lib/style.ts
@@ -1,0 +1,40 @@
+import type { StylePayload } from '../protocol';
+import type { ResolvedStyle } from './types';
+
+/**
+ * Merges two StylePayloads, with `patch` taking precedence over `base`.
+ */
+export function mergeStylePayloads(
+  base: StylePayload | null,
+  patch: StylePayload
+): StylePayload {
+  return {
+    ...base,
+    ...patch,
+    style: { ...base?.style, ...patch?.style },
+  };
+}
+
+/**
+ * Resolves a StylePayload into a fully-populated ResolvedStyle by merging
+ * user-supplied values on top of the provided defaults.
+ */
+export function resolveStyle(
+  payload: StylePayload | null,
+  defaults: ResolvedStyle
+): ResolvedStyle {
+  if (!payload) return defaults;
+  return {
+    ...defaults,
+    ...payload.style,
+    lineColor:
+      payload.style?.lineColor ||
+      payload.style?.node?.note ||
+      defaults.lineColor,
+    node: {
+      ...defaults.node,
+      ...payload.style?.node,
+    },
+    colorMode: payload.colorMode ?? defaults.colorMode,
+  };
+}


### PR DESCRIPTION
## Summary

Fixes #1620 — `foam.graph.style` settings (background colour, node colours, font size, etc.) had no effect on the graph view since 0.35.0.

**Root cause:** `getGraphStyle()` in `dataviz/index.ts` was reading `foam.graph.style` from the VS Code config and returning the raw `StyleConfig` value directly. However, the webview protocol expects a `StylePayload` envelope of the form `{ style: StyleConfig }`. Because `payload.style` was therefore always `undefined`, `resolveStyle` fell through to VS Code theme defaults for every property and discarded all user customisations.

**Changes:**

- **`dataviz/index.ts`** — wrap the config value in `{ style: ... }` before posting the `didUpdateStyle` message; export the function so it can be unit-tested.
- **`webview-ui/graph/src/lib/style.ts`** *(new)* — extract `resolveStyle` and `mergeStylePayloads` as pure exported functions from `foam-graph.ts`, making them independently testable.
- **`foam-graph.ts`** — delegate to the extracted functions; removes the private `_resolveStyle` / `_mergedStylePayload` methods.
- **`dataviz.test.ts`** — regression tests for `getGraphStyle()` verifying the `StylePayload` envelope shape.
- **`webview-ui/graph/src/lib/style.test.ts`** *(new)* — unit tests for `resolveStyle` and `mergeStylePayloads`, including a test that documents the #1620 failure mode.

## Test plan

- [ ] `yarn test:unit` passes (covers `dataviz.test.ts` regression tests)
- [ ] `yarn workspace @foam/graph test` passes (covers `lib/style.test.ts`)
- [ ] Manually open the graph view, set `foam.graph.style` in `settings.json` (e.g. `"background": "#ff0000"`), and confirm the change is reflected