### PR TITLE
Updated documentation: Embeds.md

### DIFF
--- a/docs/user/features/embeds.md
+++ b/docs/user/features/embeds.md
@@ -60,6 +60,27 @@ card![[my-note]] # Bordered container
 inline![[my-note]] # Seamless integration
 ```
 
+#### Custom Card Styling
+
+Customize the appearance of the bordered container in markdown preview by adding CSS:
+
+1. Create `.foam/css/custom-styles.css`
+2. Add CSS targeting `.embed-container-note` class:
+   ```css
+   .embed-container-note {
+      border: 1px solid #d1d9e0;
+      box-sizing: border-box;
+      padding: 4px 16px;
+      border-radius: 6px;
+   }
+   ```
+3. Update `.vscode/settings.json`:
+   ```json
+   {
+     "markdown.styles": [".foam/css/custom-styles.css"]
+   }
+   ```
+
 ### Combined Modifiers
 
 You can combine scope and style modifiers:


### PR DESCRIPTION
Added a section to indicate the CSS class to target for others who'd like to customize their card embeds like me.

Let me know if the section placement is alright; open to moving my addition further up or down the docs as the maintainers deem fit.

I could also open a PR on the /foam-template repo to add this class in the custom css file that comes with the template. Should I go ahead? And if I so I'll probably rename that file from `custom-tag-style.css` to `custom-styles.css` and come back and update the docs on Tags.md to reflect the updated file name. Checking in before proceeding in case the maintainers team has different preferences/concerns. Thank you!