### PR TITLE
Fix correctness bugs and lifecycle leaks from core model review

### DIFF
--- a/.changeset/gentle-owls-repair.md
+++ b/.changeset/gentle-owls-repair.md
@@ -1,0 +1,25 @@
+---
+'@foam/core': patch
+'foam-vscode': patch
+'@foam/cli': patch
+---
+
+Correctness and lifecycle fixes from the core model review:
+
+- Files whose names differ only by case no longer overwrite each other in the
+  workspace index (silent data loss on case-sensitive filesystems)
+- The incremental graph now re-resolves links that a newly added note wins by
+  identifier or directory-index priority, staying equivalent to a full rebuild
+- Rename edits can no longer corrupt files: duplicate definition edits are
+  deduplicated, partially overlapping edits are rejected, and a single
+  unparsable link skips that link instead of aborting the rename
+- Tag ranges are computed correctly for frontmatter tags that are substrings
+  of other tags and for hashtags on continuation lines of multi-line
+  paragraphs; quoted "tags" frontmatter keys are recognized
+- Published static-site graph JSON no longer includes raw note frontmatter,
+  only allowlisted presentation keys (color, type)
+- Uppercase attachment extensions (photo.PNG) are classified like their
+  lowercase counterparts; rapid successive changes to one file can no longer
+  leave stale content in the workspace; disposal no longer leaks FoamTags,
+  resource providers, or graph-webview registrations; one failing feature no
+  longer aborts the whole extension activation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,8 +100,8 @@ Things you won't infer quickly from reading:
 - **FoamWorkspace** uses a reversed trie for resource lookup, which is what makes short-form identifier resolution work.
 - **FoamGraph** creates placeholder resources for broken links — they're real graph nodes, not absences.
 - **ResourceProvider** is the extension point per file type (`MarkdownProvider`, `AttachmentProvider`).
-- **Features** are registered as `(context: ExtensionContext, foamPromise: Promise<Foam>) => void` in `src/features/index.ts`.
-- **The graph webview** is a Lit web component in `packages/foam-graph/`. `packages/foam-vscode/static/dataviz/` is gitignored build output, not source. `src/protocol.ts` owns the extension↔webview message contract. The extension's `tsconfig.json` `paths` resolve `@foam/graph-view/*` to TS source for typechecking; esbuild resolves via package exports at bundle time.
+- **Features** are registered as `(context: ExtensionContext, foamPromise: Promise<Foam>) => void` in `packages/foam-vscode/src/vscode/features/index.ts`.
+- **The graph webview** is a Lit web component in `packages/foam-graph/`. `packages/foam-vscode/static/dataviz/` is gitignored build output, not source. `src/protocol.ts` owns the extension↔webview message contract. The extension resolves `@foam/graph-view/*` via the package `exports` map for typechecking; esbuild resolves the same way at bundle time.
 - **`foam-extension-test-host.ts`** does not activate AI features — the mock Foam has no embeddings.
 
 ## User documentation (`docs/user/`)

--- a/docs/dev/design/core-model-and-api-review.md
+++ b/docs/dev/design/core-model-and-api-review.md
@@ -332,7 +332,7 @@ It imports `fs/promises` directly (`export-html-page/index.ts:2,85,91`) and is r
 
 ### 6.3 Path-string discipline cleanup
 
-Per the repo's own URI convention: `grouped-resources-tree-data-provider.ts:1,85-89` runs Node `path.parse` on a URI component; `export/types.ts:72` accepts `contentRoot?: string | URI` (the one both-typed field in core's config surface — a `vscode-vfs://` workspace will mis-resolve); `foam-cli/src/support/filesystem.ts:28-34` reimplements core's `isWithinPath` under the same name with a different signature. Also export `getBasename`/`getExtension`/`getDirectory` from core's barrel — CLAUDE.md tells contributors to use them, but they aren't currently exported (`index.ts:151-158`), which is part of why reimplementations happen.
+Per the repo's own URI convention: `grouped-resources-tree-data-provider.ts:1,85-89` runs Node `path.parse` on a URI component; `export/types.ts:72` accepts `contentRoot?: string | URI` (the one both-typed field in core's config surface — a `vscode-vfs://` workspace will resolve incorrectly); `foam-cli/src/support/filesystem.ts:28-34` reimplements core's `isWithinPath` under the same name with a different signature. Also export `getBasename`/`getExtension`/`getDirectory` from core's barrel — CLAUDE.md tells contributors to use them, but they aren't currently exported (`index.ts:151-158`), which is part of why reimplementations happen.
 
 **Effort:** S · **Breaking:** `contentRoot: URI` only (2 in-repo call sites) · **Impact:** Low-Medium each; collectively keeps the convention honest.
 

--- a/docs/dev/design/core-model-and-api-review.md
+++ b/docs/dev/design/core-model-and-api-review.md
@@ -1,0 +1,367 @@
+# Core Model & API Review — Improvement Spec
+
+- **Date:** 2026-08-09
+- **Scope:** `@foam/core` information model and services, package/API architecture, and the seams to `foam-vscode`, `@foam/cli`, and `@foam/mcp`. Performance items are included where they fall out of the model review.
+- **Method:** full read of `packages/foam-core/src/model/*` and `src/services/*`, the export subsystem, the consumer packages' integration points, the perf instrumentation (`load-profiler`, benches, `scripts/perf/gate.mjs`), and the open issue tracker. Every finding cites `file:line` against commit `8b03256`.
+- **Legend:** each proposal carries **Effort** (S ≈ hours, M ≈ 1–3 days, L ≈ 1–2 weeks+), **Breaking** (against the `@foam/core` public surface in `packages/foam-core/src/index.ts`, or user-visible behavior), and **Impact** with rationale.
+
+---
+
+## Executive summary
+
+The core model is in good shape structurally — the reversed-trie workspace index, the incremental graph, the `PublishTarget` export abstraction, and the perf-gate CI are all well-designed. The review found no architectural rot, but it did find:
+
+1. **A handful of genuine correctness bugs**, including one silent data-loss case in the workspace index (case-colliding filenames), a divergence between the incremental graph and a full rebuild, and rename/edit paths that can corrupt files (no overlap detection, duplicated definition edits).
+2. **A semantic gap advertised but not implemented:** aliases are offered by link completion but never participate in link resolution, so the extension can suggest a link it will then render as broken.
+3. **Lifecycle leaks** (tags never disposed, providers never disposed, one failing feature aborts the whole extension activation and strands live resources).
+4. **Avoidable hot-path costs** that map directly onto the two open perf issues (#1375, #1689): a wasted nested tree-walk in the block parser, an O(n·m) file matcher, a full SHA-1 + deserialize on every parser-cache *hit*, and a full-workspace clone per rename.
+5. **API-surface debt:** a 297-symbol barrel of which ~34% has no in-repo consumer, host concerns embedded in the platform-agnostic core (telemetry endpoint, VS Code-only config getters), and duplicated serializers that make the CLI and MCP emit different wire formats for the same data.
+6. **Doc drift:** `CLAUDE.md` describes the pre-`foam-core` repo layout and actively misdirects contributors (and agents).
+
+The roadmap at the end sequences these into four phases. Phase 1 (correctness + leaks) is entirely non-breaking and roughly two weeks of work; the breaking items are concentrated in Phase 4 and can ride a single minor/major release.
+
+---
+
+## 1. Correctness fixes
+
+### 1.1 Case-colliding filenames silently overwrite each other in the workspace index
+
+`FoamWorkspace` keys its trie by a reversed, **lowercased** path (`workspace.ts:350-365`, `normalize` at `:528`). `/a/Note.md` and `/a/note.md` produce the identical key, so the second file **replaces** the first in `_resources`, and `set()` emits `onDidUpdate` instead of `onDidAdd` (`workspace.ts:127-137`) — which then desynchronizes the graph (it disconnects the old path while connecting the new one, leaving stale backlinks). The existing #1303 regression test (`workspace.test.ts:187-209`) uses files in *different* directories, so this collision is untested. The model currently has two incompatible notions of identity: `find(URI)` is case-insensitive while `URI.isEqual` (`uri.ts:236-244`) is case-sensitive.
+
+**Proposal:** store exact-case keys in the trie with a case-insensitive lookup layer (bucket resources under the lowercased key), define identity policy in one place, and add the missing same-directory regression test.
+
+**Effort:** M · **Breaking:** No (fixes a currently-broken case) · **Impact:** High — silent data loss in the model; affects any vault with case-variant filenames (common on case-sensitive filesystems / git checkouts).
+
+### 1.2 Incremental graph diverges from a rebuild when an added file changes a non-placeholder resolution
+
+`onResourceAdded` (`graph.ts:140-144`) only re-resolves sources currently pointing at a *placeholder*. But adding a file can also change resolution of a link that already resolves to a real note, because ambiguity is broken by path sort (`workspace.ts:290`) and directory-index suffix match (`workspace.ts:229-239`). Example: `[[attachment-a.pdf]]` resolves to `/path/to/more/attachment-a.pdf`; adding `/path/to/attachment-a.pdf` should re-point it — the full-rebuild path asserts exactly this (`graph.test.ts:183-221`), the incremental path misses it. The comment at `graph.ts:136-138` acknowledges the missing inverse-resolution capability. `graph-incremental.test.ts` has no "add steals an already-resolved target" case, and the `[flat]` perf gate (`workspace-graph.bench.ts:132-142`) only covers the update path.
+
+**Proposal:** on add, additionally reconnect sources whose links resolve *by identifier* to the new resource's basename (the workspace can expose "which identifiers does this URI answer to"); add the missing incremental test and extend the scaling bench to add/delete paths.
+
+**Effort:** M · **Breaking:** No · **Impact:** High — the graph (backlinks panel, orphans, graph view) is quietly wrong after a common operation until the next full reload.
+
+### 1.3 Rename/edit pipeline can corrupt files
+
+Three compounding defects:
+
+- `TextEdit.apply` (`text-edit.ts:18-50`) has **no overlap detection** — overlapping ranges silently corrupt the document.
+- The parser resolves every reference link to the **same `NoteLinkDefinition` object** (`markdown-parser.ts:204-206`), so a file with `[a][ref]` and `[b][ref]` makes `heading-edit` emit **two edits with the identical range** (`heading-edit.ts:85-118`, `:215-247`) — no dedup anywhere, including `commands/rename.ts:47-67`. Combined with the missing overlap check, the definition line is rewritten twice.
+- `createUpdateLinkEdit` throws on external links (`markdown-link.ts:100-102`) and `heading-edit.ts:126` calls it outside its try/catch, so one odd link aborts an entire rename.
+
+**Proposal:** dedupe edits by range before applying; make `TextEdit.apply` throw on overlaps; guard the `analyzeLink`/`createUpdateLinkEdit` call sites consistently. Add the `[a][ref] + [b][ref]` test.
+
+**Effort:** S · **Breaking:** No · **Impact:** High — these are the operations users trust most (rename heading/block across the vault); failure mode is silent file corruption.
+
+### 1.4 CLI/MCP rename leaves markdown-style links dangling
+
+`link-integrity.ts:71` only rewrites `wikilink` connections; markdown `[text](note.md)` links are documented as "delegated to VS Code built-in" (`link-integrity.test.ts:134`). That fallback exists only in the editor — `commands/rename.ts:112` and `commands/note.ts:306` are the CLI/MCP path, where markdown links silently break on rename.
+
+**Proposal:** handle `link.type === 'link'` in `link-integrity`, optionally behind a `linkTypes` option so the VS Code host can keep delegating.
+
+**Effort:** M · **Breaking:** Behavior change for CLI/MCP renames (strictly a fix) · **Impact:** High for CLI/MCP users — renames are currently unsafe outside the editor.
+
+### 1.5 Tag range extraction has wrong-position bugs
+
+- Frontmatter tag ranges use substring search (`markdown-parser.ts:384-386`): tag `foo` matches inside `foobar` on an earlier line, producing a wrong range — and `TagEdit` writes edits at exactly those ranges.
+- Hashtag ranges assume a single-line text node (`markdown-parser.ts:399-408`): a `#tag` on the second line of a multi-line paragraph gets a range on the wrong line/column. All existing tests use single-line paragraphs.
+- `tag-edit.ts:79-85` distinguishes hashtag vs frontmatter tags by comparing the **range length**, coupled invisibly to how the parser computes ranges two files away.
+
+**Proposal:** fix both range computations (word-boundary anchoring; newline-aware offset mapping) with targeted tests, and add a `source: 'inline' | 'frontmatter'` discriminator to `Tag` (`note.ts:75-78`) so `tag-edit` drops the heuristic (requires a `CACHE_VERSION` bump in `foam-vscode/src/vscode/services/cache.ts:37`).
+
+**Effort:** M · **Breaking:** `Tag` field addition is additive; cached-resource schema bump only · **Impact:** Medium-High — tag rename writes edits at wrong positions in these cases; also unblocks #1240-adjacent tag work.
+
+### 1.6 Assorted small correctness fixes (batch)
+
+| Fix | Where |
+|---|---|
+| `useAngles` off-by-one: target *starting* with a space isn't angle-wrapped | `markdown-link.ts:124`, `note.ts:55` (`indexOf(' ') > 0` → `includes(' ')`) |
+| Missing null check: `workspace.find(source)` result dereferenced | `markdown-provider.ts:205` |
+| `.sort()` without comparator on objects — sorts nothing | `markdown-provider.ts:280` |
+| `/m` vs `/gm` inconsistency stripping block-anchor markers | `markdown-provider.ts:55` vs `:68` |
+| `String.replace` with string containing user text interprets `$` patterns | `tag-edit.ts:238` |
+| Attachment extension case inconsistency: `photo.PNG` accepted but misclassified | `attachment-provider.ts:39,65-67,71` |
+| Watcher change handler race: two rapid changes to one file, last *read* wins not last *event* | `foam.ts:69-73` — serialize per-URI |
+| Frontmatter `tags` line lookup can be `undefined` → tags silently vanish | `markdown-parser.ts:376-378` |
+
+**Effort:** S (one batch PR) · **Breaking:** No · **Impact:** Medium — each is small, but all are user-visible in edge cases and cheap to fix together.
+
+---
+
+## 2. Lifecycle & resource management
+
+### 2.1 `foam.dispose()` leaks `FoamTags`; workspace never disposes providers
+
+`bootstrap`'s disposer (`foam.ts:110-114`) disposes subscriptions, workspace, and graph — never `tags`, whose three workspace listeners (`tags.ts:41-45`) and emitter leak. `FoamTags.dispose()` itself also skips its emitter (unlike `FoamGraph.dispose()`, `graph.ts:263-265`). Separately, `FoamWorkspace.dispose` (`workspace.ts:460-464`) never disposes registered providers even though `ResourceProvider extends IDisposable` (`provider.ts:6`).
+
+**Proposal:** fix both; better, give `Foam` a `DisposableStore` so new members can't be forgotten.
+
+**Effort:** S · **Breaking:** No · **Impact:** Medium — leaks on every reload/deactivate cycle; matters for long-lived hosts and the embeddable MCP library.
+
+### 2.2 One failing feature aborts extension activation and strands live resources
+
+`extension.ts:174` joins all features with `Promise.all`; a single rejection means `context.subscriptions.push(foam, watcher, parserCache, …)` at `:185` never runs — `Foam`, the watcher, and the parser cache stay alive and undisposed, and `extendMarkdownIt` is silently lost (preview loses all Foam rendering). Features are anonymous functions (`features/index.ts:15-28`), so the error can't even name the culprit.
+
+**Proposal:** switch to `Promise.allSettled` with per-feature error logging; push core resources into `context.subscriptions` immediately after bootstrap; give features an `id` (and optional `supports: 'node' | 'web'`) — `interface FoamFeature { id; supports?; activate(ctx, foam) }`. The `id` also fixes the acknowledged telemetry-key collision risk (`types.d.ts:11-12`) and gives the web build a declarative way to skip Node-only features (see §6.2).
+
+**Effort:** M · **Breaking:** No (internal to the extension) · **Impact:** High — converts "any feature bug bricks Foam" into "one feature degrades".
+
+### 2.3 Leaked registrations in graph-webview
+
+`graph-webview/index.ts:21` (`onDidChangeConfiguration`) and `:62` (`registerCommand('foam-vscode.show-graph', …)`) discard their disposables; every other feature pushes them into `context.subscriptions`.
+
+**Effort:** S · **Breaking:** No · **Impact:** Low — orphaned registrations on deactivate/reactivate.
+
+### 2.4 Honor `FoamTags`' `debounceFor` parameter
+
+`tags.ts:33` accepts `debounceFor` but `:40` hardcodes `debounce(..., 500)` — the value is used only as an on/off flag, and `bootstrap` never passes it, so tags are undebounced in production.
+
+**Effort:** S · **Breaking:** No · **Impact:** Low alone; pairs with §3.4.
+
+---
+
+## 3. Performance
+
+These target the two open perf axes tracked by the bench suite (`workspace-graph.bench.ts:14-30`, #1375) and the slow-load report (#1689, `load-profiler.ts:13-14`). The perf-gate CI (`scripts/perf/gate.mjs`: fail at 2.0×, warn at 1.3×; `[linear]`≤1.8, `[flat]`≤1.0 normalized) will verify each claim.
+
+### 3.1 Block parser does a wasted nested tree-walk per node
+
+`blocksPlugin.visit` (`markdown-parser.ts:509-518`) calls `getDirectText(node)` — itself a **full subtree visit** (`:332-340`) — for every paragraph/listItem/blockquote/heading, then discards the text whenever there's no `^` block anchor, which is nearly always. This is a constant-factor ~2× traversal on flat documents and O(n·depth) on nested ones — the single largest avoidable cost in the parse path, which the profiler already identifies as the load bottleneck (`load-profiler.ts:218-219`, parse is super-linear in note size). Also: `note.blocks.some(...)` in the same loop is O(blocks²) (`:537`), and each own-line blockquote anchor re-splits the whole source (`:570`).
+
+**Proposal:** gate `getDirectText` on a cheap "does this node's source range contain `^`" check; replace the `some` with a `Set`; split the source into lines once per parse and share with the footnote scan (`:237`).
+
+**Effort:** S · **Breaking:** No · **Impact:** High — directly attacks #1689/#1375; expected double-digit-% parse-time reduction on typical vaults, verifiable in `markdown-parser.bench.ts`.
+
+### 3.2 Parser cache hits still pay SHA-1 + full deserialize
+
+`cachedParser` (`markdown-parser.ts:275-301`) hashes the entire document (SHA-1, `utils/core.ts:49`) on every call, and a hit still runs `Resource.fromJSON` (`foam-vscode/src/vscode/services/cache.ts:201-210`). During typing this is the hot path, and the profiler reports it as a cheap "hit".
+
+**Proposal:** let the host pass a cheaper validity token (document version/mtime) so unchanged documents skip hashing entirely; collapse `cache.has` + `cache.get` into one call; consider memoizing the last deserialized resource per URI.
+
+**Effort:** M · **Breaking:** No (additive cache API) · **Impact:** Medium-High — removes per-keystroke work proportional to note size.
+
+### 3.3 O(n·m) file matcher on the VS Code hot path
+
+`FileListBasedMatcher.match()` filters with `Array.includes` over a `string[]` (`datastore.ts:168-170`); `isMatch` is O(n) per call. This is the matcher VS Code selects in the common case (`editor.ts:495-502`) — on a 10k-file vault a single `match(allFiles)` is ~10⁸ comparisons. The class carries its own "to be refactored later" note (`:150`).
+
+**Proposal:** back it with a `Set<string>`. While in there: its `include`/`exclude` fields are decorative (never consulted) — either wire or remove them. This is also the natural place to add **`.gitignore` support (#1388)**, the most-requested open datastore issue.
+
+**Effort:** S (Set) + M (gitignore) · **Breaking:** No · **Impact:** Medium-High — removes a quadratic on load and on every matcher refresh; #1388 has standing user demand.
+
+### 3.4 `FoamTags` rebuilds the entire tag index on every file event
+
+`tags.update()` (`tags.ts:51-61`) is a full O(total tags) rebuild wired to all three workspace events (`:42-46`), unlike the graph which is incremental. Every panel listening to `tags.onDidUpdate` then refreshes wholesale.
+
+**Proposal:** incremental update using the `{old, new}` payload the workspace already provides (index tag locations by resource as well as label).
+
+**Effort:** M · **Breaking:** No · **Impact:** Medium — flattens per-edit cost in tag-heavy vaults; pairs with §2.4 and §4.6.
+
+### 3.5 `link-integrity` clones the whole workspace per rename
+
+`buildFutureWorkspace` (`link-integrity.ts:13-26`) copies every resource into a fresh `FoamWorkspace` to answer one identifier question — a full second index per rename on large vaults.
+
+**Proposal:** an overlay resolver over the live workspace (consult the overlay first, fall through).
+
+**Effort:** M · **Breaking:** No · **Impact:** Medium — rename latency on large vaults.
+
+### 3.6 Other measured/mechanical wins (batch)
+
+- `_unregisterDirectoryIndex` is O(workspace) on every delete of an index file (`workspace.ts:185-212`) → keep per-directory candidate lists.
+- `TextEdit.apply` builds a per-character array per edit (`text-edit.ts:22-50`) → offset-based slice concatenation.
+- Per-node plugin dispatch re-enters a try/catch and probes 6 optional methods per AST node (`markdown-parser.ts:183-189`) → precompute the visitor list per parser.
+- `getTagAtPosition` scans all tags × locations per call (`tag-edit.ts:265-283`) → per-URI index.
+- CLI gets neither parser cache nor profiler (`foam-cli/src/support/filesystem.ts:172`) → wire both; big cold-start win for CLI/MCP and export.
+- Profiler hygiene: no `reset()` (double-counts on second load), chars misreported as MiB (`load-profiler.ts:63-67`, `:147`, `:237`).
+
+**Effort:** S-M per item · **Breaking:** No · **Impact:** Medium in aggregate.
+
+### 3.7 (Strategic) Replace remark-parse v8 / unified v9 with micromark
+
+The pinned parser stack is several majors behind. It is the root cause of: the regex-based footnote scan (`markdown-parser.ts:231-268`), the collapsed consecutive-footnote ASTs, likely the documented super-linear parse scaling, and the wikilink-in-math false positives (#1317). The bench file already ships an A/B harness for exactly this migration (`markdown-parser.bench.ts:97-101`).
+
+**Proposal:** migrate to `micromark`/`mdast-util-from-markdown` behind the existing `ParserPlugin` seam; prove parity with the golden-file tests and the A/B bench before switching.
+
+**Effort:** L · **Breaking:** Potentially (AST-shape-dependent plugins; parse edge cases change) · **Impact:** High long-term — removes a whole class of workarounds and the main super-linear cost; should be scheduled, not rushed.
+
+---
+
+## 4. Information model evolution
+
+### 4.1 Make aliases participate in link resolution
+
+Aliases are parsed (`markdown-parser.ts:700-712`), stored on `Resource`, offered by **link completion** (`link-completion.ts:269`) and search — but `listByIdentifier` (`workspace.ts:266-291`) only ever consults paths. `[[my-alias]]` yields a placeholder even when a note declares `alias: my-alias`: the system suggests links it then fails to resolve. This is the single biggest semantic gap in the model.
+
+**Proposal:** index aliases alongside basenames with documented precedence (exact path > basename > alias), behind a config flag initially (matching the `directoryMode` precedent, `markdown-provider.ts:24`).
+
+**Effort:** M · **Breaking:** Behaviorally (previously-broken links start resolving — flag-gated) · **Impact:** High — closes a visible feature contradiction; frequently expected by users coming from Obsidian.
+
+### 4.2 Normalize placeholder identity in the model
+
+`URI.placeholder(path)` does no normalization (`uri.ts:99-101`): `[[page-b]]` and `[../page-b.md]` denoting the same missing file become **two distinct graph nodes** (pinned in `graph.test.ts:225-260`), so the placeholders panel shows duplicates. Placeholder construction is scattered across four sites in `markdown-provider.ts` (`:120,132,152,167`), and "placeholder-ness" is modeled three different ways (URI scheme `uri.ts:201-203`; a phantom `Resource.type === 'placeholder'` that the workspace never stores; a template-trigger type).
+
+**Proposal:** a single model-owned placeholder factory that canonicalizes identity (workspace-resolved path where resolvable, raw text kept as label); remove the phantom resource type or promote it to a real variant.
+
+**Effort:** M · **Breaking:** Yes — placeholder paths are visible in `graph.placeholders`, the panel, and tests · **Impact:** Medium-High — correct placeholder dedup, simpler consumers, prerequisite for sane "create note from placeholder" flows.
+
+### 4.3 Split `FoamWorkspace.find` and fix its inconsistencies
+
+`find(URI | string)` (`workspace.ts:367-415`) is three functions behind one signature (trie get / identifier resolution / path probing across roots), and it returns the **stored object** normally but a **fresh shallow copy** when the reference carries a `#fragment` (`:408-413`) — reference equality depends on argument syntax. Ambiguity resolution ("alphabetically first path wins") is encoded in a sort call (`:290`).
+
+**Proposal:** explicit `findByUri` / `findByIdentifier` / `findByPath`; fragment handling returns `{resource, section}` instead of a patched copy; document the ambiguity policy. Keep `find` as a deprecated shim for one release.
+
+**Effort:** M · **Breaking:** Yes (widely used in foam-vscode; mechanical migration) · **Impact:** Medium — the API's biggest ambiguity source; enables §1.2's identifier inversion cleanly.
+
+### 4.4 Key the graph by full URI identity, not `uri.path`
+
+`links`/`backlinks`/`placeholders` are `Map<uri.path, …>` (`graph.ts:21-29, 247-258`): in a virtual workspace `file:///notes/a.md` and `vscode-vfs://github/notes/a.md` collide (multi-scheme resolution is explicitly supported — `workspace.test.ts:303-326`); fragments are silently ignored, so callers must remember `.asPlain()` (done in five places in `commands/links.ts`). The same path-keyed pattern recurs in the export context (`export/types.ts:179,184`) and embeddings (`ai/model/embeddings.ts:39`).
+
+**Proposal:** introduce a small `URIMap<T>` (canonical `scheme://authority/path` keying, explicit fragment policy) in `model/uri.ts` and use it in graph, export, embeddings. Make `getLinks`/`getBacklinks` normalize their argument.
+
+**Effort:** M · **Breaking:** Yes for direct readers of `graph.links`/`graph.backlinks` (public mutable maps — see §4.5) · **Impact:** Medium — correctness on virtual/multi-root workspaces (web extension, remote repos), removes a caller ritual.
+
+### 4.5 Encapsulate the graph/tags collections
+
+`graph.placeholders/links/backlinks` and `tags.tags` are `public readonly` Maps — the reference is readonly, the contents are not; any consumer can `foam.graph.links.clear()`. Stored `Resource`s are also held by reference with no copy (`workspace.ts:131`), so in-place mutation corrupts the index and defeats the `{old, new}` update diff.
+
+**Proposal:** accessor methods returning `ReadonlyMap`/iterators; document (or enforce via `Object.freeze` in dev builds) that `Resource` is immutable once stored.
+
+**Effort:** S-M · **Breaking:** Yes, mechanical · **Impact:** Medium — removes a foot-gun class; prerequisite for safely evolving internals (§4.4).
+
+### 4.6 Batchable events with payloads
+
+`workspace.clear()` fires one delete per resource (`workspace.ts:149-158`) → N graph mutations + N full tag rebuilds + N panel refreshes; there is no batch/transaction primitive even though `PauseableEmitter`/`EventBufferer` already exist (`common/event.ts:749, 878`). `graph.onDidUpdate` and `tags.onDidUpdate` are `Event<void>`, so all ~7 VS Code listeners can only blanket-refresh. Delivery is synchronous and re-entrant (`common/event.ts:706-733`).
+
+**Proposal:** additive first — `onDidChangeBatch: Event<Change[]>` on the workspace, used by `clear()` and bulk load; a debounced aggregate `Foam.onDidChangeWorkspace` (the preview feature currently hand-rolls this from three subscriptions, `preview/index.ts:20-30`). Later, upgrade `onDidUpdate` to carry a delta (breaking for listeners).
+
+**Effort:** M (additive) + S (listener migration) · **Breaking:** Additive now; delta payload later is breaking · **Impact:** Medium-High — turns O(N) panel refresh storms into O(1); foundation for scaling to large vaults.
+
+### 4.7 Type-model tightening
+
+- `Resource.type: string` → union `'note' | 'attachment' | 'image'` (`note.ts:146`); `properties: any` → `Record<string, unknown>` (`:147`). **Breaking**, mostly mechanical.
+- `ResourceLink.definition?: string | NoteLinkDefinition` encodes a three-state machine decoded by four predicates with order-sensitive call sites (`note.ts:5-44`; `markdown-provider.ts:94-138`) → discriminated union `{kind: 'inline'} | {kind: 'ref-unresolved'; label} | {kind: 'ref-resolved'; definition}`. **Breaking** (parser + tests construct it).
+- `Connection` (`graph.ts:8-12`) carries no resolution provenance → add `resolvedBy: 'path' | 'identifier' | 'directory-index' | 'placeholder'`; every consumer currently re-derives this. **Additive.** Also directly serves typed-links exploration (#1626).
+- URI derivations (`getDirectory`, `joinPath`, …) preserve `fragment`/`query` (`uri.ts:125-152`), yielding directories with section anchors; `asPlain()` exists solely to undo it → drop fragment/query on parent/derivation ops. **Non-breaking in practice** (all call sites strip or have none).
+- `asAbsoluteUri` (`uri.ts:465-493`) disagrees with `FoamWorkspace.resolveUri` on the primary case (`uri.test.ts:131-140` vs `workspace.test.ts:277-281`) and is publicly exported → redefine in terms of `resolveUri` or remove. **Breaking.**
+- Dead indirection: `pathToPlaceholderId` is the identity function (`graph.ts:14`); `wikilinkPlugin.onDidVisitTree` is an empty function (`markdown-parser.ts:798-801`); duplicate `CancellationToken` in `progress.ts:21-24`. Delete. **Non-breaking.**
+
+**Effort:** S-M per item · **Impact:** Medium — compile-time safety over runtime predicates; cheapest during the same release that takes §4.3/§4.4.
+
+### 4.8 Parser instance isolation
+
+`sectionStack` is module-level mutable state shared by every parser instance (`markdown-parser.ts:416`), and `onDidInitializeParser` mutates the module-level `unified` processor (`:63, :105`) so `extraPlugins` from one `createMarkdownParser` call leak into all others. Safe today only because parsing is synchronous and single-instance.
+
+**Proposal:** per-instance processor; per-parse context object threaded through `ParserPlugin` (breaking for the plugin interface, which has few implementors).
+
+**Effort:** M · **Breaking:** Yes (plugin interface) · **Impact:** Medium — prerequisite for embedded-note parsing, parallel parse, and the §3.7 migration.
+
+---
+
+## 5. API & package architecture
+
+### 5.1 Tier and split the public API surface
+
+`@foam/core` exposes a single 315-line barrel re-exporting **297 symbols**; cross-referencing all three in-repo consumers, **~102 are never imported by anyone**. Output is CJS-only, so importing `URI` drags in jexl, the export pipeline, and lint rules — the web bundle and MCP pay for subsystems they never call.
+
+**Proposal:** add subpath exports (`@foam/core/model`, `/export`, `/query`, `/lint`) and ESM output alongside CJS; split the barrel into a documented contract tier and an internal tier; add an API-report CI check (api-extractor or attw). Root barrel should delegate to per-subsystem `index.ts` curators — today `src/index.ts:194-239` hand-duplicates `export/index.ts`'s list and the two have already diverged.
+
+**Effort:** M-L · **Breaking:** Additive now; demoting unused symbols is breaking for hypothetical external users only · **Impact:** High — bundle size for web/MCP, and it establishes the semver contract *before* external consumers depend on accidental surface.
+
+### 5.2 Move host concerns out of core
+
+- The App Insights connection string and envelope builder live in the platform-agnostic core (`telemetry.ts:158-159`, exported at `index.ts:180-184`). The string is deliberately a non-secret ingestion key, but a product's telemetry destination is deployment config, not library code — any fork/embedder silently inherits Foam's endpoint.
+- `IFoamConfig` (`config.ts:1-46`) carries ≥8 editor-UI getters (`getGraphOnStartup`, `getPreviewEmbedNoteType`, `getCompletionLabel`, …) that a headless CLI is forced to stub (`foam-cli/src/support/config.ts:60-65`).
+- `Config` is a mutable process-global singleton (`config.ts:149-166`) with exactly one core reader (`template-discovery.ts:15`) — a real hazard for `@foam/mcp`, which is meant to be embeddable (two workspaces in one process can't differ).
+
+**Proposal:** core keeps `ITelemetryReporter` + bucketing only; endpoint + consent copy move to hosts. Split `CoreConfig` (files, templates, daily notes) from host config. Thread config explicitly (`getTemplatesDir(rootUri, config)`), retire the global.
+
+**Effort:** M · **Breaking:** Yes — small, in-repo call-site count (≤5) · **Impact:** Medium-High — makes core genuinely embeddable and forkable; unblocks publishing `@foam/mcp`.
+
+### 5.3 Retire the `foam-vscode` shim layer; repatriate stranded platform-agnostic code
+
+Four directories in `foam-vscode/src` have zero `vscode` imports: `src/core/` (a second `bootstrap` whose 8th positional parameter *diverges* from core's — `foam-vscode/src/core/model/foam.ts:23-32` vs `foam.ts:32-42`, an accident waiting to happen), `src/ai/model` + `src/ai/services` (382-line `FoamEmbeddings`, pure core), `src/lint/`, and `src/daily-note/`. The shim type also makes the feature registry contravariantly unsound — it only compiles because `strict: false`.
+
+The lint case is user-visible: the four wikilink rules (`rule-check-links.ts:22`) are only reachable by the editor, so **`foam lint` in CI cannot catch broken wikilinks** while the editor can (`foam-cli/src/commands/lint.ts:14-18`). Relatedly, `lintNote` hardcodes its rule list while `lintWorkspace` takes `rules[]` (`lint.ts:47-49, 86`) — two extensibility models in one file.
+
+**Proposal:** move embeddings/lint/daily-note logic into core (embeddings as an optional `Foam` member; Ollama provider stays host-side); make core's `bootstrap` take an options object (it has **nine positional parameters**); delete the shim. Align `lintNote`/`lintWorkspace` on injected rules + `defaultLintRules()`.
+
+**Effort:** M-L · **Breaking:** `bootstrap` and `lintNote` signatures (3 and 2 call sites); rest is internal moves · **Impact:** High — one `bootstrap`, CLI lint parity (CI catches broken wikilinks), and unlocks `strict: true` for the extension.
+
+### 5.4 Unify the CLI/MCP wire format
+
+`foam-cli/src/support/serializers.ts` (148 lines) and `foam-mcp/src/serializers.ts` (203 lines) independently serialize the same nine core result types — and disagree: CLI emits absolute fs paths (`serializers.ts:45`), MCP emits workspace-relative POSIX paths with `placeholder:<id>` handling (`serializers.ts:52-55`). Same note, two encodings; CLI has no placeholder story at all.
+
+**Proposal:** one `@foam/core/serialize` module owning the `Json*` types and URI encoding (option: `'fs' | 'workspace-relative'`); both hosts consume it. Prefer unifying on workspace-relative.
+
+**Effort:** M · **Breaking:** CLI JSON output changes if unified (recommended; flag the old encoding) · **Impact:** Medium — consistency for scripts/agents consuming both surfaces; halves maintenance.
+
+### 5.5 Honor the `IDataStore` contract; make capabilities explicit
+
+The interface requires `list(pattern)` to filter (`datastore.ts:12-17`) but the VS Code implementation ignores the pattern entirely (`editor.ts:408` takes no parameter) — currently masked only because saved queries build their own store (`saved-store.ts:102-138`); any future `dataStore.list(glob)` call in the extension is a silent data bug. `GenericDataStore` also throws at runtime for the 4-of-6 optional operations while claiming the full interface (`datastore.ts:117-143`), and `read` conflates missing vs unreadable (both `null`, `:106-115`). None of the shipping implementations have direct tests.
+
+**Proposal:** fix the VS Code `listFiles` to honor the glob; split `IReadableDataStore`/`IWritableDataStore` (or a capabilities probe); distinguish not-found from error; add the missing tests.
+
+**Effort:** M · **Breaking:** Interface split is breaking (4 implementations, all in-repo) · **Impact:** Medium — closes a documented contract violation before it becomes a bug.
+
+### 5.6 Packaging hygiene (batch)
+
+- `@foam/core/test` relative-imports `../src/*`, forcing a dual-instance-of-`URI` alias hack in **three** vitest configs (`foam-vscode/vitest.config.mts:41-48` documents it), while `instanceof URI` is used in production (`convert-links-format.ts:26`); `test-utils` also imports `micromatch`, which is not a declared dependency, and there's no `files` allowlist so npm ships `src/`, `test-data/`, etc. → import via the package entry, fix deps, add `files`.
+- `foam-vscode` duplicates 15 of core's dependencies as phantom runtime `dependencies` (nothing installs them; esbuild bundles) — version skew between the two `package.json`s would silently ship a different parser than tests run → move to `devDependencies`, single source of truth in core.
+- `@foam/mcp` declares `"@foam/core": "*"` as a runtime dep, but core publishes under the name `foam-core` (`release.js:29-31`) — the moment `@foam/mcp` is published it cannot resolve → bundle like cli/vscode, or publish under the real name.
+- Dead `cli` build target in `foam-vscode/esbuild.js:31,136-146,177-188` (the `src/cli/` it builds no longer exists) → delete.
+- Three field-identical graph-data types (`graph-data-builder.ts:5-16`, `export/types.ts:126-144`, `foam-graph/src/protocol.ts:16-25`), with `build-site-graph.ts:12` compiling only by structural coincidence → alias the two in-core copies; keep the protocol copy as a deliberate wire contract with a compile-time compatibility assertion.
+- `graph-data-builder.ts:75` ships the **entire raw frontmatter** into graph payloads consumed by the webview *and the published static site* — private frontmatter fields leak into published graph JSON → allowlist exported keys.
+
+**Effort:** S-M per item · **Breaking:** No (except the frontmatter allowlist, a behavior fix) · **Impact:** Medium — the frontmatter leak in particular is a privacy fix for publishing.
+
+---
+
+## 6. Platform integrity (web / CLI parity)
+
+### 6.1 Mechanically enforce "no Node imports in foam-core"
+
+The invariant holds today by review only: core's `tsconfig` includes `"types": ["node"]`, so `process`/`Buffer` type-check fine. One lint rule (`no-restricted-imports` on `fs|path|os|node:*` in `packages/foam-core/src`) makes the repo's most important invariant enforceable.
+
+**Effort:** S · **Breaking:** No · **Impact:** High leverage for the cost — prevents an entire regression class.
+
+### 6.2 `export-html-page` ships broken in the web extension
+
+It imports `fs/promises` directly (`export-html-page/index.ts:2,85,91`) and is registered unconditionally; the web build's `polyfillNode()` makes it *bundle* but not work. Two other fs-users get bespoke esbuild `onResolve` swaps (`esbuild.js:72-101`) — a substring-matching mechanism invisible from the source tree.
+
+**Proposal:** route file I/O through `foam.services.dataStore` (already works in both hosts); replace the regex swap mechanism with explicit `.web.ts` twins or `browser` field mapping; use §2.2's `supports` field to gate genuinely Node-only features.
+
+**Effort:** S (gate) + M (dataStore refactor) · **Breaking:** No · **Impact:** Medium — a visibly broken command in the web host today.
+
+### 6.3 Path-string discipline cleanup
+
+Per the repo's own URI convention: `grouped-resources-tree-data-provider.ts:1,85-89` runs Node `path.parse` on a URI component; `export/types.ts:72` accepts `contentRoot?: string | URI` (the one both-typed field in core's config surface — a `vscode-vfs://` workspace will mis-resolve); `foam-cli/src/support/filesystem.ts:28-34` reimplements core's `isWithinPath` under the same name with a different signature. Also export `getBasename`/`getExtension`/`getDirectory` from core's barrel — CLAUDE.md tells contributors to use them, but they aren't currently exported (`index.ts:151-158`), which is part of why reimplementations happen.
+
+**Effort:** S · **Breaking:** `contentRoot: URI` only (2 in-repo call sites) · **Impact:** Low-Medium each; collectively keeps the convention honest.
+
+---
+
+## 7. Documentation
+
+### 7.1 `CLAUDE.md` describes the pre-`foam-core` repository and actively misdirects
+
+It states core lives in `packages/foam-vscode/src/core/` (now a one-file shim), features in `src/features/` (now `src/vscode/features/`), claims a `tsconfig` `paths` mapping for `@foam/graph-view` that doesn't exist, and recommends path utilities core doesn't export. `CONTRIBUTING.md:58-62` is *correct*, so the two root docs contradict each other. Also: `docs/user/features/templates.md:284` links to a moved file (user-facing broken link), and `docs/dev/testing-conventions.md:25` is stale.
+
+**Proposal:** rewrite the structural sections of `CLAUDE.md` against the current tree and make it point to `CONTRIBUTING.md` for structure (the duplication is what drifted); fix the two stale doc links.
+
+**Effort:** S · **Breaking:** No · **Impact:** High for contributor/agent effectiveness — this file is loaded into every AI-assisted session and currently sends it to the wrong directories.
+
+---
+
+## Prioritized roadmap
+
+**Phase 1 — Correctness & leaks (all non-breaking; ~2 weeks)**
+1.1 trie case collision · 1.2 incremental-add divergence · 1.3 edit corruption · 1.5 tag ranges · 1.6 small-fix batch · 2.1–2.4 lifecycle fixes · 5.6 frontmatter leak in published graphs · 6.1 core import lint · 7.1 CLAUDE.md rewrite
+
+**Phase 2 — Performance (non-breaking; ~1–2 weeks; verified by the existing perf gate)**
+3.1 block-parser walk · 3.3 matcher Set (+#1388 gitignore) · 3.2 cache-hit cost · 3.6 mechanical batch · 3.4 incremental tags · 3.5 rename overlay
+
+**Phase 3 — Parity & packaging (mostly non-breaking; ~2 weeks)**
+5.3 lint rules to core (CLI wikilink lint) · 1.4 CLI markdown-link rename · 6.2 web export fix + feature `supports` · 5.4 shared serializers · 5.6 packaging batch · 4.6 batch events (additive part) · 2.2 feature isolation + ids
+
+**Phase 4 — Model & API evolution (breaking; one coordinated minor/major)**
+4.1 alias resolution (flagged) · 4.2 placeholder identity · 4.3 `find` split · 4.4 `URIMap` graph keying · 4.5 collection encapsulation · 4.7 type tightening · 4.8 parser isolation · 5.1 API tiering + subpaths · 5.2 config/telemetry out of core · 5.5 datastore contract · **then** 3.7 micromark migration behind the A/B bench
+
+**Issue cross-references:** #1375/#1689 (Phases 2, 4-parser), #1388 (3.3), #1240 (1.5/4.7 groundwork), #1317 + #1631 (3.7), #1626 (Connection provenance, 4.7), #1685 (safe to do alongside 3.2), #1303 (1.1 closes the remaining gap).

--- a/docs/dev/testing-conventions.md
+++ b/docs/dev/testing-conventions.md
@@ -22,7 +22,7 @@ We use two distinct types of test files, each serving different purposes:
   - **Mock Environment**: Vitest with VS Code API mocks (fast)
   - **Real VS Code**: Full VS Code extension host (slow but comprehensive)
 - **Speed**: Depends on environment (see performance section below)
-- **Location**: Primarily in `src/features/` and service layers
+- **Location**: Primarily in `src/vscode/features/` and service layers
 
 ## Key Principle: Environment Flexibility for `.spec.ts` Files
 

--- a/docs/user/features/templates.md
+++ b/docs/user/features/templates.md
@@ -281,7 +281,7 @@ For example, `FOAM_DATE_YEAR` has the same behaviour as VS Code's `CURRENT_YEAR`
 
 By default, prefer using the `FOAM_DATE_` versions. The datetime used to compute the values will be the same for both `FOAM_DATE_` and VS Code's variables, with the exception of the creation notes using the daily note template.
 
-For more nitty-gritty details about the supported date formats, [see here](https://github.com/foambubble/foam/blob/main/packages/foam-vscode/src/services/variable-resolver.ts).
+For more nitty-gritty details about the supported date formats, [see here](https://github.com/foambubble/foam/blob/main/packages/foam-core/src/templates/variable-resolver.ts).
 
 #### Relative daily notes
 

--- a/packages/foam-core/.oxlintrc.json
+++ b/packages/foam-core/.oxlintrc.json
@@ -1,5 +1,40 @@
 {
   "ignorePatterns": ["**/*.js", "out/**"],
+  "rules": {
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          {
+            "name": "fs",
+            "message": "@foam/core must run in the browser too: do file I/O through IDataStore (services/datastore.ts)."
+          },
+          {
+            "name": "fs/promises",
+            "message": "@foam/core must run in the browser too: do file I/O through IDataStore (services/datastore.ts)."
+          },
+          {
+            "name": "path",
+            "message": "@foam/core must run in the browser too: use the POSIX-safe helpers in utils/path.ts."
+          },
+          {
+            "name": "os",
+            "message": "@foam/core must run in the browser too: no Node-only modules."
+          },
+          {
+            "name": "child_process",
+            "message": "@foam/core must run in the browser too: no Node-only modules."
+          }
+        ],
+        "patterns": [
+          {
+            "group": ["node:*"],
+            "message": "@foam/core must run in the browser too: no Node-only modules."
+          }
+        ]
+      }
+    ]
+  },
   "overrides": [
     {
       "files": ["src/**/*.test.ts"],

--- a/packages/foam-core/src/export/derive/build-site-graph.test.ts
+++ b/packages/foam-core/src/export/derive/build-site-graph.test.ts
@@ -67,4 +67,36 @@ describe('export buildSite graph data', () => {
       },
     ]);
   });
+
+  it('does not leak private frontmatter fields into the published graph data', async () => {
+    const root = URI.file('/');
+    const dataStore = new InMemoryDataStore();
+    const workspace = createTestWorkspace([root], dataStore);
+
+    const noteUri = root.joinPath('user', 'index.md');
+    const noteContent = [
+      '---',
+      'title: Home',
+      'color: red',
+      'client: ACME Corp',
+      'salary-notes: private info',
+      '---',
+      '# Home',
+    ].join('\n');
+
+    dataStore.set(noteUri, noteContent);
+    workspace.set(createNoteFromMarkdown('user/index.md', noteContent, root));
+
+    const result = await buildSite(
+      {
+        workspace,
+        graph: FoamGraph.fromWorkspace(workspace),
+        contentRoot: 'user',
+      },
+      testExportTarget()
+    );
+
+    // Only allowlisted presentation keys survive publishing
+    expect(result.graph.nodeInfo['/'].properties).toEqual({ color: 'red' });
+  });
 });

--- a/packages/foam-core/src/export/derive/build-site-graph.ts
+++ b/packages/foam-core/src/export/derive/build-site-graph.ts
@@ -16,5 +16,17 @@ export const buildExportedGraph = (
   );
   return buildGraphData(notes, context.graph.getAllConnections(), {
     resourceToId: uri => routeBySourcePath.get(uri.path),
+    // The graph JSON ships with the published site: only allowlisted
+    // presentation keys may leave the workspace, never raw frontmatter
+    transformProperties: properties => {
+      const safe: { color?: string; [key: string]: unknown } = {};
+      if (typeof properties.color === 'string') {
+        safe.color = properties.color;
+      }
+      if (properties.type !== undefined) {
+        safe.type = properties.type;
+      }
+      return safe;
+    },
   });
 };

--- a/packages/foam-core/src/model/foam.test.ts
+++ b/packages/foam-core/src/model/foam.test.ts
@@ -150,3 +150,18 @@ describe('bootstrap file-watching', () => {
     expect(matcher.refreshCount).toBe(0);
   });
 });
+
+describe('bootstrap lifecycle', () => {
+  it('disposing foam also disposes tags', async () => {
+    const matcher = new CountingMatcher();
+    const { foam } = await bootstrapWithWatcher(matcher);
+
+    let notified = false;
+    foam.tags.onDidUpdate(() => (notified = true));
+
+    foam.dispose();
+    foam.tags.update();
+
+    expect(notified).toBe(false);
+  });
+});

--- a/packages/foam-core/src/model/foam.test.ts
+++ b/packages/foam-core/src/model/foam.test.ts
@@ -165,3 +165,55 @@ describe('bootstrap lifecycle', () => {
     expect(notified).toBe(false);
   });
 });
+
+describe('bootstrap change-event handling', () => {
+  it('keeps the latest content when two change events race on the same file', async () => {
+    const matcher = new CountingMatcher();
+    const watcher = new FakeWatcher();
+    const dataStore = new GenericDataStore(
+      async () => [],
+      async () => null
+    );
+
+    // The first fetch is slow, the second fast: without per-URI
+    // serialization the slow first read finishes last and wins
+    let fetchCount = 0;
+    const racingProvider: ResourceProvider = {
+      supports: () => true,
+      readAsMarkdown: async () => null,
+      fetch: async uri => {
+        fetchCount++;
+        const version = fetchCount;
+        if (version === 1) {
+          await flush(100);
+        }
+        return createTestNote({ uri: uri.path, title: `v${version}` });
+      },
+      resolveLink: () => {
+        throw new Error('resolveLink should not be called in these tests');
+      },
+      dispose: () => {},
+    };
+
+    const foam = await bootstrap(
+      [URI.file('/workspace')],
+      matcher,
+      watcher,
+      dataStore,
+      noopParser,
+      [racingProvider],
+      '.md'
+    );
+
+    try {
+      const uri = URI.file('/workspace/racy.md');
+      watcher.fireChange(uri);
+      watcher.fireChange(uri);
+      await flush(DEBOUNCE_SETTLE_MS);
+
+      expect(foam.workspace.find(uri).title).toEqual('v2');
+    } finally {
+      foam.dispose();
+    }
+  });
+});

--- a/packages/foam-core/src/model/foam.ts
+++ b/packages/foam-core/src/model/foam.ts
@@ -109,8 +109,9 @@ export const bootstrap = async (
     },
     dispose: () => {
       subscriptions.forEach(s => s.dispose());
-      workspace.dispose();
+      tags.dispose();
       graph.dispose();
+      workspace.dispose();
     },
   };
 

--- a/packages/foam-core/src/model/foam.ts
+++ b/packages/foam-core/src/model/foam.ts
@@ -65,10 +65,23 @@ export const bootstrap = async (
   const subscriptions: IDisposable[] = [];
 
   if (watcher) {
+    // Serialize change handling per URI: two rapid changes to the same file
+    // would otherwise race on their reads, and the workspace would keep
+    // whichever read completed LAST, not the latest content
+    const pendingChanges = new Map<string, Promise<unknown>>();
     subscriptions.push(
-      watcher.onDidChange(async uri => {
+      watcher.onDidChange(uri => {
         if (matcher.isMatch(uri)) {
-          await workspace.fetchAndSet(uri);
+          const key = uri.toString();
+          const next = (pendingChanges.get(key) ?? Promise.resolve()).then(
+            () => workspace.fetchAndSet(uri)
+          );
+          pendingChanges.set(key, next);
+          next.finally(() => {
+            if (pendingChanges.get(key) === next) {
+              pendingChanges.delete(key);
+            }
+          });
         }
       })
     );

--- a/packages/foam-core/src/model/graph-incremental.test.ts
+++ b/packages/foam-core/src/model/graph-incremental.test.ts
@@ -147,6 +147,70 @@ describe('Incremental graph update equivalence', () => {
     graph.dispose();
   });
 
+  it('matches a rebuild after adding a note that steals an already-resolved identifier target', () => {
+    const workspace = createTestWorkspace();
+    workspace
+      .set(createTestNote({ uri: '/a.md', links: [{ slug: 'page' }] }))
+      .set(createTestNote({ uri: '/z/page.md' }));
+
+    const graph = FoamGraph.fromWorkspace(workspace, true);
+    const aUri = createTestNote({ uri: '/a.md' }).uri;
+    expect(graph.getLinks(aUri).map(c => c.target.path)).toEqual([
+      '/z/page.md',
+    ]);
+
+    // '/b/page.md' sorts before '/z/page.md', so it now wins the
+    // identifier ambiguity for [[page]] — A's link must re-point to it.
+    workspace.set(createTestNote({ uri: '/b/page.md' }));
+
+    expectEquivalentToRebuild(graph, workspace);
+    expect(graph.getLinks(aUri).map(c => c.target.path)).toEqual([
+      '/b/page.md',
+    ]);
+    graph.dispose();
+  });
+
+  it('matches a rebuild after adding a directory index that steals a directory link from another directory', () => {
+    const workspace = createTestWorkspace();
+    workspace
+      .set(createTestNote({ uri: '/a.md', links: [{ slug: 'bar' }] }))
+      .set(createTestNote({ uri: '/zoo/bar/index.md' }));
+
+    const graph = FoamGraph.fromWorkspace(workspace, true);
+    const aUri = createTestNote({ uri: '/a.md' }).uri;
+    expect(graph.getLinks(aUri).map(c => c.target.path)).toEqual([
+      '/zoo/bar/index.md',
+    ]);
+
+    // '/foo/bar' sorts before '/zoo/bar', so its index now wins [[bar]].
+    workspace.set(createTestNote({ uri: '/foo/bar/index.md' }));
+
+    expectEquivalentToRebuild(graph, workspace);
+    graph.dispose();
+  });
+
+  it('matches a rebuild after an index file takes over a directory link from a README in the same directory', () => {
+    const workspace = createTestWorkspace();
+    workspace
+      .set(createTestNote({ uri: '/a.md', links: [{ slug: 'bar' }] }))
+      .set(createTestNote({ uri: '/zoo/bar/README.md' }));
+
+    const graph = FoamGraph.fromWorkspace(workspace, true);
+    const aUri = createTestNote({ uri: '/a.md' }).uri;
+    expect(graph.getLinks(aUri).map(c => c.target.path)).toEqual([
+      '/zoo/bar/README.md',
+    ]);
+
+    // index beats README as directory owner: [[bar]] must re-point.
+    workspace.set(createTestNote({ uri: '/zoo/bar/index.md' }));
+
+    expectEquivalentToRebuild(graph, workspace);
+    expect(graph.getLinks(aUri).map(c => c.target.path)).toEqual([
+      '/zoo/bar/index.md',
+    ]);
+    graph.dispose();
+  });
+
   it('matches a rebuild after a rename (delete old + add new), preserving outgoing links', () => {
     // Foam has no rename event: a rename arrives as delete(old) + add(new).
     // The renamed note keeps its own outgoing links (they travel with it), but

--- a/packages/foam-core/src/model/graph.ts
+++ b/packages/foam-core/src/model/graph.ts
@@ -133,12 +133,15 @@ export class FoamGraph implements IDisposable {
   /**
    * A new note appeared. Connect its outgoing links, then handle the fan-out:
    * notes that were linking to a PLACEHOLDER which this note now fills must be
-   * recomputed (their link resolves to the real note instead). We can't cheaply
-   * invert resolution, so we re-resolve the sources of each existing placeholder
-   * and reconnect those whose target changed.
+   * recomputed (their link resolves to the real note instead), and notes whose
+   * link resolved to another REAL note the new one now out-competes must be
+   * recomputed too. We can't cheaply invert resolution, so we re-resolve the
+   * sources of each existing placeholder and of each competing target, and
+   * reconnect those whose target changed.
    */
   private onResourceAdded(resource: Resource) {
     this.reconnectAffectedPlaceholderSources();
+    this.reconnectCompetingTargetSources(resource);
     this.connectResource(resource);
     this.onDidUpdateEmitter.fire();
   }
@@ -178,6 +181,58 @@ export class FoamGraph implements IDisposable {
         affected.set(source.path, source);
       }
     }
+    this.reconnectSources(Array.from(affected.values()));
+  }
+
+  /**
+   * Adding a resource can also change how links to EXISTING notes resolve:
+   * identifier ambiguity is broken deterministically (path order,
+   * directory-index priority), so the new resource may win a resolution that
+   * another note used to own (e.g. `[[page]]` re-pointing to a
+   * shorter-path `page.md`, or a new `index.md` taking over a directory
+   * link from `README.md`). Re-resolve the sources of every target the new
+   * resource competes with. Bounded by the backlinks of same-identifier
+   * resources (plus, for directory-index files only, a scan of backlink
+   * targets), not by workspace size; reconnecting is idempotent.
+   */
+  private reconnectCompetingTargetSources(resource: Resource) {
+    const affected = new Map<string, URI>();
+    const collect = (target: URI) => {
+      for (const source of this.sourcesLinkingTo(target)) {
+        affected.set(source.path, source);
+      }
+    };
+
+    // Targets sharing the new resource's basename identifier
+    for (const competitor of this.workspace.listByIdentifier(
+      resource.uri.getBasename()
+    )) {
+      if (!competitor.uri.isEqual(resource.uri)) {
+        collect(competitor.uri);
+      }
+    }
+
+    // A new directory-index file competes for `[[dir-name]]`-style links
+    // with index files of any name inside directories with the same name
+    if (this.workspace.isDirectoryIndexFile(resource.uri)) {
+      const dirName = resource.uri.getDirectory().getBasename().toLowerCase();
+      for (const connections of this.backlinks.values()) {
+        const target = connections[0]?.target;
+        if (!target || target.isPlaceholder() || target.isEqual(resource.uri)) {
+          continue;
+        }
+        const segments = target.path.toLowerCase().split('/');
+        const basename = segments[segments.length - 1] ?? '';
+        const parentDir = segments[segments.length - 2] ?? '';
+        const isIndexCandidate = FoamWorkspace.DIRECTORY_INDEX_NAMES.some(
+          name => basename.startsWith(name + '.')
+        );
+        if (parentDir === dirName && isIndexCandidate) {
+          collect(target);
+        }
+      }
+    }
+
     this.reconnectSources(Array.from(affected.values()));
   }
 

--- a/packages/foam-core/src/model/note.test.ts
+++ b/packages/foam-core/src/model/note.test.ts
@@ -1,7 +1,7 @@
 import { createNoteFromMarkdown } from '../../test/test-utils';
 import { Position } from './position';
 import { URI } from './uri';
-import { Resource, Block } from './note';
+import { Resource, Block, NoteLinkDefinition } from './note';
 
 describe('Resource', () => {
   describe('getSectionAtPosition', () => {
@@ -193,5 +193,16 @@ Content here ^block-id
       expect(restored.uri.query).toBe('q=1');
       expect(restored.uri.isEqual(withFragment.uri)).toBe(true);
     });
+  });
+});
+
+describe('NoteLinkDefinition.format', () => {
+  it('wraps any url containing a space in angle brackets, including at position 0', () => {
+    expect(NoteLinkDefinition.format({ label: 'x', url: 'my note.md' })).toBe(
+      '[x]: <my note.md>'
+    );
+    expect(NoteLinkDefinition.format({ label: 'x', url: ' note.md' })).toBe(
+      '[x]: < note.md>'
+    );
   });
 });

--- a/packages/foam-core/src/model/note.ts
+++ b/packages/foam-core/src/model/note.ts
@@ -53,8 +53,9 @@ export interface NoteLinkDefinition {
 
 export abstract class NoteLinkDefinition {
   static format(definition: NoteLinkDefinition) {
-    const url =
-      definition.url.indexOf(' ') > 0 ? `<${definition.url}>` : definition.url;
+    const url = definition.url.includes(' ')
+      ? `<${definition.url}>`
+      : definition.url;
     let text = `[${definition.label}]: ${url}`;
     if (definition.title) {
       text = `${text} "${definition.title}"`;

--- a/packages/foam-core/src/model/tags.test.ts
+++ b/packages/foam-core/src/model/tags.test.ts
@@ -186,4 +186,19 @@ describe('FoamTags', () => {
 
     expect(tags.tags.size).toEqual(0);
   });
+
+  it('Stops notifying listeners once disposed', () => {
+    const ws = createTestWorkspace();
+    ws.set(createTestNote({ uri: '/page-a.md', tags: ['primary'] }));
+    const tags = FoamTags.fromWorkspace(ws, true);
+
+    let notified = false;
+    tags.onDidUpdate(() => (notified = true));
+
+    tags.dispose();
+    ws.set(createTestNote({ uri: '/page-b.md', tags: ['secondary'] }));
+    tags.update();
+
+    expect(notified).toBe(false);
+  });
 });

--- a/packages/foam-core/src/model/tags.test.ts
+++ b/packages/foam-core/src/model/tags.test.ts
@@ -187,6 +187,22 @@ describe('FoamTags', () => {
     expect(tags.tags.size).toEqual(0);
   });
 
+  it('Honors the debounceFor parameter when monitoring', async () => {
+    const ws = createTestWorkspace();
+    const tags = FoamTags.fromWorkspace(ws, true, 50);
+
+    ws.set(createTestNote({ uri: '/page-a.md', tags: ['primary'] }));
+    // The update is debounced, so it must not have been applied yet
+    expect(tags.tags.size).toEqual(0);
+
+    // 150ms is comfortably past the requested 50ms debounce, and well below
+    // the 500ms the implementation used to hardcode regardless of the parameter
+    await new Promise(resolve => setTimeout(resolve, 150));
+    expect(tags.tags.has('primary')).toBe(true);
+
+    tags.dispose();
+  });
+
   it('Stops notifying listeners once disposed', () => {
     const ws = createTestWorkspace();
     ws.set(createTestNote({ uri: '/page-a.md', tags: ['primary'] }));

--- a/packages/foam-core/src/model/tags.ts
+++ b/packages/foam-core/src/model/tags.ts
@@ -63,5 +63,6 @@ export class FoamTags implements IDisposable {
   dispose(): void {
     this.disposables.forEach(d => d.dispose());
     this.disposables = [];
+    this.onDidUpdateEmitter.dispose();
   }
 }

--- a/packages/foam-core/src/model/tags.ts
+++ b/packages/foam-core/src/model/tags.ts
@@ -37,7 +37,7 @@ export class FoamTags implements IDisposable {
     if (keepMonitoring) {
       const updateTags =
         debounceFor > 0
-          ? debounce(tags.update.bind(tags), 500)
+          ? debounce(tags.update.bind(tags), debounceFor)
           : tags.update.bind(tags);
       tags.disposables.push(
         workspace.onDidAdd(updateTags),

--- a/packages/foam-core/src/model/workspace.test.ts
+++ b/packages/foam-core/src/model/workspace.test.ts
@@ -520,3 +520,25 @@ describe('Directory index', () => {
     });
   });
 });
+
+describe('Workspace lifecycle', () => {
+  it('disposes registered providers when the workspace is disposed', () => {
+    const ws = new FoamWorkspace();
+    let disposed = false;
+    ws.registerProvider({
+      supports: () => false,
+      readAsMarkdown: async () => null,
+      fetch: async () => null,
+      resolveLink: () => {
+        throw new Error('not used');
+      },
+      dispose: () => {
+        disposed = true;
+      },
+    });
+
+    ws.dispose();
+
+    expect(disposed).toBe(true);
+  });
+});

--- a/packages/foam-core/src/model/workspace.test.ts
+++ b/packages/foam-core/src/model/workspace.test.ts
@@ -542,3 +542,74 @@ describe('Workspace lifecycle', () => {
     expect(disposed).toBe(true);
   });
 });
+
+describe('Case-variant filenames in the same directory (case-sensitive filesystems)', () => {
+  it('stores files differing only by case as distinct resources', () => {
+    const ws = createTestWorkspace();
+    ws.set(createTestNote({ uri: '/a/Note.md' }));
+    ws.set(createTestNote({ uri: '/a/note.md' }));
+
+    expect(
+      ws
+        .list()
+        .map(r => r.uri.path)
+        .sort()
+    ).toEqual(['/a/Note.md', '/a/note.md']);
+  });
+
+  it('fires onDidAdd, not onDidUpdate, when adding a case-variant sibling', () => {
+    const ws = createTestWorkspace();
+    ws.set(createTestNote({ uri: '/a/note.md' }));
+
+    let added = 0;
+    let updated = 0;
+    ws.onDidAdd(() => added++);
+    ws.onDidUpdate(() => updated++);
+
+    ws.set(createTestNote({ uri: '/a/Note.md' }));
+
+    expect(added).toEqual(1);
+    expect(updated).toEqual(0);
+  });
+
+  it('finds each case variant by its exact URI', () => {
+    const ws = createTestWorkspace();
+    ws.set(createTestNote({ uri: '/a/Note.md', title: 'Upper' }));
+    ws.set(createTestNote({ uri: '/a/note.md', title: 'Lower' }));
+
+    expect(ws.find(URI.file('/a/Note.md')).title).toEqual('Upper');
+    expect(ws.find(URI.file('/a/note.md')).title).toEqual('Lower');
+  });
+
+  it('deletes only the exact-case match when variants coexist', () => {
+    const ws = createTestWorkspace();
+    ws.set(createTestNote({ uri: '/a/Note.md' }));
+    ws.set(createTestNote({ uri: '/a/note.md' }));
+
+    const deleted = ws.delete(URI.file('/a/note.md'));
+
+    expect(deleted.uri.path).toEqual('/a/note.md');
+    expect(ws.list().map(r => r.uri.path)).toEqual(['/a/Note.md']);
+  });
+
+  it('still finds a resource via a case-insensitive reference when unambiguous', () => {
+    const ws = createTestWorkspace();
+    ws.set(createTestNote({ uri: '/a/page.md' }));
+
+    expect(ws.find(URI.file('/a/PAGE.md')).uri.path).toEqual('/a/page.md');
+  });
+
+  it('lists both case variants under the shared identifier', () => {
+    const ws = createTestWorkspace();
+    ws.set(createTestNote({ uri: '/a/Note.md' }));
+    ws.set(createTestNote({ uri: '/a/note.md' }));
+
+    // The exact-case filter then narrows to the exact basename
+    expect(ws.listByIdentifier('note').map(r => r.uri.path)).toEqual([
+      '/a/note.md',
+    ]);
+    expect(ws.listByIdentifier('Note').map(r => r.uri.path)).toEqual([
+      '/a/Note.md',
+    ]);
+  });
+});

--- a/packages/foam-core/src/model/workspace.ts
+++ b/packages/foam-core/src/model/workspace.ts
@@ -40,7 +40,7 @@ export class FoamWorkspace implements IDisposable {
   private _directoryIndex: Map<string, URI> = new Map();
 
   /** Basenames (without extension, lowercase) that qualify as directory index files, in priority order */
-  private static readonly DIRECTORY_INDEX_NAMES = ['index', 'readme'];
+  public static readonly DIRECTORY_INDEX_NAMES = ['index', 'readme'];
 
   /**
    * The root URIs of this workspace, in priority order.
@@ -189,6 +189,11 @@ export class FoamWorkspace implements IDisposable {
     if (!ext) return -1;
     const name = uri.getBasename().slice(0, -ext.length).toLowerCase();
     return FoamWorkspace.DIRECTORY_INDEX_NAMES.indexOf(name);
+  }
+
+  /** Whether the URI qualifies as a directory index file (e.g. index.md, README.md) */
+  public isDirectoryIndexFile(uri: URI): boolean {
+    return this._directoryIndexPriority(uri) !== -1;
   }
 
   private _registerDirectoryIndex(resource: Resource): void {

--- a/packages/foam-core/src/model/workspace.ts
+++ b/packages/foam-core/src/model/workspace.ts
@@ -25,9 +25,12 @@ export class FoamWorkspace implements IDisposable {
   private providers: ResourceProvider[] = [];
 
   /**
-   * Resources by path
+   * Resources by case-normalized path.
+   * Each entry is a bucket: resources whose paths differ only by case are
+   * distinct files on case-sensitive filesystems and must coexist, so they
+   * share a trie key but keep their own slot in the bucket.
    */
-  private _resources: TrieMap<string, Resource> = new TrieMap();
+  private _resources: TrieMap<string, Resource[]> = new TrieMap();
 
   /**
    * Maps a normalized directory path to the URI of its directory index file owner.
@@ -125,10 +128,18 @@ export class FoamWorkspace implements IDisposable {
   }
 
   set(resource: Resource) {
-    const old = this.find(resource.uri);
-
-    // store resource
-    this._resources.set(this.getTrieIdentifier(resource.uri.path), resource);
+    const key = this.getTrieIdentifier(resource.uri.path);
+    const bucket = this._resources.get(key) ?? [];
+    // Only an exact-case path match is an update: a resource whose path
+    // differs only by case is a different file and must be added alongside
+    const index = bucket.findIndex(r => r.uri.path === resource.uri.path);
+    const old = index >= 0 ? bucket[index] : null;
+    if (index >= 0) {
+      bucket[index] = resource;
+    } else {
+      bucket.push(resource);
+    }
+    this._resources.set(key, bucket);
     this._registerDirectoryIndex(resource);
 
     isSome(old)
@@ -138,8 +149,20 @@ export class FoamWorkspace implements IDisposable {
   }
 
   delete(uri: URI) {
-    const deleted = this._resources.get(this.getTrieIdentifier(uri));
-    this._resources.delete(this.getTrieIdentifier(uri));
+    const key = this.getTrieIdentifier(uri);
+    const bucket = this._resources.get(key) ?? [];
+    let index = bucket.findIndex(r => r.uri.path === uri.path);
+    if (index < 0 && bucket.length === 1) {
+      // a single case-insensitive match keeps the historical lenient lookup
+      index = 0;
+    }
+    const deleted = index >= 0 ? bucket[index] : null;
+    if (index >= 0) {
+      bucket.splice(index, 1);
+      bucket.length > 0
+        ? this._resources.set(key, bucket)
+        : this._resources.delete(key);
+    }
     this._unregisterDirectoryIndex(uri);
 
     isSome(deleted) && this.onDidDeleteEmitter.fire(deleted);
@@ -147,7 +170,7 @@ export class FoamWorkspace implements IDisposable {
   }
 
   clear() {
-    const resources = Array.from(this._resources.values());
+    const resources = Array.from(this._resources.values()).flat();
     this._resources.clear();
     this._directoryIndex.clear();
 
@@ -218,7 +241,7 @@ export class FoamWorkspace implements IDisposable {
   public findByDirectory(dirPath: string): Resource | null {
     const ownerUri = this._directoryIndex.get(normalize(dirPath));
     if (!ownerUri) return null;
-    return this._resources.get(this.getTrieIdentifier(ownerUri)) ?? null;
+    return this.getResourceByPath(ownerUri);
   }
 
   /**
@@ -231,7 +254,7 @@ export class FoamWorkspace implements IDisposable {
     const results: Resource[] = [];
     for (const [dirPath, uri] of this._directoryIndex.entries()) {
       if (dirPath === normalizedId || dirPath.endsWith('/' + normalizedId)) {
-        const resource = this._resources.get(this.getTrieIdentifier(uri));
+        const resource = this.getResourceByPath(uri);
         if (resource) results.push(resource);
       }
     }
@@ -243,13 +266,13 @@ export class FoamWorkspace implements IDisposable {
   }
 
   public list(): Resource[] {
-    return Array.from(this._resources.values());
+    return Array.from(this._resources.values()).flat();
   }
 
   public resources(): IterableIterator<Resource> {
-    const resources: Array<Resource> = Array.from(
-      this._resources.values()
-    ).sort(Resource.sortByPath);
+    const resources: Array<Resource> = Array.from(this._resources.values())
+      .flat()
+      .sort(Resource.sortByPath);
 
     return resources.values();
   }
@@ -272,10 +295,10 @@ export class FoamWorkspace implements IDisposable {
 
     let resources: Resource[] = [];
 
-    this._resources.find(needle).forEach(elm => resources.push(elm[1]));
+    this._resources.find(needle).forEach(elm => resources.push(...elm[1]));
 
     if (mdNeedle) {
-      this._resources.find(mdNeedle).forEach(elm => resources.push(elm[1]));
+      this._resources.find(mdNeedle).forEach(elm => resources.push(...elm[1]));
     }
 
     // if multiple resources found, try to filter exact case matches
@@ -364,9 +387,23 @@ export class FoamWorkspace implements IDisposable {
     return reversedPath;
   }
 
+  /**
+   * Returns the resource stored at the given URI/path.
+   * Lookup is case-insensitive; when several resources share a
+   * case-normalized path, only an exact-case match is returned.
+   */
+  private getResourceByPath(reference: URI | string): Resource | null {
+    const path = reference instanceof URI ? reference.path : reference;
+    const bucket = this._resources.get(this.getTrieIdentifier(path)) ?? [];
+    return (
+      bucket.find(r => r.uri.path === path) ??
+      (bucket.length === 1 ? bucket[0] : null)
+    );
+  }
+
   public find(reference: URI | string, baseUri?: URI): Resource | null {
     if (reference instanceof URI) {
-      return this._resources.get(this.getTrieIdentifier(reference)) ?? null;
+      return this.getResourceByPath(reference);
     }
     let resource: Resource | null = null;
     const [path, fragment] = (reference as string).split('#');
@@ -378,15 +415,13 @@ export class FoamWorkspace implements IDisposable {
         if (isAbsolute(candidate)) {
           // Try roots[0] first (via resolveUri which handles already-under-root paths)
           const resolvedUri = this.resolveUri(candidate, baseUri);
-          resource =
-            this._resources.get(this.getTrieIdentifier(resolvedUri)) ?? null;
+          resource = this.getResourceByPath(resolvedUri);
           // For workspace-relative absolute paths in multi-root workspaces,
           // also search remaining roots in case the resource lives in a different root
           if (!resource && this.roots.length > 1) {
             for (let i = 1; i < this.roots.length; i++) {
               const altUri = this.roots[i].joinPath(candidate);
-              resource =
-                this._resources.get(this.getTrieIdentifier(altUri)) ?? null;
+              resource = this.getResourceByPath(altUri);
               if (resource) {
                 break;
               }
@@ -396,9 +431,7 @@ export class FoamWorkspace implements IDisposable {
           const resolvedUri = isSome(baseUri)
             ? baseUri.resolve(candidate)
             : null;
-          resource = resolvedUri
-            ? this._resources.get(this.getTrieIdentifier(resolvedUri))
-            : null;
+          resource = resolvedUri ? this.getResourceByPath(resolvedUri) : null;
         }
         if (resource) {
           break;

--- a/packages/foam-core/src/model/workspace.ts
+++ b/packages/foam-core/src/model/workspace.ts
@@ -458,6 +458,8 @@ export class FoamWorkspace implements IDisposable {
   }
 
   public dispose(): void {
+    this.providers.forEach(p => p.dispose());
+    this.providers = [];
     this.onDidAddEmitter.dispose();
     this.onDidDeleteEmitter.dispose();
     this.onDidUpdateEmitter.dispose();

--- a/packages/foam-core/src/services/attachment-provider.test.ts
+++ b/packages/foam-core/src/services/attachment-provider.test.ts
@@ -1,0 +1,26 @@
+import { AttachmentResourceProvider } from './attachment-provider';
+import { URI } from '../model/uri';
+
+describe('AttachmentResourceProvider', () => {
+  it('classifies image extensions case-insensitively, consistently with supports()', async () => {
+    const provider = new AttachmentResourceProvider();
+    const uri = URI.file('/photo.PNG');
+
+    expect(provider.supports(uri)).toBe(true);
+
+    const resource = await provider.fetch(uri);
+    expect(resource.type).toEqual('image');
+
+    const markdown = await provider.readAsMarkdown(uri);
+    expect(markdown).toContain('![');
+  });
+
+  it('classifies non-image attachments as attachment', async () => {
+    const provider = new AttachmentResourceProvider();
+    const uri = URI.file('/doc.pdf');
+
+    const resource = await provider.fetch(uri);
+    expect(resource.type).toEqual('attachment');
+    expect(await provider.readAsMarkdown(uri)).toBe('### doc.pdf');
+  });
+});

--- a/packages/foam-core/src/services/attachment-provider.ts
+++ b/packages/foam-core/src/services/attachment-provider.ts
@@ -36,7 +36,7 @@ export const defaultAttachmentExtensions = [
 ];
 
 const asResource = (uri: URI): Resource => {
-  const type = imageExtensions.includes(uri.getExtension())
+  const type = imageExtensions.includes(uri.getExtension().toLocaleLowerCase())
     ? 'image'
     : 'attachment';
   return {
@@ -68,7 +68,7 @@ export class AttachmentResourceProvider implements ResourceProvider {
   }
 
   async readAsMarkdown(uri: URI): Promise<string | null> {
-    if (imageExtensions.includes(uri.getExtension())) {
+    if (imageExtensions.includes(uri.getExtension().toLocaleLowerCase())) {
       return `![${''}](${uri.toString()}|height=200)`;
     }
     return `### ${uri.getBasename()}`;

--- a/packages/foam-core/src/services/graph-data-builder.ts
+++ b/packages/foam-core/src/services/graph-data-builder.ts
@@ -37,6 +37,19 @@ export interface GraphBuilderOptions {
    */
   transformTitle?: (title: string, resource: Resource) => string;
   /**
+   * Optional transform for the frontmatter properties stored on each node.
+   * Defaults to passing the resource's properties through unchanged (the
+   * local graph view groups/colors nodes by arbitrary frontmatter keys).
+   *
+   * Anything that PUBLISHES the graph data must restrict this to an
+   * allowlist: raw frontmatter can contain private fields that must not
+   * ship in published graph JSON.
+   */
+  transformProperties?: (
+    properties: Record<string, unknown>,
+    resource: Resource
+  ) => GraphNodeData['properties'];
+  /**
    * Whether to include placeholder nodes — synthetic nodes created for link
    * targets that don't correspond to any real resource (i.e. broken links).
    *
@@ -53,7 +66,12 @@ export function buildGraphData(
   connections: Connection[],
   options: GraphBuilderOptions
 ): BuiltGraphData {
-  const { resourceToId, transformTitle, includePlaceholders = false } = options;
+  const {
+    resourceToId,
+    transformTitle,
+    transformProperties,
+    includePlaceholders = false,
+  } = options;
   const nodeInfo: Record<string, GraphNodeData> = {};
   const links = new Map<string, { source: string; target: string }>();
 
@@ -72,7 +90,9 @@ export function buildGraphData(
           ? resource.properties.type ?? 'note'
           : resource.type,
       title,
-      properties: resource.properties ?? {},
+      properties: transformProperties
+        ? transformProperties(resource.properties ?? {}, resource)
+        : resource.properties ?? {},
       tags: resource.tags.map(tag => ({ label: tag.label })),
     };
   }

--- a/packages/foam-core/src/services/heading-edit.test.ts
+++ b/packages/foam-core/src/services/heading-edit.test.ts
@@ -278,6 +278,41 @@ Content.
       expect(edit.edit.newText).not.toContain('see more');
     });
 
+    it('should emit a single definition edit when several reference links share one definition', () => {
+      const ws = createTestWorkspace();
+      const noteA = createNoteFromMarkdown(
+        '/note-a.md',
+        `# OldSection
+
+Content.
+`
+      );
+      const noteB = createNoteFromMarkdown(
+        '/note-b.md',
+        `[first][ref1] and [second][ref1]
+
+[ref1]: note-a#OldSection
+`
+      );
+      ws.set(noteA).set(noteB);
+      const graph = FoamGraph.fromWorkspace(ws);
+
+      const result = HeadingEdit.createRenameSectionEdits(
+        graph,
+        ws,
+        noteA.uri,
+        'OldSection',
+        'NewSection'
+      );
+
+      // Both links resolve through the definition, but the definition line
+      // must be rewritten exactly once — a duplicate edit corrupts the file
+      expect(result.edits).toHaveLength(1);
+      expect(result.edits[0].edit.newText).toBe('[ref1]: note-a#NewSection');
+      // Both links are covered by the rename
+      expect(result.totalOccurrences).toBe(2);
+    });
+
     it('should not update links that reference a different section', () => {
       const ws = createTestWorkspace();
       const noteA = createNoteFromMarkdown(

--- a/packages/foam-core/src/services/heading-edit.ts
+++ b/packages/foam-core/src/services/heading-edit.ts
@@ -120,17 +120,20 @@ export abstract class HeadingEdit {
         if (blockId !== oldId) {
           continue;
         }
-        totalOccurrences++;
-        edits.push({
-          uri: connection.source,
-          edit: MarkdownLink.createUpdateLinkEdit(link, {
+        let edit: WorkspaceTextEdit['edit'];
+        try {
+          edit = MarkdownLink.createUpdateLinkEdit(link, {
             section: '^' + newId,
-          }),
-        });
+          });
+        } catch {
+          continue;
+        }
+        totalOccurrences++;
+        edits.push({ uri: connection.source, edit });
       }
     }
 
-    return { edits, totalOccurrences };
+    return { edits: WorkspaceTextEdit.dedupe(edits), totalOccurrences };
   }
 
   /**
@@ -250,14 +253,19 @@ export abstract class HeadingEdit {
         if (section !== oldLabel) {
           continue;
         }
+        let textEdit: WorkspaceTextEdit['edit'];
+        try {
+          textEdit = MarkdownLink.createUpdateLinkEdit(link, {
+            section: newLabel,
+          });
+        } catch {
+          continue;
+        }
         totalOccurrences++;
-        const textEdit = MarkdownLink.createUpdateLinkEdit(link, {
-          section: newLabel,
-        });
         edits.push({ uri: connection.source, edit: textEdit });
       }
     }
 
-    return { edits, totalOccurrences };
+    return { edits: WorkspaceTextEdit.dedupe(edits), totalOccurrences };
   }
 }

--- a/packages/foam-core/src/services/link-integrity.ts
+++ b/packages/foam-core/src/services/link-integrity.ts
@@ -71,27 +71,34 @@ function computeRenameEditsForPairs(
       if (connection.link.type !== 'wikilink') {
         continue;
       }
-      const { target: linkTarget } = MarkdownLink.analyzeLink(connection.link);
-      let identifier: string;
-      if (
-        oldDirIdentifier &&
-        linkTarget.toLocaleLowerCase() === oldDirIdentifier
-      ) {
-        // Link uses a directory-style identifier (e.g. [[folderA]]). Compute the
-        // new directory identifier and restore its correct casing from the URI.
-        const newDirUri = newUri.getDirectory();
-        const lowerId = futureWorkspace.getDirectoryIdentifier(newUri);
-        identifier = lowerId
-          ? toCorrectCase(lowerId, newDirUri)
-          : futureWorkspace.getIdentifier(newUri);
-      } else {
-        identifier = futureWorkspace.getIdentifier(newUri);
-      }
+      // A single unparsable link must not abort the whole rename
+      try {
+        const { target: linkTarget } = MarkdownLink.analyzeLink(
+          connection.link
+        );
+        let identifier: string;
+        if (
+          oldDirIdentifier &&
+          linkTarget.toLocaleLowerCase() === oldDirIdentifier
+        ) {
+          // Link uses a directory-style identifier (e.g. [[folderA]]). Compute the
+          // new directory identifier and restore its correct casing from the URI.
+          const newDirUri = newUri.getDirectory();
+          const lowerId = futureWorkspace.getDirectoryIdentifier(newUri);
+          identifier = lowerId
+            ? toCorrectCase(lowerId, newDirUri)
+            : futureWorkspace.getIdentifier(newUri);
+        } else {
+          identifier = futureWorkspace.getIdentifier(newUri);
+        }
 
-      const edit = MarkdownLink.createUpdateLinkEdit(connection.link, {
-        target: identifier,
-      });
-      allEdits.push({ uri: connection.source, edit });
+        const edit = MarkdownLink.createUpdateLinkEdit(connection.link, {
+          target: identifier,
+        });
+        allEdits.push({ uri: connection.source, edit });
+      } catch {
+        continue;
+      }
     }
   }
 

--- a/packages/foam-core/src/services/markdown-link.ts
+++ b/packages/foam-core/src/services/markdown-link.ts
@@ -121,7 +121,7 @@ export abstract class MarkdownLink {
         return `${newTarget}${sectionDivider}${newSection}`;
       };
       const useAngles =
-        newTarget.indexOf(' ') > 0 || newSection.indexOf(' ') > 0;
+        newTarget.includes(' ') || newSection.includes(' ');
       return {
         newText: `${embed}[${newAlias ? newAlias : defaultAlias()}](${
           useAngles ? '<' : ''

--- a/packages/foam-core/src/services/markdown-parser.test.ts
+++ b/packages/foam-core/src/services/markdown-parser.test.ts
@@ -518,6 +518,27 @@ tags: hello, world
       ]);
     });
 
+    it('can find tags on the continuation lines of a multi-line paragraph', () => {
+      const noteA = createNoteFromMarkdown(
+        `first line with #one\nsecond line with #two`
+      );
+      expect(noteA.tags).toEqual([
+        { label: 'one', range: Range.create(0, 16, 0, 20) },
+        { label: 'two', range: Range.create(1, 17, 1, 21) },
+      ]);
+    });
+
+    it('computes the range of a frontmatter tag that is a substring of another tag', () => {
+      const noteA = createNoteFromMarkdown(`---
+tags: [foobar, foo]
+---
+content`);
+      expect(noteA.tags.map(t => t.label).sort()).toEqual(['foo', 'foobar']);
+      const foo = noteA.tags.find(t => t.label === 'foo');
+      // must point at the standalone 'foo', not the prefix of 'foobar'
+      expect(foo.range).toEqual(Range.create(1, 15, 1, 18));
+    });
+
     it('will skip tags in codeblocks', () => {
       const noteA = createNoteFromMarkdown(`
 this is some #text that includes #tags we #care-about.

--- a/packages/foam-core/src/services/markdown-parser.test.ts
+++ b/packages/foam-core/src/services/markdown-parser.test.ts
@@ -1309,3 +1309,14 @@ describe('block anchor extraction', () => {
     });
   });
 });
+
+describe('Frontmatter tags with quoted keys', () => {
+  it('parses tags when the tags key is quoted in frontmatter', () => {
+    const note = createNoteFromMarkdown(`---
+"tags": [alpha]
+---
+content`);
+    expect(note.tags.map(t => t.label)).toEqual(['alpha']);
+    expect(note.tags[0].range.start.line).toEqual(1);
+  });
+});

--- a/packages/foam-core/src/services/markdown-parser.ts
+++ b/packages/foam-core/src/services/markdown-parser.ts
@@ -355,7 +355,8 @@ function getPropertiesInfoFromYAML(yamlText: string): {
     if (!match) {
       continue;
     }
-    const key = match[1];
+    // YAML allows quoted keys ("tags": ...) — normalize to the plain name
+    const key = match[1].replace(/^(["'])(.*)\1$/, '$2');
     let text = lines[lineIdx];
     let j = lineIdx + 1;
     // Collect continuation lines: everything that isn't the start of a new key
@@ -398,6 +399,11 @@ const tagsPlugin: ParserPlugin = {
       const tagPropertyInfo = getPropertiesInfoFromYAML((node as any).value)[
         'tags'
       ];
+      // e.g. a quoted "tags": key is captured with its quotes and misses
+      // the plain lookup — skip the ranges rather than dropping all tags
+      if (!isSome(tagPropertyInfo)) {
+        return;
+      }
       const tagPropertyStartLine =
         node.position!.start.line + tagPropertyInfo.line;
       const tagPropertyLines = tagPropertyInfo.text.split('\n');

--- a/packages/foam-core/src/services/markdown-parser.ts
+++ b/packages/foam-core/src/services/markdown-parser.ts
@@ -369,6 +369,28 @@ function getPropertiesInfoFromYAML(yamlText: string): {
   return result;
 }
 
+/** Characters that can be part of a tag label (see HASHTAG_REGEX) */
+const TAG_LABEL_CHAR = /[\p{L}\p{Extended_Pictographic}\p{N}/_-]/u;
+
+/**
+ * Finds the column of `tag` in `line`, matching only occurrences that are not
+ * part of a longer tag-like word (so tag `foo` does not match inside `foobar`)
+ */
+const findTagColumnInLine = (line: string, tag: string): number => {
+  for (
+    let idx = line.indexOf(tag);
+    idx >= 0;
+    idx = line.indexOf(tag, idx + 1)
+  ) {
+    const before = idx > 0 ? line[idx - 1] : '';
+    const after = idx + tag.length < line.length ? line[idx + tag.length] : '';
+    if (!TAG_LABEL_CHAR.test(before) && !TAG_LABEL_CHAR.test(after)) {
+      return idx;
+    }
+  }
+  return -1;
+};
+
 const tagsPlugin: ParserPlugin = {
   name: 'tags',
   onDidFindProperties: (props, note, node) => {
@@ -381,9 +403,14 @@ const tagsPlugin: ParserPlugin = {
       const tagPropertyLines = tagPropertyInfo.text.split('\n');
       const yamlTags = extractTagsFromProp(props.tags);
       for (const tag of yamlTags) {
-        const tagLine = tagPropertyLines.findIndex(l => l.includes(tag));
+        const tagLine = tagPropertyLines.findIndex(
+          l => findTagColumnInLine(l, tag) >= 0
+        );
+        if (tagLine < 0) {
+          continue;
+        }
         const line = tagPropertyStartLine + tagLine;
-        const charStart = tagPropertyLines[tagLine].indexOf(tag);
+        const charStart = findTagColumnInLine(tagPropertyLines[tagLine], tag);
         note.tags.push({
           label: tag,
           range: Range.createFromPosition(
@@ -396,10 +423,23 @@ const tagsPlugin: ParserPlugin = {
   },
   visit: (node, note) => {
     if (node.type === 'text') {
-      const tags = extractHashtags((node as any).value);
+      const text = (node as any).value as string;
+      const tags = extractHashtags(text);
       for (const tag of tags) {
-        const start = astPointToFoamPosition(node.position!.start);
-        start.character = start.character + tag.offset;
+        // The node's value can span multiple lines (soft breaks), so the
+        // tag's position is derived by counting newlines up to its offset
+        const nodeStart = astPointToFoamPosition(node.position!.start);
+        const preceding = text.slice(0, tag.offset);
+        const lastBreak = preceding.lastIndexOf('\n');
+        const lineBreaks =
+          lastBreak < 0 ? 0 : preceding.split('\n').length - 1;
+        const start: Position = {
+          line: nodeStart.line + lineBreaks,
+          character:
+            lastBreak < 0
+              ? nodeStart.character + tag.offset
+              : tag.offset - lastBreak - 1,
+        };
         const end: Position = {
           line: start.line,
           character: start.character + tag.label.length + 1,

--- a/packages/foam-core/src/services/markdown-provider.test.ts
+++ b/packages/foam-core/src/services/markdown-provider.test.ts
@@ -1102,3 +1102,12 @@ describe('readAsMarkdown with block fragments', () => {
     expect(result).toEqual(content);
   });
 });
+
+describe('createMarkdownReferences edge cases', () => {
+  it('returns no definitions for a URI not in the workspace', () => {
+    const ws = createTestWorkspace();
+    expect(
+      createMarkdownReferences(ws, URI.file('/missing.md'), true)
+    ).toEqual([]);
+  });
+});

--- a/packages/foam-core/src/services/markdown-provider.ts
+++ b/packages/foam-core/src/services/markdown-provider.ts
@@ -52,7 +52,7 @@ export class MarkdownResourceProvider implements ResourceProvider {
               content = rows
                 .slice(range.start.line, range.end.line)
                 .join('\n')
-                .replace(/\s\^[a-zA-Z0-9-]+$/m, '');
+                .replace(/\s\^[a-zA-Z0-9-]+$/gm, '');
             } else {
               // Fallback: just the heading line
               content = rows[block.range.start.line].replace(
@@ -203,6 +203,9 @@ export function createMarkdownReferences(
   includeExtension: boolean
 ): NoteLinkDefinition[] {
   const resource = source instanceof URI ? workspace.find(source) : source;
+  if (!resource) {
+    return [];
+  }
 
   const definitions = resource.links
     .filter(link => ResourceLink.isReferenceStyleLink(link))
@@ -276,7 +279,6 @@ export function createMarkdownReferences(
         title: target.title,
       };
     })
-    .filter(isSome)
-    .sort();
+    .filter(isSome);
   return uniqBy(definitions, def => NoteLinkDefinition.format(def));
 }

--- a/packages/foam-core/src/services/tag-edit.test.ts
+++ b/packages/foam-core/src/services/tag-edit.test.ts
@@ -609,3 +609,26 @@ describe('TagEdit', () => {
     });
   });
 });
+
+describe('hierarchical rename with special characters', () => {
+  it('does not interpret $-patterns in the new parent tag name', () => {
+    const ws = createTestWorkspace();
+    ws.set(
+      createTestNote({
+        uri: '/page.md',
+        tags: ['a', 'a/child'],
+      })
+    );
+    const foamTags = FoamTags.fromWorkspace(ws);
+
+    const result = TagEdit.createHierarchicalRenameEdits(
+      foamTags,
+      'a',
+      'b$&x'
+    );
+
+    const editedTags = result.edits.map(edit => edit.edit.newText);
+    expect(editedTags).toContain('b$&x');
+    expect(editedTags).toContain('b$&x/child');
+  });
+});

--- a/packages/foam-core/src/services/tag-edit.ts
+++ b/packages/foam-core/src/services/tag-edit.ts
@@ -234,11 +234,11 @@ export abstract class TagEdit {
     // Find and rename all child tags
     const childTags = this.findChildTags(foamTags, oldParentTag);
     for (const childTag of childTags) {
-      // Replace the parent portion with the new parent name
-      const newChildTag = childTag.replace(
-        oldParentTag + '/',
-        newParentTag + '/'
-      );
+      // Replace the parent portion with the new parent name. Built with
+      // slice rather than String.replace so that `$`-patterns in the new
+      // name are not interpreted as replacement directives
+      const newChildTag =
+        newParentTag + '/' + childTag.slice(oldParentTag.length + 1);
       const childResult = this.createRenameTagEdits(
         foamTags,
         childTag,

--- a/packages/foam-core/src/services/text-edit.test.ts
+++ b/packages/foam-core/src/services/text-edit.test.ts
@@ -133,3 +133,55 @@ describe('WorkspaceTextEdit.groupByUri', () => {
     expect(groups[1].edits).toEqual([thirdEdit]);
   });
 });
+
+describe('applying multiple TextEdits', () => {
+  it('applies an identical duplicated edit only once', () => {
+    // Two reference links sharing one definition produce the same edit twice;
+    // applying both would insert the text twice
+    const edit = { newText: 'X', range: Range.create(0, 3, 0, 3) };
+    const actual = TextEdit.apply('abc', [edit, { ...edit }]);
+    expect(actual).toBe('abcX');
+  });
+
+  it('throws on overlapping edits instead of corrupting the text', () => {
+    const edits = [
+      { newText: 'X', range: Range.create(0, 0, 0, 7) },
+      { newText: 'Y', range: Range.create(0, 4, 0, 13) },
+    ];
+    expect(() => TextEdit.apply('one two three', edits)).toThrow(/overlap/);
+  });
+
+  it('lets an edit that rewrites a whole region supersede edits contained in it', () => {
+    // e.g. generateLinkReferences: deleting a stale definition line inside
+    // the region that the "append definitions" edit replaces wholesale
+    const text = 'keep\nstale\nold-tail';
+    const edits = [
+      { newText: '', range: Range.create(1, 0, 2, 0) },
+      { newText: '\nnew-tail', range: Range.create(0, 4, 2, 8) },
+    ];
+    expect(TextEdit.apply(text, edits)).toBe('keep\nnew-tail');
+  });
+
+  it('allows adjacent edits that touch at a boundary', () => {
+    const edits = [
+      { newText: 'X', range: Range.create(0, 0, 0, 3) },
+      { newText: 'Y', range: Range.create(0, 3, 0, 6) },
+    ];
+    expect(TextEdit.apply('abcdef', edits)).toBe('XY');
+  });
+});
+
+describe('WorkspaceTextEdit.dedupe', () => {
+  it('drops edits with the same uri, range and text, keeping distinct ones', () => {
+    const uri = URI.file('/note.md');
+    const edit = { newText: 'X', range: Range.create(0, 0, 0, 1) };
+    const other = { newText: 'Y', range: Range.create(1, 0, 1, 1) };
+    const deduped = WorkspaceTextEdit.dedupe([
+      { uri, edit },
+      { uri, edit: { ...edit } },
+      { uri, edit: other },
+    ]);
+    expect(deduped).toHaveLength(2);
+    expect(deduped.map(e => e.edit.newText)).toEqual(['X', 'Y']);
+  });
+});

--- a/packages/foam-core/src/services/text-edit.ts
+++ b/packages/foam-core/src/services/text-edit.ts
@@ -24,11 +24,51 @@ export abstract class TextEdit {
     textEditOrEdits: TextEdit | TextEdit[]
   ): string {
     if (Array.isArray(textEditOrEdits)) {
+      // Identical edits collapse to one: several reference links resolving to
+      // the same definition legitimately produce copies of the same edit
+      const seen = new Set<string>();
+      const uniqueEdits = textEditOrEdits.filter(edit => {
+        const key = `${Range.toString(edit.range)}|${edit.newText}`;
+        if (seen.has(key)) {
+          return false;
+        }
+        seen.add(key);
+        return true;
+      });
+      // An edit fully contained in another edit's range is superseded by it:
+      // the outer edit rewrites that whole region (e.g. deleting a stale
+      // definition inside a block another edit replaces wholesale)
+      const independentEdits = uniqueEdits.filter(
+        (edit, i) =>
+          !uniqueEdits.some(
+            (other, j) =>
+              j !== i &&
+              !Range.isEqual(edit.range, other.range) &&
+              Range.containsRange(other.range, edit.range)
+          )
+      );
       // Apply edits in reverse order (end-to-beginning) to maintain range validity
       // This matches VS Code's behavior for TextEdit application
-      const sortedEdits = [...textEditOrEdits].sort((a, b) =>
+      const sortedEdits = independentEdits.sort((a, b) =>
         Position.compareTo(b.range.start, a.range.start)
       );
+      // Partially overlapping edits would apply on top of each other's output
+      // and silently corrupt the document, so they are rejected outright
+      for (let i = 0; i < sortedEdits.length - 1; i++) {
+        // sorted descending by start: edit i starts at or after edit i+1
+        if (
+          Position.isBefore(
+            sortedEdits[i].range.start,
+            sortedEdits[i + 1].range.end
+          )
+        ) {
+          throw new Error(
+            `Cannot apply overlapping text edits: ${Range.toString(
+              sortedEdits[i + 1].range
+            )} overlaps ${Range.toString(sortedEdits[i].range)}`
+          );
+        }
+      }
       let result = text;
       for (const textEdit of sortedEdits) {
         result = this.apply(result, textEdit);
@@ -84,6 +124,25 @@ export interface WorkspaceTextEditGroup {
 }
 
 export abstract class WorkspaceTextEdit {
+  /**
+   * Drops duplicate edits (same file, same range, same replacement text).
+   * Several links can legitimately produce the same edit — e.g. reference
+   * links sharing one definition — and applying it twice corrupts the file.
+   */
+  public static dedupe(edits: WorkspaceTextEdit[]): WorkspaceTextEdit[] {
+    const seen = new Set<string>();
+    return edits.filter(({ uri, edit }) => {
+      const key = `${uri.toString()}|${Range.toString(edit.range)}|${
+        edit.newText
+      }`;
+      if (seen.has(key)) {
+        return false;
+      }
+      seen.add(key);
+      return true;
+    });
+  }
+
   public static groupByUri(
     edits: WorkspaceTextEdit[]
   ): WorkspaceTextEditGroup[] {

--- a/packages/foam-vscode/src/extension.ts
+++ b/packages/foam-vscode/src/extension.ts
@@ -99,6 +99,7 @@ export async function activate(context: ExtensionContext) {
       ),
       workspace.onDidSaveTextDocument
     );
+    context.subscriptions.push(watcher);
     // Attributes the workspace load time to reading vs parsing vs neither, so
     // that a slow startup reported by a user can be diagnosed from the log
     // alone. See issue #1689.
@@ -108,6 +109,7 @@ export async function activate(context: ExtensionContext) {
     const dataStore = profiler.instrumentDataStore(rawDataStore);
 
     const parserCache = await VsCodeBasedParserCache.create(context);
+    context.subscriptions.push(parserCache);
     const parser = createMarkdownParser([], parserCache, profiler.onParse);
 
     const workspaceRoots =
@@ -125,6 +127,7 @@ export async function activate(context: ExtensionContext) {
     const attachmentProvider = new AttachmentResourceProvider(
       attachmentExtConfig
     );
+    context.subscriptions.push(markdownProvider, attachmentProvider);
 
     // Initialize embedding provider
     const experimentalEnabled = workspace
@@ -154,6 +157,9 @@ export async function activate(context: ExtensionContext) {
     );
 
     const foam = await foamPromise;
+    // Register for disposal right away: a feature failing to load further
+    // down must not leave the workspace/graph/watchers alive and untracked
+    context.subscriptions.push(foam);
     profiler.stop();
     eventLoopMonitor.stop();
 
@@ -171,9 +177,24 @@ export async function activate(context: ExtensionContext) {
       })
     );
 
-    const feats = (await Promise.all(featuresPromises)).filter(
-      (r): r is FoamFeatureResult => r != null
-    );
+    // One broken feature must degrade that feature only, not abort the whole
+    // activation (which would also skip extendMarkdownIt for every feature)
+    const settled = await Promise.allSettled(featuresPromises);
+    settled.forEach((result, i) => {
+      if (result.status === 'rejected') {
+        Logger.error(
+          `Feature #${i} (${features[i].name || 'anonymous'}) failed to activate`,
+          result.reason
+        );
+      }
+    });
+    const feats = settled
+      .filter(
+        (r): r is PromiseFulfilledResult<FoamFeatureResult | void> =>
+          r.status === 'fulfilled'
+      )
+      .map(r => r.value)
+      .filter((r): r is FoamFeatureResult => r != null);
 
     const featureTelemetry = feats.reduce(
       (acc, r) => ({ ...acc, ...r.telemetry }),
@@ -183,11 +204,6 @@ export async function activate(context: ExtensionContext) {
     telemetry.trackWorkspaceStats(noteCount, attachmentCount, featureTelemetry);
 
     context.subscriptions.push(
-      foam,
-      watcher,
-      parserCache,
-      markdownProvider,
-      attachmentProvider,
       commands.registerCommand('foam-vscode.clear-cache', () =>
         parserCache.clear()
       ),

--- a/packages/foam-vscode/src/vscode/features/graph-webview/index.ts
+++ b/packages/foam-vscode/src/vscode/features/graph-webview/index.ts
@@ -18,17 +18,19 @@ export default async function activate(
   foamPromise: Promise<Foam>
 ) {
   let panel: vscode.WebviewPanel | undefined = undefined;
-  vscode.workspace.onDidChangeConfiguration(event => {
-    if (panel) {
-      if (event.affectsConfiguration('foam.graph.style')) {
-        const style = getGraphStyle();
-        panel.webview.postMessage({
-          type: 'didUpdateStyle',
-          payload: style,
-        });
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeConfiguration(event => {
+      if (panel) {
+        if (event.affectsConfiguration('foam.graph.style')) {
+          const style = getGraphStyle();
+          panel.webview.postMessage({
+            type: 'didUpdateStyle',
+            payload: style,
+          });
+        }
       }
-    }
-  });
+    })
+  );
 
   const attachPanelListeners = (p: vscode.WebviewPanel, foam: Foam) => {
     const onFoamChanged = _ => {
@@ -59,24 +61,26 @@ export default async function activate(
     })
   );
 
-  vscode.commands.registerCommand(
-    'foam-vscode.show-graph',
-    async (args?: ShowGraphArgs) => {
-      getTelemetry()?.trackCommand('foam-vscode.show-graph');
-      const { style, view } = resolveViewStyle(args);
-      if (panel) {
-        panel.title = view ? `Foam Graph: ${view}` : 'Foam Graph';
-        panel.webview.postMessage({ type: 'didUpdateStyle', payload: style });
-        panel.reveal();
-      } else {
-        const foam = await foamPromise;
-        panel = await createGraphPanel(foam, context, {
-          initialStyle: style,
-          view,
-        });
-        attachPanelListeners(panel, foam);
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'foam-vscode.show-graph',
+      async (args?: ShowGraphArgs) => {
+        getTelemetry()?.trackCommand('foam-vscode.show-graph');
+        const { style, view } = resolveViewStyle(args);
+        if (panel) {
+          panel.title = view ? `Foam Graph: ${view}` : 'Foam Graph';
+          panel.webview.postMessage({ type: 'didUpdateStyle', payload: style });
+          panel.reveal();
+        } else {
+          const foam = await foamPromise;
+          panel = await createGraphPanel(foam, context, {
+            initialStyle: style,
+            view,
+          });
+          attachPanelListeners(panel, foam);
+        }
       }
-    }
+    )
   );
   const shouldOpenGraphOnStartup = getFoamVsCodeConfig('graph.onStartup');
   if (shouldOpenGraphOnStartup) {

--- a/packages/foam-vscode/src/vscode/services/cache.ts
+++ b/packages/foam-vscode/src/vscode/services/cache.ts
@@ -34,7 +34,9 @@ import { fromVsCodeUri } from '../utils/vsc-utils';
  * discarded automatically on the next startup.
  */
 export default class VsCodeBasedParserCache implements ParserCache {
-  static CACHE_VERSION = 5;
+  // v6: tag range computation fixed (substring frontmatter matches,
+  // multi-line paragraph hashtags) — cached ranges must be recomputed
+  static CACHE_VERSION = 6;
   static CACHE_VERSION_KEY = 'foam-cache-version';
   static CACHE_DIR_NAME = 'parser-cache';
   static BUCKET_COUNT = 64;


### PR DESCRIPTION
Implements Phase 1 of the core model & API review (docs/dev/design/core-model-and-api-review.md), addressing correctness bugs and resource lifecycle issues.

## Summary

This PR fixes silent data loss, graph divergence, file corruption risks, and resource leaks identified in a comprehensive review of `@foam/core`'s model and services. All changes are non-breaking and improve correctness without altering the public API surface.

## Key changes

**Correctness fixes:**
- **Case-variant filenames** (`workspace.ts`): Files differing only by case (e.g., `/a/Note.md` and `/a/note.md`) now coexist as distinct resources instead of silently overwriting each other. The trie now stores buckets of resources per normalized key, with exact-case lookup for identity. Includes regression tests for same-directory case collisions.
- **Incremental graph divergence** (`graph.ts`, `graph-incremental.test.ts`): Added `reconnectCompetingTargetSources()` to re-resolve links when a newly added note wins an identifier or directory-index priority. The incremental path now matches full-rebuild behavior.
- **Rename/edit corruption** (`text-edit.ts`, `heading-edit.ts`): Duplicate edits are deduplicated, overlapping edits throw instead of silently corrupting text, and unparsable links skip that link instead of aborting the entire rename.
- **Tag range bugs** (`markdown-parser.ts`, `tag-edit.ts`): Fixed substring matching in frontmatter tags (tag `foo` no longer matches inside `foobar`), multi-line paragraph hashtag ranges, and `$`-pattern interpretation in tag renames.
- **Assorted small fixes** (`markdown-link.ts`, `markdown-provider.ts`, `attachment-provider.ts`, `foam.ts`): Off-by-one in angle-wrapping, missing null checks, case-insensitive attachment classification, and per-URI change serialization to prevent read races.

**Lifecycle & resource management:**
- **Provider disposal** (`workspace.ts`): `FoamWorkspace.dispose()` now disposes all registered providers.
- **Tags disposal** (`foam.ts`, `tags.ts`): `Foam.dispose()` now disposes `FoamTags` and its emitter; fixed `debounceFor` parameter being ignored (was hardcoded to 500ms).
- **Feature error isolation** (`extension.ts`): Switched from `Promise.all` to `Promise.allSettled` so a single failing feature doesn't abort activation and strand live resources. Core resources (`foam`, `watcher`, `parserCache`) are now pushed to `context.subscriptions` immediately after bootstrap.
- **Leaked registrations** (`graph-webview/index.ts`): Configuration and command registrations now properly disposed.

**Graph data privacy:**
- **Frontmatter filtering** (`graph-data-builder.ts`, `build-site-graph.ts`): Added `transformProperties` option to restrict published graph data to allowlisted presentation keys, preventing private frontmatter fields from shipping in exported site JSON.

## Testing

Added comprehensive test coverage for:
- Case-variant file coexistence and lookup
- Incremental graph re-resolution on add
- Duplicate and overlapping edit handling
- Tag range computation edge cases
- Lifecycle disposal and debounce parameter
- Change event serialization per URI
- Attachment extension case-insensitivity

All tests pass; no breaking changes to the public API.

https://claude.ai/code/session_01SSJdv3AjxrXtphBuh1sGeT