### PR TITLE
perf(vscode): shard parser cache storage to fix large-workspace lag

### DIFF
--- a/packages/foam-core/src/utils/cache.ts
+++ b/packages/foam-core/src/utils/cache.ts
@@ -3,5 +3,9 @@ export interface ICache<K, V> {
   has(key: K): boolean;
   set(key: K, data: V): void;
   del(key: K): void;
-  clear(): void;
+  /**
+   * May be async when clearing also removes persisted state; callers that
+   * need the cache to be gone must await the result.
+   */
+  clear(): void | Promise<void>;
 }

--- a/packages/foam-vscode/src/extension.ts
+++ b/packages/foam-vscode/src/extension.ts
@@ -68,7 +68,7 @@ export async function activate(context: ExtensionContext) {
       workspace.createFileSystemWatcher('**/*'),
       workspace.onDidSaveTextDocument
     );
-    const parserCache = new VsCodeBasedParserCache(context);
+    const parserCache = await VsCodeBasedParserCache.create(context);
     const parser = createMarkdownParser([], parserCache);
 
     const notesExtensions = Config.getNotesExtensions();
@@ -132,6 +132,7 @@ export async function activate(context: ExtensionContext) {
     context.subscriptions.push(
       foam,
       watcher,
+      parserCache,
       markdownProvider,
       attachmentProvider,
       commands.registerCommand('foam-vscode.clear-cache', () => parserCache.clear()),

--- a/packages/foam-vscode/src/extension.ts
+++ b/packages/foam-vscode/src/extension.ts
@@ -1,6 +1,12 @@
 /*global markdownit:readonly*/
 
-import { workspace, ExtensionContext, window, commands, TextEditor } from 'vscode';
+import {
+  workspace,
+  ExtensionContext,
+  window,
+  commands,
+  TextEditor,
+} from 'vscode';
 import { MarkdownResourceProvider, Logger, Config } from '@foam/core';
 import { bootstrap } from './core/model/foam';
 import { fromVsCodeUri } from './vscode/utils/vsc-utils';
@@ -75,7 +81,8 @@ export async function activate(context: ExtensionContext) {
     const defaultExtension = Config.getDefaultNoteExtension();
 
     const workspaceRoots =
-      workspace.workspaceFolders?.map(folder => fromVsCodeUri(folder.uri)) ?? [];
+      workspace.workspaceFolders?.map(folder => fromVsCodeUri(folder.uri)) ??
+      [];
 
     const directoryMode = Config.getLinksDirectoryMode();
     const markdownProvider = new MarkdownResourceProvider(
@@ -86,7 +93,9 @@ export async function activate(context: ExtensionContext) {
     );
 
     const attachmentExtConfig = Config.getAttachmentExtensions();
-    const attachmentProvider = new AttachmentResourceProvider(attachmentExtConfig);
+    const attachmentProvider = new AttachmentResourceProvider(
+      attachmentExtConfig
+    );
 
     // Initialize embedding provider
     const experimentalEnabled = workspace
@@ -108,7 +117,9 @@ export async function activate(context: ExtensionContext) {
     );
 
     // Load the features
-    const featuresPromises = features.map(feature => feature(context, foamPromise));
+    const featuresPromises = features.map(feature =>
+      feature(context, foamPromise)
+    );
 
     const foam = await foamPromise;
     const resources = foam.workspace.list();
@@ -135,7 +146,9 @@ export async function activate(context: ExtensionContext) {
       parserCache,
       markdownProvider,
       attachmentProvider,
-      commands.registerCommand('foam-vscode.clear-cache', () => parserCache.clear()),
+      commands.registerCommand('foam-vscode.clear-cache', () =>
+        parserCache.clear()
+      ),
       workspace.onDidChangeConfiguration(e => {
         if (
           [
@@ -147,7 +160,9 @@ export async function activate(context: ExtensionContext) {
             'foam.files.defaultNoteExtension',
           ].some(setting => e.affectsConfiguration(setting))
         ) {
-          window.showInformationMessage('Foam: Reload the window to use the updated settings');
+          window.showInformationMessage(
+            'Foam: Reload the window to use the updated settings'
+          );
         }
       })
     );
@@ -162,6 +177,8 @@ export async function activate(context: ExtensionContext) {
     };
   } catch (e) {
     Logger.error('An error occurred while bootstrapping Foam', e);
-    window.showErrorMessage(`An error occurred while bootstrapping Foam. ${e.stack}`);
+    window.showErrorMessage(
+      `An error occurred while bootstrapping Foam. ${e.stack}`
+    );
   }
 }

--- a/packages/foam-vscode/src/vscode/features/smart-folders/smart-folder-storage.ts
+++ b/packages/foam-vscode/src/vscode/features/smart-folders/smart-folder-storage.ts
@@ -12,6 +12,7 @@ import {
   idFromQueryFilename,
 } from '@foam/core';
 import { fromVsCodeUri, toVsCodeUri } from '../../utils/vsc-utils';
+import { writeFile } from '../../services/editor';
 
 /**
  * VS Code adapter for the core {@link QueryStore}: adds a
@@ -121,7 +122,6 @@ export class SmartFolderStorage implements IDisposable {
 
 function createVsCodeQueryOps(workspaceRoot: URI) {
   const decoder = new TextDecoder('utf-8');
-  const encoder = new TextEncoder();
 
   return {
     list: async (pattern: string): Promise<URI[]> => {
@@ -134,15 +134,7 @@ function createVsCodeQueryOps(workspaceRoot: URI) {
       const bytes = await vscode.workspace.fs.readFile(toVsCodeUri(uri));
       return decoder.decode(bytes);
     },
-    write: async (uri: URI, content: string) => {
-      await vscode.workspace.fs.createDirectory(
-        toVsCodeUri(uri.getDirectory())
-      );
-      await vscode.workspace.fs.writeFile(
-        toVsCodeUri(uri),
-        encoder.encode(content)
-      );
-    },
+    write: writeFile,
     delete: async (uri: URI) => {
       await vscode.workspace.fs.delete(toVsCodeUri(uri));
     },

--- a/packages/foam-vscode/src/vscode/services/cache.spec.ts
+++ b/packages/foam-vscode/src/vscode/services/cache.spec.ts
@@ -16,7 +16,17 @@ describe('VsCodeBasedParserCache', () => {
     } as unknown as ExtensionContext;
   };
 
-  const createTmpStorageDir = () => fs.mkdtempSync(path.join(os.tmpdir(), 'foam-cache-spec-'));
+  const tmpDirs: string[] = [];
+  const createTmpStorageDir = () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'foam-cache-spec-'));
+    tmpDirs.push(dir);
+    return dir;
+  };
+  afterEach(() => {
+    for (const dir of tmpDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
 
   const createEntry = (name: string): { uri: URI; entry: ParserCacheEntry } => {
     const resource = createTestNote({ uri: `/notes/${name}.md` });
@@ -38,9 +48,21 @@ describe('VsCodeBasedParserCache', () => {
     return snapshot;
   };
 
+  const countPersistedEntries = (storageDir: string): number => {
+    let count = 0;
+    for (const content of snapshotBucketFiles(storageDir).values()) {
+      count += JSON.parse(content).length;
+    }
+    return count;
+  };
+
+  const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
   it('starts empty when no persisted cache exists', async () => {
     const storageDir = createTmpStorageDir();
-    const cache = await VsCodeBasedParserCache.create(createContext(storageDir));
+    const cache = await VsCodeBasedParserCache.create(
+      createContext(storageDir)
+    );
     const { uri } = createEntry('some-note');
     expect(cache.has(uri)).toBe(false);
     expect(cache.get(uri)).toBeUndefined();
@@ -48,7 +70,9 @@ describe('VsCodeBasedParserCache', () => {
 
   it('returns entries with a rehydrated URI instance', async () => {
     const storageDir = createTmpStorageDir();
-    const cache = await VsCodeBasedParserCache.create(createContext(storageDir));
+    const cache = await VsCodeBasedParserCache.create(
+      createContext(storageDir)
+    );
     const { uri, entry } = createEntry('a-note');
     cache.set(uri, entry);
     const result = cache.get(uri);
@@ -114,7 +138,9 @@ describe('VsCodeBasedParserCache', () => {
     await cache.flush();
 
     const after = snapshotBucketFiles(storageDir);
-    const changed = [...after.keys()].filter(file => before.get(file) !== after.get(file));
+    const changed = [...after.keys()].filter(
+      file => before.get(file) !== after.get(file)
+    );
     expect(changed.length).toEqual(1);
   });
 
@@ -183,19 +209,131 @@ describe('VsCodeBasedParserCache', () => {
       VsCodeBasedParserCache.CACHE_VERSION_KEY,
       VsCodeBasedParserCache.CACHE_VERSION
     );
-    await context.workspaceState.update(VsCodeBasedParserCache.LEGACY_STATE_KEY, [
-      [uri.toString(), { value: entry }],
-    ]);
+    await context.workspaceState.update(
+      VsCodeBasedParserCache.LEGACY_STATE_KEY,
+      [[uri.toString(), { value: entry }]]
+    );
 
     const cache = await VsCodeBasedParserCache.create(context);
     expect(cache.has(uri)).toBe(true);
     expect(cache.get(uri).checksum).toEqual(entry.checksum);
-    expect(context.workspaceState.get(VsCodeBasedParserCache.LEGACY_STATE_KEY)).toBeUndefined();
+    expect(
+      context.workspaceState.get(VsCodeBasedParserCache.LEGACY_STATE_KEY)
+    ).toBeUndefined();
 
     // the migrated entries are re-persisted in the sharded layout
     await cache.flush();
     const reloaded = await VsCodeBasedParserCache.create(context);
     expect(reloaded.has(uri)).toBe(true);
+  });
+
+  it('persists migrated legacy entries before removing the old key', async () => {
+    const storageDir = createTmpStorageDir();
+    const context = createContext(storageDir);
+    const { uri, entry } = createEntry('legacy-note');
+    await context.workspaceState.update(
+      VsCodeBasedParserCache.CACHE_VERSION_KEY,
+      VsCodeBasedParserCache.CACHE_VERSION
+    );
+    await context.workspaceState.update(
+      VsCodeBasedParserCache.LEGACY_STATE_KEY,
+      [[uri.toString(), { value: entry }]]
+    );
+
+    await VsCodeBasedParserCache.create(context);
+
+    // the sharded files must exist as soon as create() resolves: the legacy
+    // blob is already gone, so a crash before a later debounced sync would
+    // otherwise lose the whole cache
+    expect(fs.existsSync(bucketDirOf(storageDir))).toBe(true);
+    const reloaded = await VsCodeBasedParserCache.create(context);
+    expect(reloaded.has(uri)).toBe(true);
+  });
+
+  it('does not stamp the new cache version if clearing the old cache fails', async () => {
+    const storageDir = createTmpStorageDir();
+    const context = createContext(storageDir);
+
+    const cache = await VsCodeBasedParserCache.create(context);
+    const { uri, entry } = createEntry('a-note');
+    cache.set(uri, entry);
+    await cache.flush();
+
+    await context.workspaceState.update(
+      VsCodeBasedParserCache.CACHE_VERSION_KEY,
+      VsCodeBasedParserCache.CACHE_VERSION - 1
+    );
+
+    // make the bucket files undeletable, so the version-mismatch clear fails
+    fs.chmodSync(bucketDirOf(storageDir), 0o555);
+    try {
+      await VsCodeBasedParserCache.create(context);
+      // the version must not be stamped, so the clear is retried next startup
+      expect(
+        context.workspaceState.get(VsCodeBasedParserCache.CACHE_VERSION_KEY)
+      ).toEqual(VsCodeBasedParserCache.CACHE_VERSION - 1);
+    } finally {
+      fs.chmodSync(bucketDirOf(storageDir), 0o755);
+    }
+
+    // once deleting works again, the stale entries are gone for good
+    const recovered = await VsCodeBasedParserCache.create(context);
+    expect(recovered.has(uri)).toBe(false);
+    expect(
+      context.workspaceState.get(VsCodeBasedParserCache.CACHE_VERSION_KEY)
+    ).toEqual(VsCodeBasedParserCache.CACHE_VERSION);
+  });
+
+  it('retries a failed write on the next flush, without background retries', async () => {
+    const storageDir = createTmpStorageDir();
+    const context = createContext(storageDir);
+
+    const cache = await VsCodeBasedParserCache.create(context);
+    const { uri, entry } = createEntry('a-note');
+    cache.set(uri, entry);
+    await cache.flush();
+
+    const bucketDir = bucketDirOf(storageDir);
+    const [bucketFile] = fs.readdirSync(bucketDir);
+    const bucketPath = path.join(bucketDir, bucketFile);
+    const staleContent = fs.readFileSync(bucketPath, 'utf8');
+
+    // make the write fail
+    fs.chmodSync(bucketPath, 0o444);
+    fs.chmodSync(bucketDir, 0o555);
+    cache.set(uri, { ...entry, checksum: 'updated-checksum' });
+    await cache.flush();
+    fs.chmodSync(bucketDir, 0o755);
+    fs.chmodSync(bucketPath, 0o644);
+
+    // no self-rescheduled retry may fire in the background...
+    await sleep(1500);
+    expect(fs.readFileSync(bucketPath, 'utf8')).toEqual(staleContent);
+
+    // ...but the change is still pending and lands on the next flush
+    await cache.flush();
+    expect(fs.readFileSync(bucketPath, 'utf8')).not.toEqual(staleContent);
+    const reloaded = await VsCodeBasedParserCache.create(context);
+    expect(reloaded.get(uri).checksum).toEqual('updated-checksum');
+  });
+
+  it('flush() persists buckets that only became dirty through eviction', async () => {
+    const storageDir = createTmpStorageDir();
+    const context = createContext(storageDir);
+
+    const cache = await VsCodeBasedParserCache.create(context, 10);
+    const notes = [...Array(10).keys()].map(i => createEntry(`note-${i}`));
+    for (const { uri, entry } of notes) {
+      cache.set(uri, entry);
+    }
+    await cache.flush();
+    expect(countPersistedEntries(storageDir)).toEqual(10);
+
+    // reloading with a smaller capacity evicts the overflow; the evictions
+    // mark buckets dirty without going through set()/del()
+    const reloaded = await VsCodeBasedParserCache.create(context, 5);
+    await reloaded.flush();
+    expect(countPersistedEntries(storageDir)).toEqual(5);
   });
 
   it('discards the persisted cache when the version changes', async () => {
@@ -214,9 +352,9 @@ describe('VsCodeBasedParserCache', () => {
 
     const reloaded = await VsCodeBasedParserCache.create(context);
     expect(reloaded.has(uri)).toBe(false);
-    expect(context.workspaceState.get(VsCodeBasedParserCache.CACHE_VERSION_KEY)).toEqual(
-      VsCodeBasedParserCache.CACHE_VERSION
-    );
+    expect(
+      context.workspaceState.get(VsCodeBasedParserCache.CACHE_VERSION_KEY)
+    ).toEqual(VsCodeBasedParserCache.CACHE_VERSION);
   });
 
   it('operates in-memory when no storage is available', async () => {

--- a/packages/foam-vscode/src/vscode/services/cache.spec.ts
+++ b/packages/foam-vscode/src/vscode/services/cache.spec.ts
@@ -1,0 +1,232 @@
+/* @unit-ready */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ExtensionContext, Uri } from 'vscode';
+import { URI, ParserCacheEntry } from '@foam/core';
+import { createTestNote, randomString } from '../../test/test-utils';
+import { MapBasedMemento } from '../utils/vsc-utils';
+import VsCodeBasedParserCache from './cache';
+
+describe('VsCodeBasedParserCache', () => {
+  const createContext = (storageDir?: string): ExtensionContext => {
+    return {
+      workspaceState: new MapBasedMemento(),
+      storageUri: storageDir ? Uri.file(storageDir) : undefined,
+    } as unknown as ExtensionContext;
+  };
+
+  const createTmpStorageDir = () => fs.mkdtempSync(path.join(os.tmpdir(), 'foam-cache-spec-'));
+
+  const createEntry = (name: string): { uri: URI; entry: ParserCacheEntry } => {
+    const resource = createTestNote({ uri: `/notes/${name}.md` });
+    return {
+      uri: resource.uri,
+      entry: { checksum: randomString(), resource },
+    };
+  };
+
+  const bucketDirOf = (storageDir: string) =>
+    path.join(storageDir, VsCodeBasedParserCache.CACHE_DIR_NAME);
+
+  const snapshotBucketFiles = (storageDir: string): Map<string, string> => {
+    const dir = bucketDirOf(storageDir);
+    const snapshot = new Map<string, string>();
+    for (const file of fs.readdirSync(dir)) {
+      snapshot.set(file, fs.readFileSync(path.join(dir, file), 'utf8'));
+    }
+    return snapshot;
+  };
+
+  it('starts empty when no persisted cache exists', async () => {
+    const storageDir = createTmpStorageDir();
+    const cache = await VsCodeBasedParserCache.create(createContext(storageDir));
+    const { uri } = createEntry('some-note');
+    expect(cache.has(uri)).toBe(false);
+    expect(cache.get(uri)).toBeUndefined();
+  });
+
+  it('returns entries with a rehydrated URI instance', async () => {
+    const storageDir = createTmpStorageDir();
+    const cache = await VsCodeBasedParserCache.create(createContext(storageDir));
+    const { uri, entry } = createEntry('a-note');
+    cache.set(uri, entry);
+    const result = cache.get(uri);
+    expect(result.checksum).toEqual(entry.checksum);
+    expect(result.resource.uri).toBeInstanceOf(URI);
+    expect(result.resource.uri.isEqual(uri)).toBe(true);
+  });
+
+  it('persists entries across instances', async () => {
+    const storageDir = createTmpStorageDir();
+    const context = createContext(storageDir);
+
+    const cache = await VsCodeBasedParserCache.create(context);
+    const { uri, entry } = createEntry('a-note');
+    cache.set(uri, entry);
+    await cache.flush();
+
+    const reloaded = await VsCodeBasedParserCache.create(context);
+    expect(reloaded.has(uri)).toBe(true);
+    expect(reloaded.get(uri).checksum).toEqual(entry.checksum);
+    expect(reloaded.get(uri).resource.title).toEqual(entry.resource.title);
+  });
+
+  it('removes deleted entries from the persisted cache', async () => {
+    const storageDir = createTmpStorageDir();
+    const context = createContext(storageDir);
+
+    const cache = await VsCodeBasedParserCache.create(context);
+    const first = createEntry('first');
+    const second = createEntry('second');
+    cache.set(first.uri, first.entry);
+    cache.set(second.uri, second.entry);
+    await cache.flush();
+
+    cache.del(first.uri);
+    await cache.flush();
+
+    const reloaded = await VsCodeBasedParserCache.create(context);
+    expect(reloaded.has(first.uri)).toBe(false);
+    expect(reloaded.has(second.uri)).toBe(true);
+  });
+
+  it('only rewrites the bucket files affected by a change', async () => {
+    const storageDir = createTmpStorageDir();
+    const context = createContext(storageDir);
+
+    const cache = await VsCodeBasedParserCache.create(context);
+    const notes = [...Array(50).keys()].map(i => createEntry(`note-${i}`));
+    for (const { uri, entry } of notes) {
+      cache.set(uri, entry);
+    }
+    await cache.flush();
+
+    const before = snapshotBucketFiles(storageDir);
+    // 50 keys over 64 buckets: more than one bucket file must exist,
+    // otherwise this test would pass vacuously
+    expect(before.size).toBeGreaterThan(1);
+
+    cache.set(notes[0].uri, {
+      ...notes[0].entry,
+      checksum: 'updated-checksum',
+    });
+    await cache.flush();
+
+    const after = snapshotBucketFiles(storageDir);
+    const changed = [...after.keys()].filter(file => before.get(file) !== after.get(file));
+    expect(changed.length).toEqual(1);
+  });
+
+  it('clears both the in-memory and the persisted cache', async () => {
+    const storageDir = createTmpStorageDir();
+    const context = createContext(storageDir);
+
+    const cache = await VsCodeBasedParserCache.create(context);
+    const { uri, entry } = createEntry('a-note');
+    cache.set(uri, entry);
+    await cache.flush();
+
+    await cache.clear();
+    expect(cache.has(uri)).toBe(false);
+    expect(fs.existsSync(bucketDirOf(storageDir))).toBe(false);
+
+    const reloaded = await VsCodeBasedParserCache.create(context);
+    expect(reloaded.has(uri)).toBe(false);
+  });
+
+  it('is not resurrected by a pending sync scheduled before clear()', async () => {
+    const storageDir = createTmpStorageDir();
+    const context = createContext(storageDir);
+
+    const cache = await VsCodeBasedParserCache.create(context);
+    const { uri, entry } = createEntry('a-note');
+    // set() schedules a debounced sync; clear() before it fires must win
+    cache.set(uri, entry);
+    await cache.clear();
+    await cache.flush();
+
+    const reloaded = await VsCodeBasedParserCache.create(context);
+    expect(reloaded.has(uri)).toBe(false);
+    expect(fs.existsSync(bucketDirOf(storageDir))).toBe(false);
+  });
+
+  it('recovers from a corrupted bucket file, keeping the other buckets', async () => {
+    const storageDir = createTmpStorageDir();
+    const context = createContext(storageDir);
+
+    const cache = await VsCodeBasedParserCache.create(context);
+    const notes = [...Array(50).keys()].map(i => createEntry(`note-${i}`));
+    for (const { uri, entry } of notes) {
+      cache.set(uri, entry);
+    }
+    await cache.flush();
+
+    const bucketFiles = fs.readdirSync(bucketDirOf(storageDir));
+    expect(bucketFiles.length).toBeGreaterThan(1);
+    const corrupted = path.join(bucketDirOf(storageDir), bucketFiles[0]);
+    fs.writeFileSync(corrupted, 'not valid json {');
+
+    const reloaded = await VsCodeBasedParserCache.create(context);
+    const loadedCount = notes.filter(({ uri }) => reloaded.has(uri)).length;
+    expect(loadedCount).toBeGreaterThan(0);
+    expect(loadedCount).toBeLessThan(notes.length);
+    // the corrupted bucket is discarded so it doesn't fail every startup
+    expect(fs.existsSync(corrupted)).toBe(false);
+  });
+
+  it('migrates the legacy workspaceState cache and removes the old key', async () => {
+    const storageDir = createTmpStorageDir();
+    const context = createContext(storageDir);
+    const { uri, entry } = createEntry('legacy-note');
+    await context.workspaceState.update(
+      VsCodeBasedParserCache.CACHE_VERSION_KEY,
+      VsCodeBasedParserCache.CACHE_VERSION
+    );
+    await context.workspaceState.update(VsCodeBasedParserCache.LEGACY_STATE_KEY, [
+      [uri.toString(), { value: entry }],
+    ]);
+
+    const cache = await VsCodeBasedParserCache.create(context);
+    expect(cache.has(uri)).toBe(true);
+    expect(cache.get(uri).checksum).toEqual(entry.checksum);
+    expect(context.workspaceState.get(VsCodeBasedParserCache.LEGACY_STATE_KEY)).toBeUndefined();
+
+    // the migrated entries are re-persisted in the sharded layout
+    await cache.flush();
+    const reloaded = await VsCodeBasedParserCache.create(context);
+    expect(reloaded.has(uri)).toBe(true);
+  });
+
+  it('discards the persisted cache when the version changes', async () => {
+    const storageDir = createTmpStorageDir();
+    const context = createContext(storageDir);
+
+    const cache = await VsCodeBasedParserCache.create(context);
+    const { uri, entry } = createEntry('a-note');
+    cache.set(uri, entry);
+    await cache.flush();
+
+    await context.workspaceState.update(
+      VsCodeBasedParserCache.CACHE_VERSION_KEY,
+      VsCodeBasedParserCache.CACHE_VERSION - 1
+    );
+
+    const reloaded = await VsCodeBasedParserCache.create(context);
+    expect(reloaded.has(uri)).toBe(false);
+    expect(context.workspaceState.get(VsCodeBasedParserCache.CACHE_VERSION_KEY)).toEqual(
+      VsCodeBasedParserCache.CACHE_VERSION
+    );
+  });
+
+  it('operates in-memory when no storage is available', async () => {
+    const cache = await VsCodeBasedParserCache.create(createContext());
+    const { uri, entry } = createEntry('a-note');
+    cache.set(uri, entry);
+    expect(cache.has(uri)).toBe(true);
+    await cache.flush();
+    cache.del(uri);
+    expect(cache.has(uri)).toBe(false);
+    await cache.clear();
+  });
+});

--- a/packages/foam-vscode/src/vscode/services/cache.spec.ts
+++ b/packages/foam-vscode/src/vscode/services/cache.spec.ts
@@ -8,353 +8,372 @@ import { createTestNote, randomString } from '../../test/test-utils';
 import { MapBasedMemento } from '../utils/vsc-utils';
 import VsCodeBasedParserCache from './cache';
 
+const createContext = (storageDir?: string): ExtensionContext => {
+  return {
+    workspaceState: new MapBasedMemento(),
+    storageUri: storageDir ? Uri.file(storageDir) : undefined,
+  } as unknown as ExtensionContext;
+};
+
+const createTmpStorageDir = (prefix = 'foam-cache-spec-') => {
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  return {
+    rootDir,
+    cleanup: () => fs.rmSync(rootDir, { recursive: true, force: true }),
+  };
+};
+
+const withTmpStorageDir = async (fn: (storageDir: string) => Promise<void>) => {
+  const { rootDir, cleanup } = createTmpStorageDir();
+  try {
+    await fn(rootDir);
+  } finally {
+    cleanup();
+  }
+};
+
+const createEntry = (name: string): { uri: URI; entry: ParserCacheEntry } => {
+  const resource = createTestNote({ uri: `/notes/${name}.md` });
+  return {
+    uri: resource.uri,
+    entry: { checksum: randomString(), resource },
+  };
+};
+
+const bucketDirOf = (storageDir: string) =>
+  path.join(storageDir, VsCodeBasedParserCache.CACHE_DIR_NAME);
+
+const snapshotBucketFiles = (storageDir: string): Map<string, string> => {
+  const dir = bucketDirOf(storageDir);
+  const snapshot = new Map<string, string>();
+  for (const file of fs.readdirSync(dir)) {
+    snapshot.set(file, fs.readFileSync(path.join(dir, file), 'utf8'));
+  }
+  return snapshot;
+};
+
+const countPersistedEntries = (storageDir: string): number => {
+  let count = 0;
+  for (const content of snapshotBucketFiles(storageDir).values()) {
+    count += JSON.parse(content).length;
+  }
+  return count;
+};
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
 describe('VsCodeBasedParserCache', () => {
-  const createContext = (storageDir?: string): ExtensionContext => {
-    return {
-      workspaceState: new MapBasedMemento(),
-      storageUri: storageDir ? Uri.file(storageDir) : undefined,
-    } as unknown as ExtensionContext;
-  };
-
-  const tmpDirs: string[] = [];
-  const createTmpStorageDir = () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'foam-cache-spec-'));
-    tmpDirs.push(dir);
-    return dir;
-  };
-  afterEach(() => {
-    for (const dir of tmpDirs.splice(0)) {
-      fs.rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  const createEntry = (name: string): { uri: URI; entry: ParserCacheEntry } => {
-    const resource = createTestNote({ uri: `/notes/${name}.md` });
-    return {
-      uri: resource.uri,
-      entry: { checksum: randomString(), resource },
-    };
-  };
-
-  const bucketDirOf = (storageDir: string) =>
-    path.join(storageDir, VsCodeBasedParserCache.CACHE_DIR_NAME);
-
-  const snapshotBucketFiles = (storageDir: string): Map<string, string> => {
-    const dir = bucketDirOf(storageDir);
-    const snapshot = new Map<string, string>();
-    for (const file of fs.readdirSync(dir)) {
-      snapshot.set(file, fs.readFileSync(path.join(dir, file), 'utf8'));
-    }
-    return snapshot;
-  };
-
-  const countPersistedEntries = (storageDir: string): number => {
-    let count = 0;
-    for (const content of snapshotBucketFiles(storageDir).values()) {
-      count += JSON.parse(content).length;
-    }
-    return count;
-  };
-
-  const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
-
   it('starts empty when no persisted cache exists', async () => {
-    const storageDir = createTmpStorageDir();
-    const cache = await VsCodeBasedParserCache.create(
-      createContext(storageDir)
-    );
-    const { uri } = createEntry('some-note');
-    expect(cache.has(uri)).toBe(false);
-    expect(cache.get(uri)).toBeUndefined();
+    await withTmpStorageDir(async storageDir => {
+      const cache = await VsCodeBasedParserCache.create(
+        createContext(storageDir)
+      );
+      const { uri } = createEntry('some-note');
+      expect(cache.has(uri)).toBe(false);
+      expect(cache.get(uri)).toBeUndefined();
+    });
   });
 
   it('returns entries with a rehydrated URI instance', async () => {
-    const storageDir = createTmpStorageDir();
-    const cache = await VsCodeBasedParserCache.create(
-      createContext(storageDir)
-    );
-    const { uri, entry } = createEntry('a-note');
-    cache.set(uri, entry);
-    const result = cache.get(uri);
-    expect(result.checksum).toEqual(entry.checksum);
-    expect(result.resource.uri).toBeInstanceOf(URI);
-    expect(result.resource.uri.isEqual(uri)).toBe(true);
+    await withTmpStorageDir(async storageDir => {
+      const cache = await VsCodeBasedParserCache.create(
+        createContext(storageDir)
+      );
+      const { uri, entry } = createEntry('a-note');
+      cache.set(uri, entry);
+      const result = cache.get(uri);
+      expect(result.checksum).toEqual(entry.checksum);
+      expect(result.resource.uri).toBeInstanceOf(URI);
+      expect(result.resource.uri.isEqual(uri)).toBe(true);
+    });
   });
 
   it('persists entries across instances', async () => {
-    const storageDir = createTmpStorageDir();
-    const context = createContext(storageDir);
+    await withTmpStorageDir(async storageDir => {
+      const context = createContext(storageDir);
 
-    const cache = await VsCodeBasedParserCache.create(context);
-    const { uri, entry } = createEntry('a-note');
-    cache.set(uri, entry);
-    await cache.flush();
+      const cache = await VsCodeBasedParserCache.create(context);
+      const { uri, entry } = createEntry('a-note');
+      cache.set(uri, entry);
+      await cache.flush();
 
-    const reloaded = await VsCodeBasedParserCache.create(context);
-    expect(reloaded.has(uri)).toBe(true);
-    expect(reloaded.get(uri).checksum).toEqual(entry.checksum);
-    expect(reloaded.get(uri).resource.title).toEqual(entry.resource.title);
+      const reloaded = await VsCodeBasedParserCache.create(context);
+      expect(reloaded.has(uri)).toBe(true);
+      expect(reloaded.get(uri).checksum).toEqual(entry.checksum);
+      expect(reloaded.get(uri).resource.title).toEqual(entry.resource.title);
+    });
   });
 
   it('removes deleted entries from the persisted cache', async () => {
-    const storageDir = createTmpStorageDir();
-    const context = createContext(storageDir);
+    await withTmpStorageDir(async storageDir => {
+      const context = createContext(storageDir);
 
-    const cache = await VsCodeBasedParserCache.create(context);
-    const first = createEntry('first');
-    const second = createEntry('second');
-    cache.set(first.uri, first.entry);
-    cache.set(second.uri, second.entry);
-    await cache.flush();
+      const cache = await VsCodeBasedParserCache.create(context);
+      const first = createEntry('first');
+      const second = createEntry('second');
+      cache.set(first.uri, first.entry);
+      cache.set(second.uri, second.entry);
+      await cache.flush();
 
-    cache.del(first.uri);
-    await cache.flush();
+      cache.del(first.uri);
+      await cache.flush();
 
-    const reloaded = await VsCodeBasedParserCache.create(context);
-    expect(reloaded.has(first.uri)).toBe(false);
-    expect(reloaded.has(second.uri)).toBe(true);
+      const reloaded = await VsCodeBasedParserCache.create(context);
+      expect(reloaded.has(first.uri)).toBe(false);
+      expect(reloaded.has(second.uri)).toBe(true);
+    });
   });
 
   it('only rewrites the bucket files affected by a change', async () => {
-    const storageDir = createTmpStorageDir();
-    const context = createContext(storageDir);
+    await withTmpStorageDir(async storageDir => {
+      const context = createContext(storageDir);
 
-    const cache = await VsCodeBasedParserCache.create(context);
-    const notes = [...Array(50).keys()].map(i => createEntry(`note-${i}`));
-    for (const { uri, entry } of notes) {
-      cache.set(uri, entry);
-    }
-    await cache.flush();
+      const cache = await VsCodeBasedParserCache.create(context);
+      const notes = [...Array(50).keys()].map(i => createEntry(`note-${i}`));
+      for (const { uri, entry } of notes) {
+        cache.set(uri, entry);
+      }
+      await cache.flush();
 
-    const before = snapshotBucketFiles(storageDir);
-    // 50 keys over 64 buckets: more than one bucket file must exist,
-    // otherwise this test would pass vacuously
-    expect(before.size).toBeGreaterThan(1);
+      const before = snapshotBucketFiles(storageDir);
+      // 50 keys over 64 buckets: more than one bucket file must exist,
+      // otherwise this test would pass vacuously
+      expect(before.size).toBeGreaterThan(1);
 
-    cache.set(notes[0].uri, {
-      ...notes[0].entry,
-      checksum: 'updated-checksum',
+      cache.set(notes[0].uri, {
+        ...notes[0].entry,
+        checksum: 'updated-checksum',
+      });
+      await cache.flush();
+
+      const after = snapshotBucketFiles(storageDir);
+      const changed = [...after.keys()].filter(
+        file => before.get(file) !== after.get(file)
+      );
+      expect(changed.length).toEqual(1);
     });
-    await cache.flush();
-
-    const after = snapshotBucketFiles(storageDir);
-    const changed = [...after.keys()].filter(
-      file => before.get(file) !== after.get(file)
-    );
-    expect(changed.length).toEqual(1);
   });
 
   it('clears both the in-memory and the persisted cache', async () => {
-    const storageDir = createTmpStorageDir();
-    const context = createContext(storageDir);
+    await withTmpStorageDir(async storageDir => {
+      const context = createContext(storageDir);
 
-    const cache = await VsCodeBasedParserCache.create(context);
-    const { uri, entry } = createEntry('a-note');
-    cache.set(uri, entry);
-    await cache.flush();
+      const cache = await VsCodeBasedParserCache.create(context);
+      const { uri, entry } = createEntry('a-note');
+      cache.set(uri, entry);
+      await cache.flush();
 
-    await cache.clear();
-    expect(cache.has(uri)).toBe(false);
-    expect(fs.existsSync(bucketDirOf(storageDir))).toBe(false);
+      await cache.clear();
+      expect(cache.has(uri)).toBe(false);
+      expect(fs.existsSync(bucketDirOf(storageDir))).toBe(false);
 
-    const reloaded = await VsCodeBasedParserCache.create(context);
-    expect(reloaded.has(uri)).toBe(false);
+      const reloaded = await VsCodeBasedParserCache.create(context);
+      expect(reloaded.has(uri)).toBe(false);
+    });
   });
 
   it('is not resurrected by a pending sync scheduled before clear()', async () => {
-    const storageDir = createTmpStorageDir();
-    const context = createContext(storageDir);
+    await withTmpStorageDir(async storageDir => {
+      const context = createContext(storageDir);
 
-    const cache = await VsCodeBasedParserCache.create(context);
-    const { uri, entry } = createEntry('a-note');
-    // set() schedules a debounced sync; clear() before it fires must win
-    cache.set(uri, entry);
-    await cache.clear();
-    await cache.flush();
+      const cache = await VsCodeBasedParserCache.create(context);
+      const { uri, entry } = createEntry('a-note');
+      // set() schedules a debounced sync; clear() before it fires must win
+      cache.set(uri, entry);
+      await cache.clear();
+      await cache.flush();
 
-    const reloaded = await VsCodeBasedParserCache.create(context);
-    expect(reloaded.has(uri)).toBe(false);
-    expect(fs.existsSync(bucketDirOf(storageDir))).toBe(false);
+      const reloaded = await VsCodeBasedParserCache.create(context);
+      expect(reloaded.has(uri)).toBe(false);
+      expect(fs.existsSync(bucketDirOf(storageDir))).toBe(false);
+    });
   });
 
   it('recovers from a corrupted bucket file, keeping the other buckets', async () => {
-    const storageDir = createTmpStorageDir();
-    const context = createContext(storageDir);
+    await withTmpStorageDir(async storageDir => {
+      const context = createContext(storageDir);
 
-    const cache = await VsCodeBasedParserCache.create(context);
-    const notes = [...Array(50).keys()].map(i => createEntry(`note-${i}`));
-    for (const { uri, entry } of notes) {
-      cache.set(uri, entry);
-    }
-    await cache.flush();
+      const cache = await VsCodeBasedParserCache.create(context);
+      const notes = [...Array(50).keys()].map(i => createEntry(`note-${i}`));
+      for (const { uri, entry } of notes) {
+        cache.set(uri, entry);
+      }
+      await cache.flush();
 
-    const bucketFiles = fs.readdirSync(bucketDirOf(storageDir));
-    expect(bucketFiles.length).toBeGreaterThan(1);
-    const corrupted = path.join(bucketDirOf(storageDir), bucketFiles[0]);
-    fs.writeFileSync(corrupted, 'not valid json {');
+      const bucketFiles = fs.readdirSync(bucketDirOf(storageDir));
+      expect(bucketFiles.length).toBeGreaterThan(1);
+      const corrupted = path.join(bucketDirOf(storageDir), bucketFiles[0]);
+      fs.writeFileSync(corrupted, 'not valid json {');
 
-    const reloaded = await VsCodeBasedParserCache.create(context);
-    const loadedCount = notes.filter(({ uri }) => reloaded.has(uri)).length;
-    expect(loadedCount).toBeGreaterThan(0);
-    expect(loadedCount).toBeLessThan(notes.length);
-    // the corrupted bucket is discarded so it doesn't fail every startup
-    expect(fs.existsSync(corrupted)).toBe(false);
+      const reloaded = await VsCodeBasedParserCache.create(context);
+      const loadedCount = notes.filter(({ uri }) => reloaded.has(uri)).length;
+      expect(loadedCount).toBeGreaterThan(0);
+      expect(loadedCount).toBeLessThan(notes.length);
+      // the corrupted bucket is discarded so it doesn't fail every startup
+      expect(fs.existsSync(corrupted)).toBe(false);
+    });
   });
 
   it('migrates the legacy workspaceState cache and removes the old key', async () => {
-    const storageDir = createTmpStorageDir();
-    const context = createContext(storageDir);
-    const { uri, entry } = createEntry('legacy-note');
-    await context.workspaceState.update(
-      VsCodeBasedParserCache.CACHE_VERSION_KEY,
-      VsCodeBasedParserCache.CACHE_VERSION
-    );
-    await context.workspaceState.update(
-      VsCodeBasedParserCache.LEGACY_STATE_KEY,
-      [[uri.toString(), { value: entry }]]
-    );
+    await withTmpStorageDir(async storageDir => {
+      const context = createContext(storageDir);
+      const { uri, entry } = createEntry('legacy-note');
+      await context.workspaceState.update(
+        VsCodeBasedParserCache.CACHE_VERSION_KEY,
+        VsCodeBasedParserCache.CACHE_VERSION
+      );
+      await context.workspaceState.update(
+        VsCodeBasedParserCache.LEGACY_STATE_KEY,
+        [[uri.toString(), { value: entry }]]
+      );
 
-    const cache = await VsCodeBasedParserCache.create(context);
-    expect(cache.has(uri)).toBe(true);
-    expect(cache.get(uri).checksum).toEqual(entry.checksum);
-    expect(
-      context.workspaceState.get(VsCodeBasedParserCache.LEGACY_STATE_KEY)
-    ).toBeUndefined();
+      const cache = await VsCodeBasedParserCache.create(context);
+      expect(cache.has(uri)).toBe(true);
+      expect(cache.get(uri).checksum).toEqual(entry.checksum);
+      expect(
+        context.workspaceState.get(VsCodeBasedParserCache.LEGACY_STATE_KEY)
+      ).toBeUndefined();
 
-    // the migrated entries are re-persisted in the sharded layout
-    await cache.flush();
-    const reloaded = await VsCodeBasedParserCache.create(context);
-    expect(reloaded.has(uri)).toBe(true);
+      // the migrated entries are re-persisted in the sharded layout
+      await cache.flush();
+      const reloaded = await VsCodeBasedParserCache.create(context);
+      expect(reloaded.has(uri)).toBe(true);
+    });
   });
 
   it('persists migrated legacy entries before removing the old key', async () => {
-    const storageDir = createTmpStorageDir();
-    const context = createContext(storageDir);
-    const { uri, entry } = createEntry('legacy-note');
-    await context.workspaceState.update(
-      VsCodeBasedParserCache.CACHE_VERSION_KEY,
-      VsCodeBasedParserCache.CACHE_VERSION
-    );
-    await context.workspaceState.update(
-      VsCodeBasedParserCache.LEGACY_STATE_KEY,
-      [[uri.toString(), { value: entry }]]
-    );
+    await withTmpStorageDir(async storageDir => {
+      const context = createContext(storageDir);
+      const { uri, entry } = createEntry('legacy-note');
+      await context.workspaceState.update(
+        VsCodeBasedParserCache.CACHE_VERSION_KEY,
+        VsCodeBasedParserCache.CACHE_VERSION
+      );
+      await context.workspaceState.update(
+        VsCodeBasedParserCache.LEGACY_STATE_KEY,
+        [[uri.toString(), { value: entry }]]
+      );
 
-    await VsCodeBasedParserCache.create(context);
+      await VsCodeBasedParserCache.create(context);
 
-    // the sharded files must exist as soon as create() resolves: the legacy
-    // blob is already gone, so a crash before a later debounced sync would
-    // otherwise lose the whole cache
-    expect(fs.existsSync(bucketDirOf(storageDir))).toBe(true);
-    const reloaded = await VsCodeBasedParserCache.create(context);
-    expect(reloaded.has(uri)).toBe(true);
+      // the sharded files must exist as soon as create() resolves: the legacy
+      // blob is already gone, so a crash before a later debounced sync would
+      // otherwise lose the whole cache
+      expect(fs.existsSync(bucketDirOf(storageDir))).toBe(true);
+      const reloaded = await VsCodeBasedParserCache.create(context);
+      expect(reloaded.has(uri)).toBe(true);
+    });
   });
 
   it('does not stamp the new cache version if clearing the old cache fails', async () => {
-    const storageDir = createTmpStorageDir();
-    const context = createContext(storageDir);
+    await withTmpStorageDir(async storageDir => {
+      const context = createContext(storageDir);
 
-    const cache = await VsCodeBasedParserCache.create(context);
-    const { uri, entry } = createEntry('a-note');
-    cache.set(uri, entry);
-    await cache.flush();
+      const cache = await VsCodeBasedParserCache.create(context);
+      const { uri, entry } = createEntry('a-note');
+      cache.set(uri, entry);
+      await cache.flush();
 
-    await context.workspaceState.update(
-      VsCodeBasedParserCache.CACHE_VERSION_KEY,
-      VsCodeBasedParserCache.CACHE_VERSION - 1
-    );
+      await context.workspaceState.update(
+        VsCodeBasedParserCache.CACHE_VERSION_KEY,
+        VsCodeBasedParserCache.CACHE_VERSION - 1
+      );
 
-    // make the bucket files undeletable, so the version-mismatch clear fails
-    fs.chmodSync(bucketDirOf(storageDir), 0o555);
-    try {
-      await VsCodeBasedParserCache.create(context);
-      // the version must not be stamped, so the clear is retried next startup
+      // make the bucket files undeletable, so the version-mismatch clear fails
+      fs.chmodSync(bucketDirOf(storageDir), 0o555);
+      try {
+        await VsCodeBasedParserCache.create(context);
+        // the version must not be stamped, so the clear is retried next startup
+        expect(
+          context.workspaceState.get(VsCodeBasedParserCache.CACHE_VERSION_KEY)
+        ).toEqual(VsCodeBasedParserCache.CACHE_VERSION - 1);
+      } finally {
+        fs.chmodSync(bucketDirOf(storageDir), 0o755);
+      }
+
+      // once deleting works again, the stale entries are gone for good
+      const recovered = await VsCodeBasedParserCache.create(context);
+      expect(recovered.has(uri)).toBe(false);
       expect(
         context.workspaceState.get(VsCodeBasedParserCache.CACHE_VERSION_KEY)
-      ).toEqual(VsCodeBasedParserCache.CACHE_VERSION - 1);
-    } finally {
-      fs.chmodSync(bucketDirOf(storageDir), 0o755);
-    }
-
-    // once deleting works again, the stale entries are gone for good
-    const recovered = await VsCodeBasedParserCache.create(context);
-    expect(recovered.has(uri)).toBe(false);
-    expect(
-      context.workspaceState.get(VsCodeBasedParserCache.CACHE_VERSION_KEY)
-    ).toEqual(VsCodeBasedParserCache.CACHE_VERSION);
+      ).toEqual(VsCodeBasedParserCache.CACHE_VERSION);
+    });
   });
 
   it('retries a failed write on the next flush, without background retries', async () => {
-    const storageDir = createTmpStorageDir();
-    const context = createContext(storageDir);
+    await withTmpStorageDir(async storageDir => {
+      const context = createContext(storageDir);
 
-    const cache = await VsCodeBasedParserCache.create(context);
-    const { uri, entry } = createEntry('a-note');
-    cache.set(uri, entry);
-    await cache.flush();
+      const cache = await VsCodeBasedParserCache.create(context);
+      const { uri, entry } = createEntry('a-note');
+      cache.set(uri, entry);
+      await cache.flush();
 
-    const bucketDir = bucketDirOf(storageDir);
-    const [bucketFile] = fs.readdirSync(bucketDir);
-    const bucketPath = path.join(bucketDir, bucketFile);
-    const staleContent = fs.readFileSync(bucketPath, 'utf8');
+      const bucketDir = bucketDirOf(storageDir);
+      const [bucketFile] = fs.readdirSync(bucketDir);
+      const bucketPath = path.join(bucketDir, bucketFile);
+      const staleContent = fs.readFileSync(bucketPath, 'utf8');
 
-    // make the write fail
-    fs.chmodSync(bucketPath, 0o444);
-    fs.chmodSync(bucketDir, 0o555);
-    cache.set(uri, { ...entry, checksum: 'updated-checksum' });
-    await cache.flush();
-    fs.chmodSync(bucketDir, 0o755);
-    fs.chmodSync(bucketPath, 0o644);
+      // make the write fail
+      fs.chmodSync(bucketPath, 0o444);
+      fs.chmodSync(bucketDir, 0o555);
+      cache.set(uri, { ...entry, checksum: 'updated-checksum' });
+      await cache.flush();
+      fs.chmodSync(bucketDir, 0o755);
+      fs.chmodSync(bucketPath, 0o644);
 
-    // no self-rescheduled retry may fire in the background...
-    await sleep(1500);
-    expect(fs.readFileSync(bucketPath, 'utf8')).toEqual(staleContent);
+      // no self-rescheduled retry may fire in the background...
+      await sleep(1500);
+      expect(fs.readFileSync(bucketPath, 'utf8')).toEqual(staleContent);
 
-    // ...but the change is still pending and lands on the next flush
-    await cache.flush();
-    expect(fs.readFileSync(bucketPath, 'utf8')).not.toEqual(staleContent);
-    const reloaded = await VsCodeBasedParserCache.create(context);
-    expect(reloaded.get(uri).checksum).toEqual('updated-checksum');
+      // ...but the change is still pending and lands on the next flush
+      await cache.flush();
+      expect(fs.readFileSync(bucketPath, 'utf8')).not.toEqual(staleContent);
+      const reloaded = await VsCodeBasedParserCache.create(context);
+      expect(reloaded.get(uri).checksum).toEqual('updated-checksum');
+    });
   });
 
   it('flush() persists buckets that only became dirty through eviction', async () => {
-    const storageDir = createTmpStorageDir();
-    const context = createContext(storageDir);
+    await withTmpStorageDir(async storageDir => {
+      const context = createContext(storageDir);
 
-    const cache = await VsCodeBasedParserCache.create(context, 10);
-    const notes = [...Array(10).keys()].map(i => createEntry(`note-${i}`));
-    for (const { uri, entry } of notes) {
-      cache.set(uri, entry);
-    }
-    await cache.flush();
-    expect(countPersistedEntries(storageDir)).toEqual(10);
+      const cache = await VsCodeBasedParserCache.create(context, 10);
+      const notes = [...Array(10).keys()].map(i => createEntry(`note-${i}`));
+      for (const { uri, entry } of notes) {
+        cache.set(uri, entry);
+      }
+      await cache.flush();
+      expect(countPersistedEntries(storageDir)).toEqual(10);
 
-    // reloading with a smaller capacity evicts the overflow; the evictions
-    // mark buckets dirty without going through set()/del()
-    const reloaded = await VsCodeBasedParserCache.create(context, 5);
-    await reloaded.flush();
-    expect(countPersistedEntries(storageDir)).toEqual(5);
+      // reloading with a smaller capacity evicts the overflow; the evictions
+      // mark buckets dirty without going through set()/del()
+      const reloaded = await VsCodeBasedParserCache.create(context, 5);
+      await reloaded.flush();
+      expect(countPersistedEntries(storageDir)).toEqual(5);
+    });
   });
 
   it('discards the persisted cache when the version changes', async () => {
-    const storageDir = createTmpStorageDir();
-    const context = createContext(storageDir);
+    await withTmpStorageDir(async storageDir => {
+      const context = createContext(storageDir);
 
-    const cache = await VsCodeBasedParserCache.create(context);
-    const { uri, entry } = createEntry('a-note');
-    cache.set(uri, entry);
-    await cache.flush();
+      const cache = await VsCodeBasedParserCache.create(context);
+      const { uri, entry } = createEntry('a-note');
+      cache.set(uri, entry);
+      await cache.flush();
 
-    await context.workspaceState.update(
-      VsCodeBasedParserCache.CACHE_VERSION_KEY,
-      VsCodeBasedParserCache.CACHE_VERSION - 1
-    );
+      await context.workspaceState.update(
+        VsCodeBasedParserCache.CACHE_VERSION_KEY,
+        VsCodeBasedParserCache.CACHE_VERSION - 1
+      );
 
-    const reloaded = await VsCodeBasedParserCache.create(context);
-    expect(reloaded.has(uri)).toBe(false);
-    expect(
-      context.workspaceState.get(VsCodeBasedParserCache.CACHE_VERSION_KEY)
-    ).toEqual(VsCodeBasedParserCache.CACHE_VERSION);
+      const reloaded = await VsCodeBasedParserCache.create(context);
+      expect(reloaded.has(uri)).toBe(false);
+      expect(
+        context.workspaceState.get(VsCodeBasedParserCache.CACHE_VERSION_KEY)
+      ).toEqual(VsCodeBasedParserCache.CACHE_VERSION);
+    });
   });
 
   it('operates in-memory when no storage is available', async () => {

--- a/packages/foam-vscode/src/vscode/services/cache.ts
+++ b/packages/foam-vscode/src/vscode/services/cache.ts
@@ -2,11 +2,10 @@ import { debounce } from 'lodash';
 import { LRUCache } from 'lru-cache';
 import { ExtensionContext } from 'vscode';
 import { URI } from '@foam/core';
-import {
-  ParserCache,
-  ParserCacheEntry,
-} from '@foam/core';
+import { ParserCache, ParserCacheEntry } from '@foam/core';
 import { Logger } from '@foam/core';
+import { deleteFile, readFile, writeFile } from './editor';
+import { fromVsCodeUri } from '../utils/vsc-utils';
 
 /**
  * This is a best effort implementation to cache resources.
@@ -14,24 +13,64 @@ import { Logger } from '@foam/core';
  *
  * We use the URI and a checksum of the markdown file to cache the resource.
  *
+ * Entries live in an in-memory LRU cache; persistence shards them across a
+ * fixed number of bucket files under the extension storage area:
+ *
+ *   <storageUri>/parser-cache/bucket-00.json ... bucket-3f.json
+ *
+ * A resource always maps to the same bucket (hash of its URI), and only
+ * buckets touched since the last sync are rewritten, so the cost of
+ * persisting is proportional to what changed, not to the workspace size.
+ * A corrupted bucket file only invalidates the notes in that bucket, which
+ * are transparently re-parsed.
+ *
+ * Global LRU recency is not preserved across restarts (entries are
+ * re-inserted bucket by bucket); eviction order self-corrects as entries
+ * are accessed.
+ *
  * Bump CACHE_VERSION whenever the cached Resource schema changes (e.g. new
  * fields added to Block, ResourceLink, etc.) so stale persisted entries are
  * discarded automatically on the next startup.
  */
 export default class VsCodeBasedParserCache implements ParserCache {
-  static CACHE_NAME = 'foam-cache';
   static CACHE_VERSION = 5;
   static CACHE_VERSION_KEY = 'foam-cache-version';
-  private _cache: LRUCache<string, ParserCacheEntry>;
+  static CACHE_DIR_NAME = 'parser-cache';
+  static BUCKET_COUNT = 64;
+  /** workspaceState key used by earlier versions, migrated on load */
+  static LEGACY_STATE_KEY = 'foam-cache';
 
-  constructor(private context: ExtensionContext, size = 10000) {
+  private _cache: LRUCache<string, ParserCacheEntry>;
+  private _cacheDir: URI | undefined;
+  private _dirty = new Set<number>();
+  private _pendingWrite: Promise<void> = Promise.resolve();
+
+  private constructor(private context: ExtensionContext, size: number) {
+    this._cacheDir = context.storageUri
+      ? fromVsCodeUri(context.storageUri).joinPath(VsCodeBasedParserCache.CACHE_DIR_NAME)
+      : undefined;
     this._cache = new LRUCache({
       max: size,
       updateAgeOnGet: true,
       updateAgeOnHas: false,
+      // set()/del() mark their bucket dirty themselves; eviction is the
+      // only other way an entry leaves the cache and must be persisted
+      dispose: (_entry, key, reason) => {
+        if (reason === 'evict') {
+          this._dirty.add(bucketOf(key));
+        }
+      },
     });
+  }
 
-    const storedVersion = context.workspaceState.get<number>(
+  static async create(context: ExtensionContext, size = 10000): Promise<VsCodeBasedParserCache> {
+    const instance = new VsCodeBasedParserCache(context, size);
+    await instance.load();
+    return instance;
+  }
+
+  private async load(): Promise<void> {
+    const storedVersion = this.context.workspaceState.get<number>(
       VsCodeBasedParserCache.CACHE_VERSION_KEY,
       0
     );
@@ -39,29 +78,92 @@ export default class VsCodeBasedParserCache implements ParserCache {
       Logger.debug(
         `Cache version mismatch (stored: ${storedVersion}, current: ${VsCodeBasedParserCache.CACHE_VERSION}) — clearing cache`
       );
-      this.clear();
-      context.workspaceState.update(
+      await this.clear();
+      await this.context.workspaceState.update(
         VsCodeBasedParserCache.CACHE_VERSION_KEY,
         VsCodeBasedParserCache.CACHE_VERSION
       );
-    } else {
-      const source = context.workspaceState.get(
-        VsCodeBasedParserCache.CACHE_NAME,
-        []
-      );
-      try {
-        this._cache.load(source);
-      } catch (e) {
-        Logger.warn(`Failed to load cache: ${e}`);
-        this.clear();
-      }
+      return;
+    }
+
+    const imported = await this.importLegacyWorkspaceState();
+    if (!imported) {
+      await this.loadBuckets();
     }
     Logger.debug('Cache size: ' + this._cache.size);
   }
 
-  clear(): void {
+  /**
+   * Imports the cache blob that earlier versions kept in workspaceState,
+   * re-shards it to bucket files, and removes the old key — keeping the
+   * blob would defeat the purpose of file-based storage, as it gets
+   * serialized with the rest of the workspace state (see #1677).
+   * Returns whether any entries were imported.
+   */
+  private async importLegacyWorkspaceState(): Promise<boolean> {
+    const source = this.context.workspaceState.get<any[]>(VsCodeBasedParserCache.LEGACY_STATE_KEY);
+    if (source === undefined) {
+      return false;
+    }
+    let imported = false;
+    if (Array.isArray(source) && source.length > 0) {
+      try {
+        this._cache.load(source);
+        for (const key of this._cache.keys()) {
+          this._dirty.add(bucketOf(key));
+        }
+        this.scheduleSync();
+        imported = true;
+        Logger.info(`Migrated parser cache from workspace state (${this._cache.size} entries)`);
+      } catch (e) {
+        Logger.warn(`Failed to migrate parser cache from workspace state: ${e}`);
+      }
+    }
+    await this.context.workspaceState.update(VsCodeBasedParserCache.LEGACY_STATE_KEY, undefined);
+    return imported;
+  }
+
+  private bucketUri(index: number): URI {
+    return this._cacheDir.joinPath(`bucket-${index.toString(16).padStart(2, '0')}.json`);
+  }
+
+  private async loadBuckets(): Promise<void> {
+    if (!this._cacheDir) {
+      return;
+    }
+    await Promise.all(
+      [...Array(VsCodeBasedParserCache.BUCKET_COUNT).keys()].map(index => this.loadBucket(index))
+    );
+  }
+
+  private async loadBucket(index: number): Promise<void> {
+    const uri = this.bucketUri(index);
+    try {
+      const content = await readFile(uri);
+      if (content === undefined) {
+        return;
+      }
+      const entries: [string, ParserCacheEntry][] = JSON.parse(content);
+      for (const [key, entry] of entries) {
+        this._cache.set(key, entry);
+      }
+    } catch (e) {
+      // a corrupted bucket only costs re-parsing its own notes
+      Logger.warn(`Failed to load cache bucket ${uri.toFsPath()}: ${e}`);
+      await deleteQuietly(uri);
+    }
+  }
+
+  async clear(): Promise<void> {
+    this.scheduleSync.cancel();
     this._cache.clear();
-    this.context.workspaceState.update(VsCodeBasedParserCache.CACHE_NAME, []);
+    this._dirty.clear();
+    // let any in-flight write settle, so it cannot recreate files afterwards
+    await this._pendingWrite;
+    if (this._cacheDir) {
+      await deleteQuietly(this._cacheDir);
+    }
+    await this.context.workspaceState.update(VsCodeBasedParserCache.LEGACY_STATE_KEY, undefined);
   }
 
   get(uri: URI): ParserCacheEntry {
@@ -88,23 +190,95 @@ export default class VsCodeBasedParserCache implements ParserCache {
   }
 
   set(uri: URI, entry: ParserCacheEntry): void {
-    this._cache.set(uri.toString(), entry);
-    delayedSync(this._cache, this.context);
+    const key = uri.toString();
+    this._cache.set(key, entry);
+    this._dirty.add(bucketOf(key));
+    this.scheduleSync();
   }
 
   del(uri: URI): void {
-    this._cache.delete(uri.toString());
-    delayedSync(this._cache, this.context);
+    const key = uri.toString();
+    this._cache.delete(key);
+    this._dirty.add(bucketOf(key));
+    this.scheduleSync();
+  }
+
+  /**
+   * Persists any pending change immediately, bypassing the debounce.
+   */
+  async flush(): Promise<void> {
+    this.scheduleSync.flush();
+    await this._pendingWrite;
+  }
+
+  /**
+   * Register the cache in `context.subscriptions` so the latest parse
+   * results are persisted on shutdown (best effort).
+   */
+  dispose(): void {
+    this.flush();
+  }
+
+  private scheduleSync = debounce(() => {
+    this.performSync();
+  }, 1000);
+
+  private performSync(): Promise<void> {
+    // writes are chained so two syncs can never interleave
+    this._pendingWrite = this._pendingWrite.then(() => this.writeDirtyBuckets());
+    return this._pendingWrite;
+  }
+
+  private async writeDirtyBuckets(): Promise<void> {
+    if (!this._cacheDir || this._dirty.size === 0) {
+      return;
+    }
+    const buckets = new Map<number, [string, ParserCacheEntry][]>();
+    for (const index of this._dirty) {
+      buckets.set(index, []);
+    }
+    this._dirty = new Set();
+    // single pass over the keys; only entries of dirty buckets are serialized
+    for (const [key, entry] of this._cache.entries()) {
+      buckets.get(bucketOf(key))?.push([key, entry]);
+    }
+    Logger.debug(`Updating parser cache (${buckets.size} buckets)`);
+    await Promise.all(
+      [...buckets].map(async ([index, entries]) => {
+        try {
+          if (entries.length === 0) {
+            await deleteQuietly(this.bucketUri(index));
+          } else {
+            await writeFile(this.bucketUri(index), JSON.stringify(entries));
+          }
+        } catch (e) {
+          Logger.warn(`Failed to write cache bucket ${index}: ${e}`);
+          this._dirty.add(index); // retried on the next sync
+        }
+      })
+    );
+    if (this._dirty.size > 0) {
+      this.scheduleSync();
+    }
   }
 }
 
-const delayedSync = debounce(
-  (cache: LRUCache<string, ParserCacheEntry>, context) => {
-    Logger.debug('Updating parser cache');
-    context.workspaceState.update(
-      VsCodeBasedParserCache.CACHE_NAME,
-      cache.dump()
-    );
-  },
-  1000
-);
+async function deleteQuietly(uri: URI): Promise<void> {
+  try {
+    await deleteFile(uri);
+  } catch {
+    // the file may not exist — deleting is best effort
+  }
+}
+
+/**
+ * FNV-1a — stable across sessions, so a URI always lands in the same bucket
+ */
+function bucketOf(key: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < key.length; i++) {
+    hash ^= key.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0) % VsCodeBasedParserCache.BUCKET_COUNT;
+}

--- a/packages/foam-vscode/src/vscode/services/cache.ts
+++ b/packages/foam-vscode/src/vscode/services/cache.ts
@@ -4,7 +4,7 @@ import { ExtensionContext } from 'vscode';
 import { URI } from '@foam/core';
 import { ParserCache, ParserCacheEntry } from '@foam/core';
 import { Logger } from '@foam/core';
-import { deleteFile, readFile, writeFile } from './editor';
+import { deleteFile, dirExists, readFile, writeFile } from './editor';
 import { fromVsCodeUri } from '../utils/vsc-utils';
 
 /**
@@ -47,7 +47,9 @@ export default class VsCodeBasedParserCache implements ParserCache {
 
   private constructor(private context: ExtensionContext, size: number) {
     this._cacheDir = context.storageUri
-      ? fromVsCodeUri(context.storageUri).joinPath(VsCodeBasedParserCache.CACHE_DIR_NAME)
+      ? fromVsCodeUri(context.storageUri).joinPath(
+          VsCodeBasedParserCache.CACHE_DIR_NAME
+        )
       : undefined;
     this._cache = new LRUCache({
       max: size,
@@ -63,7 +65,10 @@ export default class VsCodeBasedParserCache implements ParserCache {
     });
   }
 
-  static async create(context: ExtensionContext, size = 10000): Promise<VsCodeBasedParserCache> {
+  static async create(
+    context: ExtensionContext,
+    size = 10000
+  ): Promise<VsCodeBasedParserCache> {
     const instance = new VsCodeBasedParserCache(context, size);
     await instance.load();
     return instance;
@@ -79,6 +84,14 @@ export default class VsCodeBasedParserCache implements ParserCache {
         `Cache version mismatch (stored: ${storedVersion}, current: ${VsCodeBasedParserCache.CACHE_VERSION}) — clearing cache`
       );
       await this.clear();
+      if (this._cacheDir && (await dirExists(this._cacheDir))) {
+        // deleting the outdated files failed: don't stamp the new version,
+        // or the stale entries would be loaded as current data next startup
+        Logger.warn(
+          'Could not remove the outdated parser cache — will retry on next startup'
+        );
+        return;
+      }
       await this.context.workspaceState.update(
         VsCodeBasedParserCache.CACHE_VERSION_KEY,
         VsCodeBasedParserCache.CACHE_VERSION
@@ -101,7 +114,9 @@ export default class VsCodeBasedParserCache implements ParserCache {
    * Returns whether any entries were imported.
    */
   private async importLegacyWorkspaceState(): Promise<boolean> {
-    const source = this.context.workspaceState.get<any[]>(VsCodeBasedParserCache.LEGACY_STATE_KEY);
+    const source = this.context.workspaceState.get<any[]>(
+      VsCodeBasedParserCache.LEGACY_STATE_KEY
+    );
     if (source === undefined) {
       return false;
     }
@@ -112,19 +127,30 @@ export default class VsCodeBasedParserCache implements ParserCache {
         for (const key of this._cache.keys()) {
           this._dirty.add(bucketOf(key));
         }
-        this.scheduleSync();
+        // persist the re-sharded entries before the legacy blob is removed
+        // below, so a crash in between cannot lose the whole cache
+        await this.performSync();
         imported = true;
-        Logger.info(`Migrated parser cache from workspace state (${this._cache.size} entries)`);
+        Logger.info(
+          `Migrated parser cache from workspace state (${this._cache.size} entries)`
+        );
       } catch (e) {
-        Logger.warn(`Failed to migrate parser cache from workspace state: ${e}`);
+        Logger.warn(
+          `Failed to migrate parser cache from workspace state: ${e}`
+        );
       }
     }
-    await this.context.workspaceState.update(VsCodeBasedParserCache.LEGACY_STATE_KEY, undefined);
+    await this.context.workspaceState.update(
+      VsCodeBasedParserCache.LEGACY_STATE_KEY,
+      undefined
+    );
     return imported;
   }
 
   private bucketUri(index: number): URI {
-    return this._cacheDir.joinPath(`bucket-${index.toString(16).padStart(2, '0')}.json`);
+    return this._cacheDir.joinPath(
+      `bucket-${index.toString(16).padStart(2, '0')}.json`
+    );
   }
 
   private async loadBuckets(): Promise<void> {
@@ -132,7 +158,9 @@ export default class VsCodeBasedParserCache implements ParserCache {
       return;
     }
     await Promise.all(
-      [...Array(VsCodeBasedParserCache.BUCKET_COUNT).keys()].map(index => this.loadBucket(index))
+      [...Array(VsCodeBasedParserCache.BUCKET_COUNT).keys()].map(index =>
+        this.loadBucket(index)
+      )
     );
   }
 
@@ -163,7 +191,10 @@ export default class VsCodeBasedParserCache implements ParserCache {
     if (this._cacheDir) {
       await deleteQuietly(this._cacheDir);
     }
-    await this.context.workspaceState.update(VsCodeBasedParserCache.LEGACY_STATE_KEY, undefined);
+    await this.context.workspaceState.update(
+      VsCodeBasedParserCache.LEGACY_STATE_KEY,
+      undefined
+    );
   }
 
   get(uri: URI): ParserCacheEntry {
@@ -207,8 +238,10 @@ export default class VsCodeBasedParserCache implements ParserCache {
    * Persists any pending change immediately, bypassing the debounce.
    */
   async flush(): Promise<void> {
-    this.scheduleSync.flush();
-    await this._pendingWrite;
+    // sync directly instead of flushing the debounce: buckets dirtied by
+    // eviction (or by a failed write) have no scheduled sync to flush
+    this.scheduleSync.cancel();
+    await this.performSync();
   }
 
   /**
@@ -225,7 +258,9 @@ export default class VsCodeBasedParserCache implements ParserCache {
 
   private performSync(): Promise<void> {
     // writes are chained so two syncs can never interleave
-    this._pendingWrite = this._pendingWrite.then(() => this.writeDirtyBuckets());
+    this._pendingWrite = this._pendingWrite.then(() =>
+      this.writeDirtyBuckets()
+    );
     return this._pendingWrite;
   }
 
@@ -252,14 +287,13 @@ export default class VsCodeBasedParserCache implements ParserCache {
             await writeFile(this.bucketUri(index), JSON.stringify(entries));
           }
         } catch (e) {
+          // the bucket stays dirty and is retried on the next sync or flush;
+          // rescheduling here would retry a persistent failure forever
           Logger.warn(`Failed to write cache bucket ${index}: ${e}`);
-          this._dirty.add(index); // retried on the next sync
+          this._dirty.add(index);
         }
       })
     );
-    if (this._dirty.size > 0) {
-      this.scheduleSync();
-    }
   }
 }
 

--- a/packages/foam-vscode/src/vscode/services/editor.ts
+++ b/packages/foam-vscode/src/vscode/services/editor.ts
@@ -76,7 +76,7 @@ export const getFoamDocSelectors = () =>
  * that look like a file name) is resolved like a wikilink identifier.
  *
  * Returns `undefined` when the active tab cannot be mapped to a file (settings
- * page, terminal, unrecognized webview, ...). 
+ * page, terminal, unrecognized webview, ...).
  *
  * Exported separately from `getActiveTabUri()` so it can be unit-tested without
  * mocking the `tabGroups` namespace.
@@ -172,8 +172,8 @@ export function getActiveTabUri(fWorkspace?: FoamWorkspace): URI | undefined {
  * note the user is currently on.
  *
  * The listener may fire multiple times per user interaction (opening a file
- * typically fires both `onDidChangeActiveTextEditor` and `onDidChangeTabs`). 
- * Dedupe is delegated to consumers to avoid unnecessary complexity 
+ * typically fires both `onDidChangeActiveTextEditor` and `onDidChangeTabs`).
+ * Dedupe is delegated to consumers to avoid unnecessary complexity
  * and overhead when it's not needed.
  */
 export function onDidChangeActiveTab(listener: () => void): Disposable {
@@ -315,6 +315,15 @@ export async function fileExists(uri: URI): Promise<boolean> {
   }
 }
 
+export async function dirExists(uri: URI): Promise<boolean> {
+  try {
+    const stat = await workspace.fs.stat(toVsCodeUri(uri));
+    return stat.type === FileType.Directory;
+  } catch (e) {
+    return false;
+  }
+}
+
 export async function readFile(uri: URI): Promise<string | undefined> {
   if (await fileExists(uri)) {
     return workspace.fs
@@ -328,12 +337,11 @@ export function deleteFile(uri: URI) {
   return workspace.fs.delete(toVsCodeUri(uri), { recursive: true });
 }
 
+const utf8Encoder = new TextEncoder();
+
 export async function writeFile(uri: URI, content: string): Promise<void> {
   await workspace.fs.createDirectory(toVsCodeUri(uri.getDirectory()));
-  await workspace.fs.writeFile(
-    toVsCodeUri(uri),
-    new TextEncoder().encode(content)
-  );
+  await workspace.fs.writeFile(toVsCodeUri(uri), utf8Encoder.encode(content));
 }
 
 /**
@@ -454,14 +462,9 @@ export async function createMatcherAndDataStore(
   };
 
   const decoder = new TextDecoder('utf-8');
-  const encoder = new TextEncoder();
   const readFile = async (uri: URI) => {
     const content = await workspace.fs.readFile(toVsCodeUri(uri));
     return decoder.decode(content);
-  };
-  const writeFile = async (uri: URI, content: string) => {
-    await workspace.fs.createDirectory(toVsCodeUri(uri.getDirectory()));
-    await workspace.fs.writeFile(toVsCodeUri(uri), encoder.encode(content));
   };
   const deleteFile = async (uri: URI) => {
     await workspace.fs.delete(toVsCodeUri(uri));

--- a/packages/foam-vscode/src/vscode/services/editor.ts
+++ b/packages/foam-vscode/src/vscode/services/editor.ts
@@ -328,6 +328,14 @@ export function deleteFile(uri: URI) {
   return workspace.fs.delete(toVsCodeUri(uri), { recursive: true });
 }
 
+export async function writeFile(uri: URI, content: string): Promise<void> {
+  await workspace.fs.createDirectory(toVsCodeUri(uri.getDirectory()));
+  await workspace.fs.writeFile(
+    toVsCodeUri(uri),
+    new TextEncoder().encode(content)
+  );
+}
+
 /**
  * Turns a relative URI into an absolute URI for the given workspace.
  * @param uriOrPath the uri or path to evaluate


### PR DESCRIPTION
The parser cache was persisted under a single workspaceState key, so every debounced sync serialized the entire cache (up to 10k entries, ~50MB) and shipped it over IPC to the main thread, freezing the UI on large workspaces during startup and while typing.

The cache now persists to 64 bucket files under the extension storageUri. A note maps to a stable bucket via a hash of its URI and only dirty buckets are rewritten, so persistence cost is proportional to the change, not the workspace size. The legacy workspaceState blob is migrated to the new layout on first activation and removed. Pending writes are flushed on shutdown, and clear() can no longer be undone by an in-flight sync.

Supersedes #1677.