### PR TITLE
Fix extra line breaks between link definitions in vscode plugin

### DIFF
--- a/packages/foam-core/src/lint/generate-link-references.ts
+++ b/packages/foam-core/src/lint/generate-link-references.ts
@@ -86,6 +86,7 @@ export const generateLinkReferences = (
         def.range?.start.line === insertLineIndex
     );
     const prefix = isKeptFoamDefinitionAtInsert ? eol : eol + eol;
+    // The generated edit owns its surrounding EOLs; callers apply it verbatim.
     const text = prefix + definitions.join(eol) + eol;
 
     edits.push({

--- a/packages/foam-vscode/src/vscode/features/editing/update-wikilinks.spec.ts
+++ b/packages/foam-vscode/src/vscode/features/editing/update-wikilinks.spec.ts
@@ -54,41 +54,4 @@ describe('Update wikilink definitions', () => {
 [doc3]: doc3 "Third"
 `);
   });
-
-  it('orders existing definitions by wikilink occurrence when configured', async () => {
-    const doc1 = await createFile('# First', ['doc1.md']);
-    const doc2 = await createFile('# Second', ['doc2.md']);
-    const source = await createFile(`[[doc2]] [[doc1]]
-
-[doc1]: doc1 "First"
-[doc2]: doc2 "Second"
-`);
-
-    await waitForNoteInFoamWorkspace(doc1.uri);
-    await waitForNoteInFoamWorkspace(doc2.uri);
-    await waitForNoteInFoamWorkspace(source.uri);
-    const { editor } = await showInEditor(source.uri);
-
-    await withModifiedFoamConfiguration(
-      'edit.linkReferenceDefinitions',
-      'withoutExtensions',
-      async () => {
-        await withModifiedFoamConfiguration(
-          'edit.linkReferenceDefinitionsSort',
-          'occurrence',
-          async () => {
-            await vscode.commands.executeCommand(
-              'foam-vscode.update-wikilink-definitions'
-            );
-          }
-        );
-      }
-    );
-
-    expect(editor.document.getText()).toBe(`[[doc2]] [[doc1]]
-
-[doc2]: doc2 "Second"
-[doc1]: doc1 "First"
-`);
-  });
 });

--- a/packages/foam-vscode/src/vscode/features/editing/update-wikilinks.spec.ts
+++ b/packages/foam-vscode/src/vscode/features/editing/update-wikilinks.spec.ts
@@ -1,0 +1,94 @@
+/* @unit-ready */
+
+import * as vscode from 'vscode';
+import {
+  cleanWorkspace,
+  closeEditors,
+  createFile,
+  showInEditor,
+  waitForNoteInFoamWorkspace,
+  withModifiedFoamConfiguration,
+} from '../../../test/test-utils-vscode';
+
+describe('Update wikilink definitions', () => {
+  beforeEach(async () => {
+    await cleanWorkspace();
+    await closeEditors();
+  });
+
+  afterEach(async () => {
+    await cleanWorkspace();
+    await closeEditors();
+  });
+
+  it('appends a new definition without adding a blank line to the definition block', async () => {
+    const doc1 = await createFile('# First', ['doc1.md']);
+    const doc2 = await createFile('# Second', ['doc2.md']);
+    const doc3 = await createFile('# Third', ['doc3.md']);
+    const source = await createFile(`[[doc1]] [[doc2]] [[doc3]]
+
+[doc1]: doc1 "First"
+[doc2]: doc2 "Second"
+`);
+
+    await waitForNoteInFoamWorkspace(doc1.uri);
+    await waitForNoteInFoamWorkspace(doc2.uri);
+    await waitForNoteInFoamWorkspace(doc3.uri);
+    await waitForNoteInFoamWorkspace(source.uri);
+    const { editor } = await showInEditor(source.uri);
+
+    await withModifiedFoamConfiguration(
+      'edit.linkReferenceDefinitions',
+      'withoutExtensions',
+      async () => {
+        await vscode.commands.executeCommand(
+          'foam-vscode.update-wikilink-definitions'
+        );
+      }
+    );
+
+    expect(editor.document.getText()).toBe(`[[doc1]] [[doc2]] [[doc3]]
+
+[doc1]: doc1 "First"
+[doc2]: doc2 "Second"
+[doc3]: doc3 "Third"
+`);
+  });
+
+  it('orders existing definitions by wikilink occurrence when configured', async () => {
+    const doc1 = await createFile('# First', ['doc1.md']);
+    const doc2 = await createFile('# Second', ['doc2.md']);
+    const source = await createFile(`[[doc2]] [[doc1]]
+
+[doc1]: doc1 "First"
+[doc2]: doc2 "Second"
+`);
+
+    await waitForNoteInFoamWorkspace(doc1.uri);
+    await waitForNoteInFoamWorkspace(doc2.uri);
+    await waitForNoteInFoamWorkspace(source.uri);
+    const { editor } = await showInEditor(source.uri);
+
+    await withModifiedFoamConfiguration(
+      'edit.linkReferenceDefinitions',
+      'withoutExtensions',
+      async () => {
+        await withModifiedFoamConfiguration(
+          'edit.linkReferenceDefinitionsSort',
+          'occurrence',
+          async () => {
+            await vscode.commands.executeCommand(
+              'foam-vscode.update-wikilink-definitions'
+            );
+          }
+        );
+      }
+    );
+
+    expect(editor.document.getText()).toBe(`[[doc2]] [[doc1]]
+
+[doc2]: doc2 "Second"
+[doc1]: doc1 "First"
+`);
+  });
+});

--- a/packages/foam-vscode/src/vscode/features/editing/update-wikilinks.ts
+++ b/packages/foam-vscode/src/vscode/features/editing/update-wikilinks.ts
@@ -104,10 +104,7 @@ async function updateWikilinkDefinitions(
   if (updates.length > 0) {
     await editor.edit(editBuilder => {
       updates.forEach(update => {
-        const gap = doc.lineAt(update.range.start.line - 1).isEmptyOrWhitespace
-          ? ''
-          : eol;
-        editBuilder.replace(toVsCodeRange(update.range), gap + update.newText);
+        editBuilder.replace(toVsCodeRange(update.range), update.newText);
       });
     });
   }


### PR DESCRIPTION
Remove unnecessary line breaks when updating wikilink definitions and add comments for clarity.

AI assisted, human reviewed. Feel free to close if the fix is in the wrong place, but I feel this works well.