### PR TITLE
Fix duplicated Foam variables in mirrored tabstops

### DIFF
--- a/.changeset/tender-snippets-rest.md
+++ b/.changeset/tender-snippets-rest.md
@@ -1,0 +1,8 @@
+---
+'@foam/core': patch
+'foam-vscode': patch
+'@foam/cli': patch
+---
+
+Fixed Foam variables being duplicated when used as defaults for mirrored
+snippet tabstops (#1215).

--- a/packages/foam-core/src/common/snippetParser.ts
+++ b/packages/foam-core/src/common/snippetParser.ts
@@ -557,21 +557,44 @@ export class TextmateSnippet extends Marker {
 	}
 
 	snippetTextWithVariablesSubstituted(variableNames?: Set<string>): string {
-		const resolvedVariables: Variable[] = [];
+		const substitutions: { variable: Variable; start: number; end: number }[] = [];
+		const substitutedRanges = new Set<string>();
 		this.walk(marker => {
-			if (marker instanceof Variable && (!variableNames || variableNames.has(marker.name))) {
-				resolvedVariables.push(marker as Variable);
+			if (
+				marker instanceof Variable
+				&& marker.pos !== undefined
+				&& marker.endPos !== undefined
+				&& (!variableNames || variableNames.has(marker.name))
+			) {
+				// Mirrored placeholders clone their children, including the source
+				// range of nested variables. Substitute each source range only once.
+				const sourceRange = `${marker.pos}:${marker.endPos}`;
+				if (!substitutedRanges.has(sourceRange)) {
+					substitutedRanges.add(sourceRange);
+					substitutions.push({
+						variable: marker,
+						start: marker.pos,
+						end: marker.endPos,
+					});
+				}
 			}
 			return true;
 		});
+		substitutions.sort((a, b) =>
+			a.start - b.start || b.end - a.end
+		);
 
 		let result = '';
 
 		let i = 0;
-		resolvedVariables.forEach(variable => {
-			result += this.value.substring(i, variable.pos);
+		substitutions.forEach(({ variable, start, end }) => {
+			// A resolved outer variable already replaces any nested source span.
+			if (start < i) {
+				return;
+			}
+			result += this.value.substring(i, start);
 			result += variable.toString();
-			i = variable.endPos;
+			i = end;
 		});
 		result += this.value.substring(i);
 

--- a/packages/foam-core/src/templates/variable-resolver.test.ts
+++ b/packages/foam-core/src/templates/variable-resolver.test.ts
@@ -51,6 +51,28 @@ describe('variable-resolver, text substitution', () => {
     const resolver = new Resolver(givenValues, new Date());
     expect(await resolver.resolveText(input)).toEqual(expected);
   });
+
+  it('should substitute a Foam variable once when its placeholder is mirrored', async () => {
+    const input = `\${1:$FOAM_TITLE} :: $1 :: $1`;
+    const expected = `\${1:Invalid "Characters"} :: $1 :: $1`;
+
+    const givenValues = new Map<string, string>();
+    givenValues.set('FOAM_TITLE', 'Invalid "Characters"');
+    const resolver = new Resolver(givenValues, new Date());
+
+    expect(await resolver.resolveText(input)).toEqual(expected);
+  });
+
+  it('should substitute variables in source order when a mirror precedes its default', async () => {
+    const input = `$1 :: $FOAM_SLUG :: \${1:$FOAM_TITLE}`;
+    const expected = `$1 :: my-note :: \${1:My Note}`;
+
+    const givenValues = new Map<string, string>();
+    givenValues.set('FOAM_TITLE', 'My Note');
+    const resolver = new Resolver(givenValues, new Date());
+
+    expect(await resolver.resolveText(input)).toEqual(expected);
+  });
 });
 
 describe('variable-resolver, variable resolution', () => {


### PR DESCRIPTION
## Summary

- prevent mirrored snippet tabstops from substituting the same Foam variable
  source range more than once
- apply substitutions in source order and skip source spans already covered by
  an outer variable
- add regression coverage for repeated mirrors and for mirrors that precede
  their later default

## Root cause

When the snippet parser copies a placeholder default into its mirrors, cloned
variables retain the original variable's `pos` and `endPos`. The resolver then
processed every cloned marker against the original text, replacing one source
span multiple times. A mirror before its default could additionally put the
markers out of source order and move the substitution cursor backwards.

## Validation

- `yarn workspace @foam/core test:unit` (1077 passed, 1 skipped)
- `yarn workspace foam-vscode test:unit` (682 passed, 5 skipped, 1 todo)
- `yarn workspace @foam/cli test` (389 unit tests and 18 end-to-end tests passed)
- `yarn build`
- `yarn lint` (0 errors; existing warnings only)
- `yarn changeset status`

Fixes #1215
