### PR TITLE
Render math in embedded notes

### DIFF
--- a/.changeset/math-notes-render.md
+++ b/.changeset/math-notes-render.md
@@ -1,0 +1,5 @@
+---
+"foam-vscode": patch
+---
+
+Render math in embedded notes and foam-query source content using VS Code's built-in Markdown math extension, including its math setting and configured macros. Ordinary embedding remains available when the math extension cannot be activated.

--- a/packages/foam-vscode/src/vscode/features/preview/index.ts
+++ b/packages/foam-vscode/src/vscode/features/preview/index.ts
@@ -1,7 +1,7 @@
 /*global markdownit:readonly*/
 
 import * as vscode from 'vscode';
-import { Foam, URI, createRenderContext } from '@foam/core';
+import { Foam, URI, Logger, createRenderContext } from '@foam/core';
 import { fromVsCodeUri, toVsCodeUri } from '../../utils/vsc-utils';
 import { createFoamMarkdownIt } from './foam-markdown-it';
 import { createVsCodeLinkResolver } from './link-resolvers';
@@ -14,6 +14,7 @@ export default async function activate(
   foamPromise: Promise<Foam>
 ) {
   const foam = await foamPromise;
+  const math = await loadMarkdownMath();
 
   // Refresh the markdown preview whenever the workspace changes so that
   // foam-query embed blocks show up-to-date results in real time.
@@ -72,9 +73,49 @@ export default async function activate(
           getEmbedNoteType: () =>
             getFoamVsCodeConfig<string>(CONFIG_EMBED_NOTE_TYPE),
           renderContext,
+          // The host installs math on the outer renderer. Fresh renderers for
+          // embeds and query cells need their own installation, without
+          // re-entering the outer pipeline or sharing render-local macros.
+          extensions: [
+            inner => {
+              if (inner !== md) math?.extendMarkdownIt(inner);
+            },
+          ],
         },
         md
       );
     },
   };
+}
+
+interface MarkdownMathExtension {
+  extendMarkdownIt(md: markdownit): markdownit;
+}
+
+async function loadMarkdownMath(): Promise<MarkdownMathExtension | undefined> {
+  try {
+    const extension = vscode.extensions.getExtension<MarkdownMathExtension>(
+      'vscode.markdown-math'
+    );
+    if (!extension) {
+      Logger.warn(
+        'Markdown math extension unavailable; embedded math is disabled'
+      );
+      return undefined;
+    }
+    const api = await extension.activate();
+    if (typeof api?.extendMarkdownIt !== 'function') {
+      Logger.warn(
+        'Markdown math extension has no extendMarkdownIt API; embedded math is disabled'
+      );
+      return undefined;
+    }
+    return api;
+  } catch (error) {
+    Logger.warn(
+      'Could not activate Markdown math; embedded math is disabled',
+      error
+    );
+    return undefined;
+  }
 }

--- a/packages/foam-vscode/src/vscode/features/preview/math-preview-adapter.spec.ts
+++ b/packages/foam-vscode/src/vscode/features/preview/math-preview-adapter.spec.ts
@@ -1,0 +1,101 @@
+/* @unit-ready */
+import * as vscode from 'vscode';
+import MarkdownIt from 'markdown-it';
+import { Foam, URI, FoamGraph, createMarkdownParser } from '@foam/core';
+import activate from './index';
+import { createTestWorkspace } from '../../../test/test-utils';
+import { createFile, deleteFile } from '../../../test/test-utils-vscode';
+
+describe('Preview math extension adapter', () => {
+  async function withExtension(
+    api: unknown,
+    check: (preview: Awaited<ReturnType<typeof activate>>, calls: any) => void,
+    reject = false
+  ) {
+    const extensionActivate = vi.fn(async () => {
+      if (reject) throw new Error('Math activation failed');
+      return api;
+    });
+    const original = vscode.extensions.getExtension.bind(vscode.extensions);
+    const spy = vi
+      .spyOn(vscode.extensions, 'getExtension')
+      .mockImplementation(id => {
+        if (id !== 'vscode.markdown-math') return original(id);
+        return api === undefined
+          ? undefined
+          : ({ activate: extensionActivate } as any);
+      });
+    const config = vscode.workspace.getConfiguration();
+    const previousStyle = config.get('foam.preview.embedNoteType');
+    await config.update('foam.preview.embedNoteType', 'full-card');
+    const parser = createMarkdownParser();
+    const workspace = createTestWorkspace([
+      URI.file(vscode.workspace.workspaceFolders[0].uri.fsPath),
+    ]);
+    const graph = FoamGraph.fromWorkspace(workspace, false);
+    const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+    const file = await createFile('Embedded text', [
+      'math-adapter',
+      'Child.md',
+    ]);
+    workspace.set(parser.parse(file.uri, file.content));
+    try {
+      const preview = await activate(
+        context,
+        Promise.resolve({ workspace, graph, services: { parser } } as Foam)
+      );
+      check(preview, extensionActivate);
+    } finally {
+      spy.mockRestore();
+      await config.update('foam.preview.embedNoteType', previousStyle);
+      context.subscriptions.forEach(d => d.dispose());
+      graph.dispose();
+      await deleteFile(file);
+    }
+  }
+
+  it('activates once and installs only on fresh inner renderers, including query cells', async () => {
+    const install = vi.fn((md: MarkdownIt) => {
+      md.renderer.rules.text = (tokens, idx) =>
+        `[math-ready:${tokens[idx].content}]`;
+      return md;
+    });
+    await withExtension({ extendMarkdownIt: install }, (preview, calls) => {
+      expect(calls).toHaveBeenCalledTimes(1);
+      const outer = MarkdownIt({ html: true });
+      preview.extendMarkdownIt(outer);
+      expect(install).not.toHaveBeenCalled();
+      const first = outer.render('![[Child]]');
+      expect(first).toContain('[math-ready:Embedded text]');
+      expect(install).toHaveBeenCalledTimes(1);
+      outer.render('![[Child]]');
+      expect(install).toHaveBeenCalledTimes(2);
+      expect(install.mock.calls[0][0]).not.toBe(install.mock.calls[1][0]);
+      expect(
+        outer.render(
+          '```foam-query\nfilter:\n  path: math-adapter/Child\nselect: [body]\n```'
+        )
+      ).toContain('[math-ready:Embedded text]');
+      expect(install.mock.calls.every(([md]) => md !== outer)).toBe(true);
+      expect(calls).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  for (const [name, api, reject] of [
+    ['absent extension', undefined, false],
+    ['missing export', {}, false],
+    ['invalid export', { extendMarkdownIt: true }, false],
+    ['activation failure', {}, true],
+  ] as const) {
+    it(`keeps ordinary embeds available on ${name}`, async () => {
+      await withExtension(
+        api,
+        preview => {
+          const md = preview.extendMarkdownIt(MarkdownIt({ html: true }));
+          expect(md.render('![[Child]]')).toContain('Embedded text');
+        },
+        reject
+      );
+    });
+  }
+});

--- a/packages/foam-vscode/src/vscode/features/preview/math-preview.spec.ts
+++ b/packages/foam-vscode/src/vscode/features/preview/math-preview.spec.ts
@@ -1,0 +1,164 @@
+import * as vscode from 'vscode';
+import MarkdownIt from 'markdown-it';
+import { Foam, URI, FoamGraph, createMarkdownParser } from '@foam/core';
+import activate from './index';
+import { createTestWorkspace } from '../../../test/test-utils';
+import { createFile, deleteFile } from '../../../test/test-utils-vscode';
+
+// This spec deliberately runs only in the real VS Code extension host.
+// Keep fixtures independent of frontmatter handling (a separate fix).
+describe('Math in the VS Code preview', () => {
+  async function withPreview(
+    check: (
+      render: (source: string, hostFirst?: boolean) => string
+    ) => Promise<void> | void
+  ) {
+    const math = await vscode.extensions
+      .getExtension('vscode.markdown-math')
+      ?.activate();
+    expect(typeof math?.extendMarkdownIt).toBe('function');
+    const sources = {
+      Child:
+        '# Child\n\nInline $x+1$.\n\n$$\nx^2\n$$\n\n## Section\n\nSection $y$ ^formula\n',
+      Parent: '![[Child]]',
+      Outer: '![[Parent]]',
+      Macro: '$\\RR$\n',
+      Define: '$\\gdef\\local{abc}\\local$',
+      Use: '$\\local$',
+      Cycle: '![[Cycle]]',
+      Self: '# Self\n\n![[#Section]]\n\n## Section\n\nSelf $z$',
+    };
+    const files = [];
+    const parser = createMarkdownParser();
+    const workspace = createTestWorkspace([
+      URI.file(vscode.workspace.workspaceFolders[0].uri.fsPath),
+    ]);
+    const graph = FoamGraph.fromWorkspace(workspace, false);
+    const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+    try {
+      for (const [name, content] of Object.entries(sources)) {
+        const file = await createFile(content, ['preview-math', name + '.md']);
+        files.push(file);
+        workspace.set(parser.parse(file.uri, content));
+      }
+      const preview = await activate(
+        context,
+        Promise.resolve({ workspace, graph, services: { parser } } as Foam)
+      );
+      await check((source, hostFirst = true) => {
+        const md = MarkdownIt({ html: true });
+        if (hostFirst) math.extendMarkdownIt(md);
+        preview.extendMarkdownIt(md);
+        if (!hostFirst) math.extendMarkdownIt(md);
+        return md.render(source);
+      });
+    } finally {
+      context.subscriptions.forEach(d => d.dispose());
+      graph.dispose();
+      for (const file of files) await deleteFile(file);
+    }
+  }
+
+  it('renders inline/display math in embeds, fragments, nested embeds and query cells in either plugin order', async () => {
+    const config = vscode.workspace.getConfiguration('markdown');
+    const previous = config.inspect('math.enabled').workspaceValue;
+    await config.update(
+      'math.enabled',
+      true,
+      vscode.ConfigurationTarget.Workspace
+    );
+    try {
+      await withPreview(render => {
+        for (const hostFirst of [true, false]) {
+          for (const source of [
+            '![[Child]]',
+            'inline![[Child]]',
+            '![[Outer]]',
+          ]) {
+            const html = render(source, hostFirst);
+            expect(html).toContain('class="katex"');
+            expect(html).toContain('katex-display');
+            expect(html).not.toContain('katex-error');
+          }
+          for (const source of [
+            '![[Child#Section]]',
+            '![[Child#^formula]]',
+            '![[Self]]',
+            '```foam-query\nfilter:\n  path: preview-math/Child\nselect: [body]\n```',
+          ]) {
+            const html = render(source, hostFirst);
+            expect(html).toContain('class="katex"');
+            expect(html).not.toContain('katex-error');
+          }
+          expect(render('$x$', hostFirst).match(/class="katex"/g)).toHaveLength(
+            1
+          );
+          expect(render('![[Cycle]]', hostFirst)).toContain(
+            'Cyclic link detected'
+          );
+        }
+      });
+    } finally {
+      await config.update(
+        'math.enabled',
+        previous,
+        vscode.ConfigurationTarget.Workspace
+      );
+    }
+  });
+
+  it('respects math settings across renderer reloads and isolates render-local macros', async () => {
+    const config = vscode.workspace.getConfiguration('markdown');
+    const enabled = config.inspect('math.enabled').workspaceValue;
+    const macros = config.inspect('math.macros').workspaceValue;
+    try {
+      await config.update(
+        'math.enabled',
+        true,
+        vscode.ConfigurationTarget.Workspace
+      );
+      await config.update(
+        'math.macros',
+        { '\\RR': '\\mathbb{R}' },
+        vscode.ConfigurationTarget.Workspace
+      );
+      await withPreview(async render => {
+        expect(render('![[Macro]]')).not.toContain('katex-error');
+        expect(render('![[Macro]]')).toContain('mathbb');
+        expect(render('![[Define]]')).not.toContain('katex-error');
+        expect(render('![[Use]]')).toContain('katex-error');
+        expect(render('![[Define]]\n\n![[Use]]')).toContain('katex-error');
+        await config.update(
+          'math.macros',
+          {},
+          vscode.ConfigurationTarget.Workspace
+        );
+        expect(render('![[Macro]]')).toContain('katex-error');
+        await config.update(
+          'math.enabled',
+          false,
+          vscode.ConfigurationTarget.Workspace
+        );
+        expect(render('![[Child]]')).toContain('$x+1$');
+        expect(render('![[Child]]')).not.toContain('class="katex"');
+        await config.update(
+          'math.enabled',
+          true,
+          vscode.ConfigurationTarget.Workspace
+        );
+        expect(render('![[Child]]')).toContain('class="katex"');
+      });
+    } finally {
+      await config.update(
+        'math.macros',
+        macros,
+        vscode.ConfigurationTarget.Workspace
+      );
+      await config.update(
+        'math.enabled',
+        enabled,
+        vscode.ConfigurationTarget.Workspace
+      );
+    }
+  });
+});


### PR DESCRIPTION
# Render math in embedded notes

A child note containing `$x+1$` and display math renders correctly in VS Code's built-in preview, but embedding it with `![[Child]]` leaves the formulas as source text. The fresh inner markdown-it renderer does not receive the host's math plugin.

The VS Code preview adapter now activates the optional `vscode.markdown-math` extension once and installs its `extendMarkdownIt` hook only on fresh inner renderers through the existing factory `extensions` option. The host retains responsibility for the outer renderer. This also covers source-derived `foam-query` cells and preserves the built-in enabled setting, configured macros, and render-local macro reset behavior. If the extension is absent, activation fails, or the export is unavailable, ordinary embedding remains available with a diagnostic.

## Reproduction

Create `Child.md`:

```markdown
# Child

Inline $x+1$.

$$
x^2
$$
```

Create `Parent.md` containing `![[Child]]` and `Outer.md` containing `![[Parent]]`. Enable `markdown.math.enabled` and compare direct, embedded, and nested previews. Both inline and display formulas should render.

## Validation

- The adapter regression fails before the fix: the inner-renderer math installer is never called.
- Final extension unit suite: 717 passed, 5 skipped, 1 todo.
- Real host: 7 passed using the actual built-in math extension plus adapter failure tests. Coverage includes plugin order, inline/display math, nested/section/block/self-fragment embeds, query body cells, math configuration changes, configured macros, local macro isolation, and cycle detection.
- Combined with the independent content fix: 53 real-host checks passed, including nested notes with both metadata and formulas.

Validation on Linux x64, Node 22.23.2, Yarn 1.22.22; base `97b82e4ed7f363ff9cdbbfab0bb4dd90c7c4d487`.

- `yarn build` passes (including the Node and web extension bundles).
- `yarn workspace foam-vscode compile` passes.
- `yarn workspace foam-vscode lint` completes with 0 errors; the 77 remaining warnings are pre-existing.

The stock `test:e2e` command currently reports **no tests**, with “Runner ... vitest-pool-vscode.ts is not supported” under the locked Vitest 4.1.11, and nevertheless exits 0. I did **not** count that as a pass. For these host checks I used an uncommitted local entrypoint that calls the existing pool directly, adapting its removed `@vitest/spy` `mocks` export in generated output only. Tests ran in the real VS Code 1.110.0 extension host, with an isolated user-data directory and actual VS Code APIs. The runner workaround is not part of this PR.

## Compatibility

This relies on the existing export of VS Code's built-in `vscode.markdown-math` extension; it is not a newly declared hard extension dependency or an independently maintained KaTeX renderer. The small interface check and activation fallback keep the rest of Foam usable if that export is unavailable. No user settings or shared factory API change is introduced. The web extension retains its existing unsupported-embed behavior.

Includes a `foam-vscode` patch changeset. Frontmatter/title extraction is a separate, independent PR targeting `main`.

## Submission status

Independent companion PR: #1704. Both branches target `main` directly and can be reviewed or merged separately.

[Upstream CI](https://github.com/foambubble/foam/actions/runs/34244907494) currently reports `action_required` with no jobs started. The local results above are separate from upstream CI; a green CI result has not yet been obtained.
