### PR TITLE
Omit embedded frontmatter and preserve content without a title

### DIFF
--- a/.changeset/tidy-embeds-preserve.md
+++ b/.changeset/tidy-embeds-preserve.md
@@ -1,0 +1,6 @@
+---
+"foam-vscode": patch
+"@foam/cli": patch
+---
+
+Omit leading YAML metadata from whole-note embeds. Content-only embeds now preserve the first body line of titleless notes and all subsequent sections, and remove complete ATX or Setext titles without shifting section or block references.

--- a/packages/foam-vscode/src/vscode/features/preview/embed-content.test.ts
+++ b/packages/foam-vscode/src/vscode/features/preview/embed-content.test.ts
@@ -79,8 +79,9 @@ describe('Embedded note content', () => {
         expect(html).not.toContain('<hr');
         expect(html).not.toContain('aliases:');
         expect(html).not.toContain('id: 1');
-        if (source.includes('First body line'))
-          expect(html).toContain('First body line');
+        expect(html.includes('First body line')).toBe(
+          source.includes('First body line')
+        );
       });
     });
   }
@@ -92,8 +93,10 @@ describe('Embedded note content', () => {
     it(`keeps titleless content ${JSON.stringify(source)}`, () => {
       withNote(source, render => {
         const html = render('content-inline![[Child]]');
-        if (source) expect(html).toContain('First body line');
-        if (source.includes('Tail')) expect(html).toContain('Tail');
+        expect(html.includes('First body line')).toBe(
+          source.includes('First body line')
+        );
+        expect(html.includes('Tail')).toBe(source.includes('Tail'));
       });
     });
   }

--- a/packages/foam-vscode/src/vscode/features/preview/embed-content.test.ts
+++ b/packages/foam-vscode/src/vscode/features/preview/embed-content.test.ts
@@ -1,0 +1,188 @@
+import MarkdownIt from 'markdown-it';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { FoamGraph, URI, createMarkdownParser } from '@foam/core';
+import { createTestWorkspace } from '../../../test/test-utils';
+import { createFoamMarkdownIt } from './foam-markdown-it';
+
+function withNote(
+  source: string,
+  check: (render: (input: string) => string) => void
+) {
+  const dir = mkdtempSync(path.join(tmpdir(), 'foam-embed-content-'));
+  const uri = URI.file(path.join(dir, 'Child.md'));
+  writeFileSync(uri.toFsPath(), source);
+  const parser = createMarkdownParser();
+  const note = parser.parse(uri, source);
+  const workspace = createTestWorkspace([URI.file(dir)]).set(note);
+  for (const [name, body] of [
+    ['Parent', '---\naliases: [parent]\n---\n![[Child]]'],
+    ['Outer', '![[Parent]]'],
+  ]) {
+    const nestedUri = URI.file(path.join(dir, name + '.md'));
+    writeFileSync(nestedUri.toFsPath(), body);
+    workspace.set(parser.parse(nestedUri, body));
+  }
+  const graph = FoamGraph.fromWorkspace(workspace, false);
+  try {
+    const md = createFoamMarkdownIt(
+      {
+        workspace,
+        graph,
+        parser,
+        linkResolver: ({ resource }) => ({ href: resource.uri.path }),
+        getCurrentResource: () => note,
+      },
+      MarkdownIt({ html: true })
+    );
+    check(input => md.render(input));
+  } finally {
+    graph.dispose();
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe('Embedded note content', () => {
+  for (const style of [
+    'full-inline',
+    'full-card',
+    'content-inline',
+    'content-card',
+  ]) {
+    it(`omits metadata and preserves the body in ${style}`, () => {
+      withNote(
+        '---\naliases: [example]\n---\n# Title\n\nFirst body line\n\n# Second\n\nLast body line',
+        render => {
+          const html = render(`${style}![[Child]]`);
+          expect(html).not.toContain('aliases:');
+          expect(html).toContain('First body line');
+          expect(html).toContain('Last body line');
+          expect(html).toContain('Second</h1>');
+          expect(html.includes('Title</h1>')).toBe(style.startsWith('full'));
+        }
+      );
+    });
+  }
+  for (const frontmatter of [
+    '---\n---\n',
+    '---\n# comment\n---\n',
+    '\uFEFF---\r\naliases: [example]\r\n...\r\n',
+    '---\nid: 1\n---',
+  ]) {
+    it(`strips closed metadata ${JSON.stringify(frontmatter)}`, () => {
+      const source = frontmatter.endsWith('---')
+        ? frontmatter
+        : frontmatter + 'First body line';
+      withNote(source, render => {
+        const html = render('content-inline![[Child]]');
+        expect(html).not.toContain('<hr');
+        expect(html).not.toContain('aliases:');
+        expect(html).not.toContain('id: 1');
+        if (source.includes('First body line'))
+          expect(html).toContain('First body line');
+      });
+    });
+  }
+  for (const source of [
+    'First body line\n\n## Later heading\n\nTail',
+    'First body line',
+    '',
+  ]) {
+    it(`keeps titleless content ${JSON.stringify(source)}`, () => {
+      withNote(source, render => {
+        const html = render('content-inline![[Child]]');
+        if (source) expect(html).toContain('First body line');
+        if (source.includes('Tail')) expect(html).toContain('Tail');
+      });
+    });
+  }
+  for (const title of [
+    '# Title',
+    '### Title ###',
+    'Title\n=====',
+    'Title\n-----',
+    'Multi\nline title\n=====',
+  ]) {
+    it(`removes a leading heading ${JSON.stringify(title)}`, () => {
+      withNote(
+        `---\nid: 1\n---\n\n${title}\n\nBody\n\n# Sibling\n\nTail`,
+        render => {
+          const html = render('content-inline![[Child]]');
+          expect(html).not.toMatch(/<h[1-6]>Title/);
+          expect(html).not.toContain('line title');
+          expect(html).toContain('Body');
+          expect(html).toContain('Sibling</h1>');
+          expect(html).toContain('Tail');
+        }
+      );
+    });
+  }
+  for (const source of [
+    '---\nid: 1\nBody',
+    '---\nid: [broken\n---\nBody',
+    '---\nordinary prose\n---\nBody',
+    'Body\n\n---\nTail',
+    '```md\n# Code title\n```\n\nBody',
+  ]) {
+    it(`preserves non-metadata and malformed input ${JSON.stringify(
+      source
+    )}`, () => {
+      withNote(source, render => {
+        expect(render('content-inline![[Child]]')).toContain(
+          MarkdownIt({ html: true }).render(source)
+        );
+      });
+    });
+  }
+  it('omits metadata in nested embeds and preserves resolved links and images', () => {
+    withNote(
+      '---\nid: 1\n---\n# Child\n\nBody [[Outer]]\n\n![Example](https://example.com/image.png)',
+      render => {
+        const html = render('![[Outer]]');
+        expect(html).toContain('Body');
+        expect(html).not.toContain('aliases:');
+        expect(html).not.toContain('id: 1');
+        expect(html).toContain('/Outer.md');
+        expect(html).toContain('https://example.com/image.png');
+      }
+    );
+  });
+  it('keeps heading blocks intact even in content mode', () => {
+    withNote('---\nid: 1\n---\n# Heading ^heading\n\nBody', render => {
+      const html = render('content-inline![[Child#^heading]]');
+      expect(html).toContain('Heading</h1>');
+      expect(html).toContain('Body');
+      expect(html).not.toContain('^heading');
+    });
+  });
+  it('extracts sections and blocks against original lines with metadata', () => {
+    withNote(
+      '---\nid: 1\n---\n# Title\n\nIntro\n\n## Section\n\nSelected text ^selected\n\n## Other\n\nTail',
+      render => {
+        for (const input of [
+          'full-inline![[Child#Section]]',
+          'content-inline![[Child#Section]]',
+          'full-inline![[Child#^selected]]',
+          'content-inline![[Child#^selected]]',
+          'inline![[#Section]]',
+        ]) {
+          const html = render(input);
+          expect(html).toContain('Selected text');
+          expect(html).not.toContain('Intro');
+          expect(html).not.toContain('Tail');
+          expect(html).not.toContain('id: 1');
+        }
+      }
+    );
+  });
+  it('removes the entire Setext section heading in content mode', () => {
+    withNote('# Title\n\nSection\n-------\n\nBody\n\n# Tail', render => {
+      const html = render('content-inline![[Child#Section]]');
+      expect(html).toContain('Body');
+      expect(html).not.toContain('<hr');
+      expect(html).not.toContain('Section');
+      expect(html).not.toContain('Tail');
+    });
+  });
+});

--- a/packages/foam-vscode/src/vscode/features/preview/wikilink-embed.ts
+++ b/packages/foam-vscode/src/vscode/features/preview/wikilink-embed.ts
@@ -3,6 +3,8 @@
 // eslint-disable-next-line no-restricted-imports
 import { readFileSync } from 'fs';
 import markdownItRegex from 'markdown-it-regex';
+import MarkdownIt from 'markdown-it';
+import { isMap, parseDocument } from 'yaml';
 import { FoamWorkspace } from '@foam/core';
 import { Logger } from '@foam/core';
 import { Resource, ResourceParser, Block } from '@foam/core';
@@ -306,6 +308,37 @@ export type EmbedNoteExtractor = (
   workspace: FoamWorkspace
 ) => string;
 
+// Parse headings without the host's plugins: extracting a title must not
+// recursively render embeds or execute queries.
+const headingParser = MarkdownIt();
+
+function stripLeadingTitle(source: string): string {
+  const first = headingParser.parse(source, {})[0];
+  if (first?.type !== 'heading_open' || !first.map) {
+    return source;
+  }
+  return source.split('\n').slice(first.map[1]).join('\n');
+}
+
+function stripLeadingFrontmatter(source: string): string {
+  const opening = /^\uFEFF?---[ \t]*\r?\n/.exec(source);
+  if (!opening) return source;
+  const remaining = source.slice(opening[0].length);
+  const closing = /^(?:---|\.\.\.)[ \t]*(?:\r?\n|$)/m.exec(remaining);
+  if (!closing) return source;
+
+  // Only mappings (or empty metadata) are frontmatter. Keep malformed YAML
+  // and prose between thematic breaks intact instead of losing note content.
+  const document = parseDocument(remaining.slice(0, closing.index));
+  if (
+    document.errors.length > 0 ||
+    (document.contents !== null && !isMap(document.contents))
+  ) {
+    return source;
+  }
+  return remaining.slice(closing.index + closing[0].length);
+}
+
 function fullExtractor(
   note: Resource,
   parser: ResourceParser,
@@ -318,7 +351,7 @@ function fullExtractor(
     if (isSome(block)) {
       noteText = extractBlockContent(noteText, note, block);
     }
-  } else {
+  } else if (note.uri.fragment) {
     const section = Resource.findSection(note, note.uri.fragment);
     if (isSome(section)) {
       const rows = noteText.split('\n');
@@ -326,14 +359,17 @@ function fullExtractor(
         .slice(section.range.start.line, section.range.end.line)
         .join('\n');
     }
+  } else {
+    // Section and block ranges refer to the original source, including YAML.
+    // Strip metadata only when embedding the whole note.
+    noteText = stripLeadingFrontmatter(noteText);
   }
-  noteText = withLinksRelativeToWorkspaceRoot(
+  return withLinksRelativeToWorkspaceRoot(
     note.uri,
     noteText,
     parser,
     workspace
   );
-  return noteText;
 }
 
 function contentExtractor(
@@ -341,38 +377,14 @@ function contentExtractor(
   parser: ResourceParser,
   workspace: FoamWorkspace
 ): string {
-  let noteText = readFileSync(note.uri.toFsPath()).toString();
-  if (note.uri.fragment.startsWith('^')) {
-    const blockId = note.uri.fragment.slice(1);
-    const block = Resource.findBlock(note, blockId);
-    if (isSome(block)) {
-      noteText = extractBlockContent(noteText, note, block);
-    }
-  } else {
-    let section = Resource.findSection(note, note.uri.fragment);
-    if (!note.uri.fragment) {
-      // if there's no fragment(section), the wikilink is linking to the entire note,
-      // in which case we need to remove the title. We could just use rows.shift()
-      // but should the note start with blank lines, it will only remove the first blank line
-      // leaving the title
-      // A better way is to find where the actual title starts by assuming it's at section[0]
-      // then we treat it as the same case as link to a section
-      section = note.sections.length ? note.sections[0] : null;
-    }
-    let rows = noteText.split('\n');
-    if (isSome(section)) {
-      rows = rows.slice(section.range.start.line, section.range.end.line);
-    }
-    rows.shift();
-    noteText = rows.join('\n');
-  }
-  noteText = withLinksRelativeToWorkspaceRoot(
-    note.uri,
-    noteText,
-    parser,
-    workspace
-  );
-  return noteText;
+  const noteText = fullExtractor(note, parser, workspace);
+  if (note.uri.fragment.startsWith('^')) return noteText;
+  // Whole-note embeds keep all sections, not just the first section's range.
+  // A missing section must not cause an arbitrary first line to be removed.
+  return !note.uri.fragment ||
+    isSome(Resource.findSection(note, note.uri.fragment))
+    ? stripLeadingTitle(noteText)
+    : noteText;
 }
 
 /**


### PR DESCRIPTION
# Omit embedded frontmatter and preserve content without a title

Whole-note embeds currently display YAML metadata as Markdown. `content-*` embeds can discard the first body line of a titleless note or truncate the note after its first section. Setext section titles can leave their underline in the rendered output.

This change omits leading, closed, valid mapping/empty YAML from whole-note embeds and removes only an actual leading ATX/Setext title in content mode. It keeps subsequent sibling sections. Fragment ranges are applied to the original source before any display-only cleanup; block semantics and link rewriting are retained. Unclosed/invalid YAML and prose between thematic breaks are preserved.

For example, embed this child with `full-inline![[Child]]` or `content-inline![[Child]]`:

```markdown
---
aliases: [example]
---
# Child

First body line

# Second

Last body line
```

Expected: metadata is absent, both body paragraphs remain, and only content mode omits the initial title. A titleless child retains its first line.

## Validation

- Before the fix: 21 new regression tests failed; 714 tests passed.
- Final extension unit suite: 737 passed, 5 skipped, 1 todo. The final assertion-only cleanup also passed all 25 content cases.
- Real host: 46 passed (21 existing embed tests plus 25 new content cases).
- CLI: 389 unit tests and 18 end-to-end tests passed.
- Combined with the independent math fix: 53 real-host checks passed, including nested notes with YAML plus inline/display math.

Validation on Linux x64, Node 22.23.2, Yarn 1.22.22; base `97b82e4ed7f363ff9cdbbfab0bb4dd90c7c4d487`.

- `yarn build` passes (including the Node and web extension bundles).
- `yarn workspace foam-vscode compile` passes.
- `yarn workspace foam-vscode lint` completes with 0 errors; the 77 remaining warnings are pre-existing.

The stock `test:e2e` command currently reports **no tests**, with “Runner ... vitest-pool-vscode.ts is not supported” under the locked Vitest 4.1.11, and nevertheless exits 0. I did **not** count that as a pass. For these host checks I used an uncommitted local entrypoint that calls the existing pool directly, adapting its removed `@vitest/spy` `mocks` export in generated output only. Tests ran in the real VS Code 1.110.0 extension host, with an isolated user-data directory and actual VS Code APIs. The runner workaround is not part of this PR.

Includes patch changesets for `foam-vscode` and `@foam/cli`, which bundles this shared preview code. The math integration is a separate, independent PR; this branch targets `main` directly. No private notes or local installation patches are included.

## Submission status

Independent companion PR: #1703. Both branches target `main` directly and can be reviewed or merged separately.

[Upstream CI](https://github.com/foambubble/foam/actions/runs/34244975374) currently reports `action_required` with no jobs started. The local results above are separate from upstream CI; a green CI result has not yet been obtained.
