### PR TITLE
Ignore External links

### DIFF
--- a/packages/foam-core/src/services/markdown-provider.test.ts
+++ b/packages/foam-core/src/services/markdown-provider.test.ts
@@ -574,6 +574,29 @@ describe('Generation of markdown references', () => {
     ]);
   });
 
+  it('should ignore external links when generating markdown references', () => {
+    const workspace = createTestWorkspace();
+    const noteA = createNoteFromMarkdown(
+      'Visit [Foam][docs] and [[page-b]]\n\n[docs]: https://foam.md/docs',
+      '/dir1/page-a.md'
+    );
+    const noteB = createNoteFromMarkdown(
+      'Content of note B',
+      '/dir1/page-b.md'
+    );
+    workspace.set(noteA).set(noteB);
+
+    const warnSpy = vi.spyOn(Logger, 'warn');
+    const references = createMarkdownReferences(workspace, noteA.uri, false);
+
+    expect(references).toHaveLength(1);
+    expect(references[0].label).toBe('page-b');
+    expect(references[0].url).toBe('page-b');
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
   it('should not generate links for placeholders', () => {
     const workspace = createTestWorkspace();
     const noteA = createNoteFromMarkdown(

--- a/packages/foam-core/src/services/markdown-provider.ts
+++ b/packages/foam-core/src/services/markdown-provider.ts
@@ -96,8 +96,8 @@ export class MarkdownResourceProvider implements ResourceProvider {
         typeof link.definition === 'string'
           ? link.definition
           : ResourceLink.isResolvedReference(link)
-            ? link.definition.url
-            : link.rawText;
+          ? link.definition.url
+          : link.rawText;
       return URI.parse(url, 'external');
     }
     const { target, section, blockId } = MarkdownLink.analyzeLink(link);
@@ -207,6 +207,11 @@ export function createMarkdownReferences(
   const definitions = resource.links
     .filter(link => ResourceLink.isReferenceStyleLink(link))
     .map(link => {
+      if (link.type === 'external') {
+        // no need to create definitions for external links
+        return null;
+      }
+
       if (ResourceLink.isResolvedReference(link)) {
         return link.definition;
       }


### PR DESCRIPTION
Ignores external links so we avoid logging a warning that external links cannot be resolved.

When using `foam lint` I had a lot of warnings that my external "https" links etc could not resolve.

**Before:**
```log
[warn] Link https://internal.example.com/application in file:///C%3A/Users/example/project/docs/Standard-B.md is not valid.
[warn] Link https://internal.example.com/ in file:///C%3A/Users/example/project/docs/Internal-System.md is not valid.
```

**After:**
No messages are logged for "external" links.


Note: This PR was AI assisted but I have self reviewed the code, and tested the new CLI build locally. If this PR is not useful or I have missed anything feel free to close the PR. Thank you for a great project!