### PR TITLE
Fix notes disappearing from index when folders are moved

### DIFF
--- a/.changeset/great-donuts-repeat.md
+++ b/.changeset/great-donuts-repeat.md
@@ -1,0 +1,24 @@
+---
+'@foam/core': patch
+'foam-vscode': patch
+'@foam/cli': patch
+---
+
+Fixed notes disappearing from the workspace index when their folder is moved or
+renamed in the Explorer ([#1696](https://github.com/foambubble/foam/issues/1696)).
+The notes were dropped from the Notes Explorer, graph, backlinks, `foam-query`
+and wikilink resolution, under both the old and the new path, and only a window
+reload brought them back. Because the entries were gone, moving the same folder
+a second time also silently stopped updating any links pointing into it.
+
+A directory rename now migrates the index itself instead of relying on file
+watcher events that a directory-granularity rename may never produce: the
+affected notes are re-indexed under their new paths as part of the rename, on
+every platform. Index migration also no longer depends on the
+`foam.links.sync.enable` setting.
+
+Include/exclude matching now evaluates the globs directly rather than looking
+paths up in a snapshot of the workspace file listing, which could go stale and
+never recover. Matching is case-insensitive and covers dot-directories, mirroring
+how `workspace.findFiles` behaves today, and the VS Code extension and the CLI
+now share one matcher implementation.

--- a/packages/foam-cli/src/support/glob-matcher.ts
+++ b/packages/foam-cli/src/support/glob-matcher.ts
@@ -1,32 +1,15 @@
-import micromatch from 'micromatch';
-import { URI, IMatcher } from '@foam/core';
+import { GlobMatcher as CoreGlobMatcher, URI } from '@foam/core';
 
-export class GlobMatcher implements IMatcher {
-  private readonly rootPath: string;
-
+/**
+ * Single-root convenience wrapper over the shared {@link CoreGlobMatcher}, so
+ * the CLI and the VS Code extension answer include/exclude the same way.
+ */
+export class GlobMatcher extends CoreGlobMatcher {
   constructor(
-    public readonly include: string[] = ['**/*'],
-    public readonly exclude: string[] = [],
+    include: string[] = ['**/*'],
+    exclude: string[] = [],
     rootDir: URI
   ) {
-    this.rootPath = rootDir.path.endsWith('/') ? rootDir.path : rootDir.path + '/';
-  }
-
-  match(files: URI[]): URI[] {
-    return files.filter(f => this.isMatch(f));
-  }
-
-  isMatch(uri: URI): boolean {
-    const rel = uri.path.startsWith(this.rootPath)
-      ? uri.path.slice(this.rootPath.length)
-      : uri.path;
-    return (
-      micromatch.isMatch(rel, this.include) &&
-      (this.exclude.length === 0 || !micromatch.isMatch(rel, this.exclude))
-    );
-  }
-
-  refresh(): Promise<void> {
-    return Promise.resolve();
+    super([{ uri: rootDir, include, exclude }]);
   }
 }

--- a/packages/foam-core/package.json
+++ b/packages/foam-core/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@types/jexl": "^2.3.4",
+    "@types/micromatch": "^4.0.10",
     "oxlint": "^1.57.0",
     "rimraf": "^3.0.2",
     "typescript": "^5.8.0",
@@ -45,6 +46,7 @@
     "js-sha1": "^0.7.0",
     "lodash": "^4.17.21",
     "lru-cache": "^11.0.0",
+    "micromatch": "^4.0.8",
     "mnemonist": "^0.39.8",
     "remark-frontmatter": "^2.0.0",
     "remark-parse": "^8.0.2",

--- a/packages/foam-core/src/index.ts
+++ b/packages/foam-core/src/index.ts
@@ -22,6 +22,8 @@ export {
   AlwaysIncludeMatcher,
   SubstringExcludeMatcher,
 } from './services/datastore';
+export { GlobMatcher } from './services/glob-matcher';
+export type { GlobMatcherRoot } from './services/glob-matcher';
 export { createMarkdownParser, getLinkDefinitions, getBlockFor } from './services/markdown-parser';
 export type {
   ParserPlugin,
@@ -48,6 +50,7 @@ export type { TagEditResult } from './services/tag-edit';
 export {
   computeWikilinkRenameEdits,
   computeDirectoryWikilinkRenameEdits,
+  listDirectoryRenamePairs,
 } from './services/link-integrity';
 
 // Templates / note creation

--- a/packages/foam-core/src/services/glob-matcher.test.ts
+++ b/packages/foam-core/src/services/glob-matcher.test.ts
@@ -1,0 +1,144 @@
+import { GlobMatcher } from './glob-matcher';
+import { URI } from '../model/uri';
+
+const root = URI.file('/workspace');
+
+describe('GlobMatcher', () => {
+  it('includes files matching the include globs', () => {
+    const matcher = new GlobMatcher([
+      { uri: root, include: ['**/*'], exclude: [] },
+    ]);
+
+    expect(matcher.isMatch(root.joinPath('notes/a.md'))).toBeTruthy();
+    expect(matcher.isMatch(root.joinPath('deeply/nested/a.md'))).toBeTruthy();
+  });
+
+  it('rejects files that match an exclude glob', () => {
+    const matcher = new GlobMatcher([
+      { uri: root, include: ['**/*'], exclude: ['**/node_modules/**/*'] },
+    ]);
+
+    expect(matcher.isMatch(root.joinPath('notes/a.md'))).toBeTruthy();
+    expect(
+      matcher.isMatch(root.joinPath('node_modules/pkg/a.md'))
+    ).toBeFalsy();
+  });
+
+  it('rejects files that match no include glob', () => {
+    const matcher = new GlobMatcher([
+      { uri: root, include: ['notes/**'], exclude: [] },
+    ]);
+
+    expect(matcher.isMatch(root.joinPath('notes/a.md'))).toBeTruthy();
+    expect(matcher.isMatch(root.joinPath('other/a.md'))).toBeFalsy();
+  });
+
+  /**
+   * VS Code's `findFiles` returns files inside dot-directories, which is why
+   * Foam has to exclude `**\/.foam/**` explicitly. A matcher that silently
+   * dropped them would remove e.g. `.github/notes.md` from the index.
+   */
+  it('includes files inside dot-directories, as findFiles does', () => {
+    const matcher = new GlobMatcher([
+      { uri: root, include: ['**/*'], exclude: [] },
+    ]);
+
+    expect(matcher.isMatch(root.joinPath('.github/notes.md'))).toBeTruthy();
+    expect(matcher.isMatch(root.joinPath('notes/.hidden.md'))).toBeTruthy();
+  });
+
+  it('excludes the .foam directory while keeping the rest of the workspace', () => {
+    const matcher = new GlobMatcher([
+      { uri: root, include: ['**/*'], exclude: ['**/.foam/**'] },
+    ]);
+
+    expect(
+      matcher.isMatch(root.joinPath('.foam/templates/t.md'))
+    ).toBeFalsy();
+    expect(matcher.isMatch(root.joinPath('notes/a.md'))).toBeTruthy();
+  });
+
+  /**
+   * `findFiles` follows the filesystem, so on Windows and default macOS an
+   * exclude of `**\/Archive/**` also excludes a folder named `archive`.
+   */
+  it('matches case-insensitively', () => {
+    const matcher = new GlobMatcher([
+      { uri: root, include: ['**/*.md'], exclude: ['**/archive/**'] },
+    ]);
+
+    expect(matcher.isMatch(root.joinPath('Notes/A.MD'))).toBeTruthy();
+    expect(matcher.isMatch(root.joinPath('docs/Archive/x.md'))).toBeFalsy();
+  });
+
+  it('supports brace alternates in globs', () => {
+    const matcher = new GlobMatcher([
+      { uri: root, include: ['**/*.{md,markdown}'], exclude: [] },
+    ]);
+
+    expect(matcher.isMatch(root.joinPath('a.md'))).toBeTruthy();
+    expect(matcher.isMatch(root.joinPath('a.markdown'))).toBeTruthy();
+    expect(matcher.isMatch(root.joinPath('a.txt'))).toBeFalsy();
+  });
+
+  it('applies each root its own include and exclude globs', () => {
+    const notesRoot = URI.file('/notes-root');
+    const docsRoot = URI.file('/docs-root');
+    const matcher = new GlobMatcher([
+      { uri: notesRoot, include: ['**/*'], exclude: ['**/private/**'] },
+      { uri: docsRoot, include: ['published/**'], exclude: [] },
+    ]);
+
+    expect(matcher.isMatch(notesRoot.joinPath('a.md'))).toBeTruthy();
+    expect(matcher.isMatch(notesRoot.joinPath('private/a.md'))).toBeFalsy();
+    expect(matcher.isMatch(docsRoot.joinPath('published/a.md'))).toBeTruthy();
+    expect(matcher.isMatch(docsRoot.joinPath('draft/a.md'))).toBeFalsy();
+    // notes-root's permissive include must not leak into docs-root
+    expect(matcher.isMatch(docsRoot.joinPath('a.md'))).toBeFalsy();
+  });
+
+  it('rejects a uri that belongs to no root', () => {
+    const matcher = new GlobMatcher([
+      { uri: root, include: ['**/*'], exclude: [] },
+    ]);
+
+    expect(matcher.isMatch(URI.file('/elsewhere/a.md'))).toBeFalsy();
+  });
+
+  it('does not treat a sibling root sharing a name prefix as a match', () => {
+    const matcher = new GlobMatcher([
+      { uri: URI.file('/vault'), include: ['**/*'], exclude: [] },
+    ]);
+
+    expect(matcher.isMatch(URI.file('/vault-backup/a.md'))).toBeFalsy();
+  });
+
+  it('filters a list of uris down to the matching ones', () => {
+    const matcher = new GlobMatcher([
+      { uri: root, include: ['**/*'], exclude: ['**/.foam/**'] },
+    ]);
+
+    const matched = matcher.match([
+      root.joinPath('a.md'),
+      root.joinPath('.foam/templates/t.md'),
+      root.joinPath('b.md'),
+    ]);
+
+    expect(matched.map(u => u.path)).toEqual([
+      '/workspace/a.md',
+      '/workspace/b.md',
+    ]);
+  });
+
+  it('answers without a refresh, because it holds no file list', async () => {
+    const matcher = new GlobMatcher([
+      { uri: root, include: ['**/*'], exclude: [] },
+    ]);
+
+    // A path that has never been listed still matches: there is no snapshot to
+    // go stale. This is what makes it safe to check a file that was just moved.
+    expect(matcher.isMatch(root.joinPath('brand/new/note.md'))).toBeTruthy();
+    await matcher.refresh();
+    expect(matcher.isMatch(root.joinPath('brand/new/note.md'))).toBeTruthy();
+  });
+});

--- a/packages/foam-core/src/services/glob-matcher.ts
+++ b/packages/foam-core/src/services/glob-matcher.ts
@@ -1,0 +1,81 @@
+import micromatch from 'micromatch';
+import { URI } from '../model/uri';
+import { IMatcher } from './datastore';
+
+/**
+ * A workspace root, with the include/exclude globs that apply within it.
+ * Globs are relative to the root.
+ */
+export interface GlobMatcherRoot {
+  uri: URI;
+  include: string[];
+  exclude: string[];
+}
+
+/**
+ * micromatch options chosen to mirror how `workspace.findFiles` behaves today:
+ *
+ * - `dot`: findFiles returns files inside dot-directories — which is precisely
+ *   why Foam has to exclude `.foam` explicitly. Without this, `**\/*` would
+ *   match nothing under any dot-directory and quietly drop e.g. `.github/`
+ *   notes from the index.
+ * - `nocase`: findFiles follows the filesystem, so on Windows and default macOS
+ *   an exclude of `**\/Archive/**` also excludes a folder named `archive`.
+ */
+const MATCH_OPTIONS: micromatch.Options = { dot: true, nocase: true };
+
+const asPrefix = (path: string) => (path.endsWith('/') ? path : path + '/');
+
+/**
+ * An {@link IMatcher} that answers from the include/exclude globs directly.
+ *
+ * Unlike a matcher backed by a file listing, it holds no state that can go
+ * stale, so {@link refresh} is a no-op and a path can be tested before it has
+ * ever been listed — which is what makes it safe to check a file that was just
+ * created or moved.
+ */
+export class GlobMatcher implements IMatcher {
+  public readonly include: string[];
+  public readonly exclude: string[];
+
+  private readonly roots: { prefix: string; include: string[]; exclude: string[] }[];
+
+  constructor(roots: GlobMatcherRoot[]) {
+    this.roots = roots.map(r => ({
+      prefix: asPrefix(r.uri.path),
+      include: r.include,
+      exclude: r.exclude,
+    }));
+    this.include = roots.flatMap(r => r.include);
+    this.exclude = roots.flatMap(r => r.exclude);
+  }
+
+  match(files: URI[]): URI[] {
+    return files.filter(f => this.isMatch(f));
+  }
+
+  isMatch(uri: URI): boolean {
+    // With nested roots, the innermost one owns the file.
+    let owner: (typeof this.roots)[number] | undefined;
+    for (const root of this.roots) {
+      if (
+        uri.path.startsWith(root.prefix) &&
+        (!owner || root.prefix.length > owner.prefix.length)
+      ) {
+        owner = root;
+      }
+    }
+    if (!owner || owner.include.length === 0) {
+      return false;
+    }
+    const relativePath = uri.path.slice(owner.prefix.length);
+    return (
+      micromatch.isMatch(relativePath, owner.include, MATCH_OPTIONS) &&
+      !micromatch.isMatch(relativePath, owner.exclude, MATCH_OPTIONS)
+    );
+  }
+
+  refresh(): Promise<void> {
+    return Promise.resolve();
+  }
+}

--- a/packages/foam-core/src/services/link-integrity.test.ts
+++ b/packages/foam-core/src/services/link-integrity.test.ts
@@ -1,6 +1,7 @@
 import {
   computeWikilinkRenameEdits,
   computeDirectoryWikilinkRenameEdits,
+  listDirectoryRenamePairs,
 } from './link-integrity';
 import {
   createNoteFromMarkdown,
@@ -403,5 +404,75 @@ describe('computeDirectoryWikilinkRenameEdits', () => {
     );
 
     expect(edits[0].edit.newText).toEqual('[[folderB/note-a#Section]]');
+  });
+});
+
+describe('listDirectoryRenamePairs', () => {
+  it('maps every resource under the directory to its path after the move', () => {
+    const noteA = createNoteFromMarkdown('folderA/note-a.md', 'A', root);
+    const noteB = createNoteFromMarkdown('folderA/note-b.md', 'B', root);
+    const outside = createNoteFromMarkdown('elsewhere/note-c.md', 'C', root);
+    const { workspace } = createWorkspaceAndGraph(noteA, noteB, outside);
+
+    const pairs = listDirectoryRenamePairs(
+      workspace,
+      URI.file('/folderA'),
+      URI.file('/folderB')
+    );
+
+    expect(pairs.map(p => p.newUri.path).sort()).toEqual([
+      '/folderB/note-a.md',
+      '/folderB/note-b.md',
+    ]);
+    expect(pairs.map(p => p.oldResource.uri.path).sort()).toEqual([
+      '/folderA/note-a.md',
+      '/folderA/note-b.md',
+    ]);
+  });
+
+  it('preserves nested sub-directory structure under the new path', () => {
+    const nested = createNoteFromMarkdown(
+      'folderA/sub/deep/note.md',
+      'nested',
+      root
+    );
+    const { workspace } = createWorkspaceAndGraph(nested);
+
+    const pairs = listDirectoryRenamePairs(
+      workspace,
+      URI.file('/folderA'),
+      URI.file('/parent/folderB')
+    );
+
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0].newUri.path).toEqual('/parent/folderB/sub/deep/note.md');
+  });
+
+  it('does not match sibling directories that share a name prefix', () => {
+    const inside = createNoteFromMarkdown('notes/a.md', 'inside', root);
+    const sibling = createNoteFromMarkdown('notes-archive/b.md', 'sibling', root);
+    const { workspace } = createWorkspaceAndGraph(inside, sibling);
+
+    const pairs = listDirectoryRenamePairs(
+      workspace,
+      URI.file('/notes'),
+      URI.file('/journal')
+    );
+
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0].newUri.path).toEqual('/journal/a.md');
+  });
+
+  it('returns an empty list for a directory with no indexed resources', () => {
+    const outside = createNoteFromMarkdown('outside.md', 'Content', root);
+    const { workspace } = createWorkspaceAndGraph(outside);
+
+    const pairs = listDirectoryRenamePairs(
+      workspace,
+      URI.file('/empty-folder'),
+      URI.file('/renamed-folder')
+    );
+
+    expect(pairs).toEqual([]);
   });
 });

--- a/packages/foam-core/src/services/link-integrity.ts
+++ b/packages/foam-core/src/services/link-integrity.ts
@@ -113,19 +113,39 @@ export function computeWikilinkRenameEdits(
   ]);
 }
 
+/**
+ * Lists every resource indexed under `oldDirUri`, paired with the URI it will
+ * live at once the directory has been moved to `newDirUri`.
+ *
+ * Used both to rewrite the links pointing into the directory and to migrate the
+ * workspace entries themselves, so the two always agree on what is moving.
+ */
+export function listDirectoryRenamePairs(
+  workspace: FoamWorkspace,
+  oldDirUri: URI,
+  newDirUri: URI
+): Array<{ oldResource: Resource; newUri: URI }> {
+  // The trailing slash keeps a sibling that merely shares a name prefix
+  // (`notes-archive` next to `notes`) out of the list.
+  const oldDirPrefix = oldDirUri.path + '/';
+  return workspace
+    .list()
+    .filter(r => r.uri.path.startsWith(oldDirPrefix))
+    .map(r => ({
+      oldResource: r,
+      newUri: newDirUri.joinPath(r.uri.path.slice(oldDirPrefix.length)),
+    }));
+}
+
 export function computeDirectoryWikilinkRenameEdits(
   workspace: FoamWorkspace,
   graph: FoamGraph,
   oldDirUri: URI,
   newDirUri: URI
 ): WorkspaceTextEdit[] {
-  const oldDirPath = oldDirUri.path;
-  const renames = workspace
-    .list()
-    .filter(r => r.uri.path.startsWith(oldDirPath + '/'))
-    .map(r => ({
-      oldResource: r,
-      newUri: newDirUri.joinPath(r.uri.path.slice(oldDirPath.length + 1)),
-    }));
-  return computeRenameEditsForPairs(workspace, graph, renames);
+  return computeRenameEditsForPairs(
+    workspace,
+    graph,
+    listDirectoryRenamePairs(workspace, oldDirUri, newDirUri)
+  );
 }

--- a/packages/foam-vscode/src/test/vscode-mock.ts
+++ b/packages/foam-vscode/src/test/vscode-mock.ts
@@ -919,6 +919,11 @@ class MockTextDocument implements TextDocument {
   async save(): Promise<boolean> {
     try {
       await fs.promises.writeFile(this.uri.fsPath, this._content);
+      // Saving changes the file on disk, so the file watcher fires — same as
+      // every other write path in this mock, and as VS Code does for real.
+      for (const watcher of mockState.fileWatchers) {
+        watcher._fireChange(this.uri);
+      }
       return true;
     } catch {
       return false;

--- a/packages/foam-vscode/src/vscode/features/editing/refactor.spec.ts
+++ b/packages/foam-vscode/src/vscode/features/editing/refactor.spec.ts
@@ -210,13 +210,6 @@ describe('Note rename sync', () => {
         );
       }, 2000);
 
-      // The mock does not re-index a file whose content was changed through
-      // applyEdit; in the real editor the save in the rename handler triggers
-      // that via onDidSaveTextDocument. Re-read it so the graph sees the
-      // rewritten link before the second move.
-      const foam = await getFoamFromVSCode();
-      await foam.workspace.fetchAndSet(outside.uri);
-
       const folderCUri = parentUri.joinPath('twice-folderC');
       await renameFile(folderBUri, folderCUri);
 

--- a/packages/foam-vscode/src/vscode/features/editing/refactor.spec.ts
+++ b/packages/foam-vscode/src/vscode/features/editing/refactor.spec.ts
@@ -10,6 +10,7 @@ import {
   showInEditor,
   runCommand,
   deleteFile,
+  getFoamFromVSCode,
 } from '../../../test/test-utils-vscode';
 import { UPDATE_GRAPH_COMMAND_NAME } from '../notes/update-graph';
 
@@ -149,6 +150,85 @@ describe('Note rename sync', () => {
 
       await deleteFile(outside.uri);
       await deleteFile(folderBUri);
+    });
+
+    it('should keep the moved notes in the workspace index under the new path', async () => {
+      const noteA = await createFile('Content of A', [
+        'dir-move-index',
+        'idx-folderA',
+        'indexed-note.md',
+      ]);
+
+      await wait(1000);
+      await runCommand(UPDATE_GRAPH_COMMAND_NAME);
+
+      const folderAUri = noteA.uri.getDirectory();
+      const folderBUri = folderAUri.getDirectory().joinPath('idx-folderB');
+      const movedNoteUri = folderBUri.joinPath('indexed-note.md');
+      const foam = await getFoamFromVSCode();
+
+      await renameFile(folderAUri, folderBUri);
+
+      // Asserted immediately, with no wait: the rename must leave the index
+      // consistent by itself. Waiting here would let the debounced watcher
+      // create events re-add the note and mask the bug.
+      expect(foam.workspace.find(movedNoteUri)).toBeTruthy();
+      expect(foam.workspace.find(noteA.uri)).toBeFalsy();
+
+      await deleteFile(folderBUri);
+    });
+
+    it('should still sync wikilinks when the same folder is moved twice', async () => {
+      // The first move must leave the notes indexed, otherwise the second move
+      // has nothing to compute renames from and silently updates no links.
+      const noteA = await createFile('Content of A', [
+        'dir-move-twice',
+        'twice-folderA',
+        'twice-note.md',
+      ]);
+      const conflict = await createFile('Conflicting note', [
+        'dir-move-twice',
+        'twice-other',
+        'twice-note.md',
+      ]);
+      const outside = await createFile('Link to [[twice-folderA/twice-note]]', [
+        'dir-move-twice',
+        'outside.md',
+      ]);
+
+      await wait(1000);
+      await runCommand(UPDATE_GRAPH_COMMAND_NAME);
+
+      const folderAUri = noteA.uri.getDirectory();
+      const parentUri = folderAUri.getDirectory();
+      const folderBUri = parentUri.joinPath('twice-folderB');
+      await renameFile(folderAUri, folderBUri);
+
+      await waitForExpect(async () => {
+        expect((await readFile(outside.uri)).trim()).toEqual(
+          'Link to [[twice-folderB/twice-note]]'
+        );
+      }, 2000);
+
+      // The mock does not re-index a file whose content was changed through
+      // applyEdit; in the real editor the save in the rename handler triggers
+      // that via onDidSaveTextDocument. Re-read it so the graph sees the
+      // rewritten link before the second move.
+      const foam = await getFoamFromVSCode();
+      await foam.workspace.fetchAndSet(outside.uri);
+
+      const folderCUri = parentUri.joinPath('twice-folderC');
+      await renameFile(folderBUri, folderCUri);
+
+      await waitForExpect(async () => {
+        expect((await readFile(outside.uri)).trim()).toEqual(
+          'Link to [[twice-folderC/twice-note]]'
+        );
+      }, 2000);
+
+      await deleteFile(outside.uri);
+      await deleteFile(folderCUri);
+      await deleteFile(conflict.uri);
     });
   });
 

--- a/packages/foam-vscode/src/vscode/features/editing/refactor.ts
+++ b/packages/foam-vscode/src/vscode/features/editing/refactor.ts
@@ -10,6 +10,7 @@ import {
 import {
   computeWikilinkRenameEdits,
   computeDirectoryWikilinkRenameEdits,
+  listDirectoryRenamePairs,
 } from '@foam/core';
 
 const MARKDOWN_LINK_NOTIFICATION_KEY =
@@ -21,11 +22,22 @@ export default async function activate(
 ) {
   const foam = await foamPromise;
 
+  /**
+   * Resources that a directory rename is about to move, collected while the old
+   * paths are still indexed and consumed once the rename has happened. Keyed by
+   * the old directory URI.
+   */
+  const pendingDirectoryRenames = new Map<
+    string,
+    ReturnType<typeof listDirectoryRenamePairs>
+  >();
+
   context.subscriptions.push(
     vscode.workspace.onWillRenameFiles(async e => {
-      if (!getFoamVsCodeConfig<boolean>('links.sync.enable', true)) {
-        return;
-      }
+      const syncLinks = getFoamVsCodeConfig<boolean>('links.sync.enable', true);
+      // Anything still pending belongs to an earlier rename that was cancelled
+      // before it completed, so it can never be consumed.
+      pendingDirectoryRenames.clear();
       const renameEdits = new vscode.WorkspaceEdit();
       let hasMarkdownBacklinks = false;
       for (const { oldUri, newUri } of e.files) {
@@ -35,6 +47,19 @@ export default async function activate(
         const isDirectory =
           (await vscode.workspace.fs.stat(oldUri)).type ===
           vscode.FileType.Directory;
+
+        // Collected before the links.sync check: rewriting links is optional,
+        // keeping the workspace index consistent is not.
+        if (isDirectory) {
+          pendingDirectoryRenames.set(
+            oldUri.toString(),
+            listDirectoryRenamePairs(foam.workspace, foamOldUri, foamNewUri)
+          );
+        }
+
+        if (!syncLinks) {
+          continue;
+        }
 
         const wikilinkEdits = isDirectory
           ? computeDirectoryWikilinkRenameEdits(
@@ -58,20 +83,6 @@ export default async function activate(
           );
         }
 
-        // For directory renames, remove stale workspace entries for files under
-        // the old directory path. On macOS (FSEvents), the file watcher fires
-        // directory-level events rather than per-file events, so Foam never
-        // receives individual delete events for those files. We clean up here,
-        // synchronously, inside the awaited onWillRenameFiles handler, before
-        // VS Code performs the actual rename.
-        if (isDirectory) {
-          const oldDirPath = foamOldUri.path;
-          foam.workspace
-            .list()
-            .filter(r => r.uri.path.startsWith(oldDirPath + '/'))
-            .forEach(resource => foam.workspace.delete(resource.uri));
-        }
-
         if (!isDirectory) {
           if (
             foam.graph
@@ -81,6 +92,10 @@ export default async function activate(
             hasMarkdownBacklinks = true;
           }
         }
+      }
+
+      if (!syncLinks) {
+        return;
       }
 
       try {
@@ -151,6 +166,30 @@ export default async function activate(
                   );
               }
             });
+        }
+      }
+    }),
+
+    /**
+     * Completes a directory rename: the entries collected before the move are
+     * removed from their old paths and re-indexed under the new ones.
+     *
+     * Foam cannot rely on file watcher events here. The watcher is scoped to
+     * note and attachment extensions, and a directory rename is reported at
+     * directory granularity on several platforms, so the per-file creates that
+     * would otherwise re-index these files may never arrive. Doing it here
+     * makes the rename self-contained and platform-independent (issue #1696).
+     */
+    vscode.workspace.onDidRenameFiles(async e => {
+      for (const { oldUri } of e.files) {
+        const pairs = pendingDirectoryRenames.get(oldUri.toString());
+        if (!pairs) {
+          continue;
+        }
+        pendingDirectoryRenames.delete(oldUri.toString());
+        for (const { oldResource, newUri } of pairs) {
+          foam.workspace.delete(oldResource.uri);
+          await foam.workspace.fetchAndSet(newUri);
         }
       }
     }),

--- a/packages/foam-vscode/src/vscode/services/editor.ts
+++ b/packages/foam-vscode/src/vscode/services/editor.ts
@@ -1,4 +1,3 @@
-import { isEmpty } from 'lodash';
 import {
   Disposable,
   EndOfLine,
@@ -21,9 +20,8 @@ import { fromVsCodeUri, toVsCodeUri } from '../utils/vsc-utils';
 import { asAbsoluteUri, FoamWorkspace, URI } from '@foam/core';
 import { getFoamVsCodeConfig } from '../config';
 import {
-  AlwaysIncludeMatcher,
-  FileListBasedMatcher,
   GenericDataStore,
+  GlobMatcher,
   IDataStore,
   IMatcher,
 } from '@foam/core';
@@ -492,14 +490,16 @@ export async function createMatcherAndDataStore(
     moveFile,
     fileExists
   );
-  const matcher =
-    isEmpty(excludes) && includes.length === 1 && includes[0] === '**/*'
-      ? new AlwaysIncludeMatcher()
-      : await FileListBasedMatcher.createFromListFn(
-          listFiles,
-          includes,
-          excludes
-        );
+  // Matching is answered from the globs directly, so a file can be tested
+  // before it has ever been listed — which is what lets a just-moved file be
+  // re-indexed without waiting for a workspace rescan. See issue #1696.
+  const matcher = new GlobMatcher(
+    workspace.workspaceFolders.map(folder => ({
+      uri: fromVsCodeUri(folder.uri),
+      include: includePatterns.get(folder.name),
+      exclude: excludePatterns.get(folder.name),
+    }))
+  );
 
   return { matcher, dataStore, includePatterns, excludePatterns };
 }


### PR DESCRIPTION
Fixes #1696: notes were dropped from the workspace index when their containing folder was moved or renamed in the Explorer, disappearing from the Notes Explorer, graph, backlinks, and wikilink resolution. Moving the same folder twice also silently stopped updating links.

## Root cause

Directory renames were delegated to file watcher events, which fire at directory granularity on macOS (FSEvents) and other platforms. The watcher is scoped to note and attachment extensions, so per-file create events for moved files never arrived, leaving the index stale.

## Changes

**New `GlobMatcher` in `@foam/core`:** Evaluates include/exclude globs directly rather than looking paths up in a snapshot of the workspace file listing. This eliminates staleness — a file can be tested before it has ever been listed, which is essential for re-indexing a just-moved file without waiting for a workspace rescan. Matching is case-insensitive and covers dot-directories, mirroring `workspace.findFiles` behavior.

**Directory rename handling in VS Code extension:** 
- Collects affected resources before the move (via new `listDirectoryRenamePairs` helper) while old paths are still indexed
- Completes the rename in `onDidRenameFiles` by removing old entries and re-indexing under new paths
- Index migration is now self-contained and platform-independent, no longer dependent on file watcher events or the `foam.links.sync.enable` setting

**Shared implementation:** The CLI's `GlobMatcher` now extends the core version, so both answer include/exclude the same way.

**Tests:** Added comprehensive test coverage for glob matching behavior and two new integration tests verifying that moved notes stay indexed and that moving the same folder twice still syncs wikilinks.

https://claude.ai/code/session_01Q9aWeNAxGtHwNuNbVmwgjx